### PR TITLE
feat: ワークツリー削除時の外部プロセス確実kill + 永続リトライ + キャンセル機能

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,7 +55,7 @@ libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
-windows = { version = "0.58", features = ["Win32_UI_Shell"] }
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm", "Win32_System_Environment"] }
+windows = { version = "0.58", features = ["Win32_UI_Shell", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm", "Win32_System_Environment", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug"] }
 windows-version = "0.1"
 

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -1,5 +1,7 @@
-use crate::process_utils::make_command;
+use crate::process_utils::{kill_external_processes_in_dir, make_command};
 use crate::settings::NotificationHookEntry;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use serde::Serialize;
 
 /// git コマンドを repo_path で実行して stdout を返す共通ヘルパー
@@ -1075,6 +1077,107 @@ pub fn worktree_remove(repo_path: &str, worktree_path: &str) -> Result<(), Strin
     }
 
     Err(last_dir_error)
+}
+
+/// ワークツリーを削除する（永続リトライ付き）。
+///
+/// Phase 1: 既存の `worktree_remove`（最大5回リトライ）を試みる。
+/// Phase 2: 失敗した場合、`on_enter_persistent` を呼び出した後、
+///          cancel_flag が true になるまで無限にリトライを続ける。
+///          各反復で `kill_external_processes_in_dir` を呼びプロセスをkillしてから削除を試みる。
+///
+/// キャンセルされた場合は `Err("cancelled")` を返す。
+pub fn worktree_remove_persistent(
+    repo_path: &str,
+    worktree_path: &str,
+    cancel_flag: Arc<AtomicBool>,
+    on_enter_persistent: Option<&dyn Fn()>,
+) -> Result<(), String> {
+    // Phase 1: 通常の5回リトライ
+    match worktree_remove(repo_path, worktree_path) {
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            log::warn!(
+                "worktree_remove failed, entering persistent retry: {}",
+                e
+            );
+        }
+    }
+
+    // Phase 2: 永続リトライ
+    if let Some(cb) = on_enter_persistent {
+        cb();
+    }
+
+    loop {
+        if cancel_flag.load(Ordering::Relaxed) {
+            return Err("cancelled".to_string());
+        }
+
+        // CWD ベースのプロセスkill
+        let killed = kill_external_processes_in_dir(worktree_path);
+        if killed > 0 {
+            log::info!(
+                "worktree_remove_persistent: killed {} processes in {}",
+                killed, worktree_path
+            );
+            // ファイルハンドル解放を待つ（200ms×5回、各スリープ前にキャンセルチェック）
+            for _ in 0..5 {
+                if cancel_flag.load(Ordering::Relaxed) {
+                    return Err("cancelled".to_string());
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+
+        if cancel_flag.load(Ordering::Relaxed) {
+            return Err("cancelled".to_string());
+        }
+
+        // ディレクトリが既に無ければメタデータ掃除だけ
+        let path = std::path::Path::new(worktree_path);
+        if !path.exists() {
+            let _ = make_command("git")
+                .args(["worktree", "prune"])
+                .current_dir(repo_path)
+                .output();
+            return Ok(());
+        }
+
+        // git worktree remove を試みる
+        let git_ok = make_command("git")
+            .args(["worktree", "remove", "--force", "--force", worktree_path])
+            .current_dir(repo_path)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+        if git_ok {
+            return Ok(());
+        }
+
+        // 直接ディレクトリ削除にフォールバック
+        match std::fs::remove_dir_all(path) {
+            Ok(()) => {
+                let _ = make_command("git")
+                    .args(["worktree", "prune"])
+                    .current_dir(repo_path)
+                    .output();
+                return Ok(());
+            }
+            Err(e) => {
+                log::info!("worktree_remove_persistent: remove_dir_all failed: {}", e);
+            }
+        }
+
+        // 2秒待機（200ms×10、各スリープでキャンセルチェック）
+        for _ in 0..10 {
+            if cancel_flag.load(Ordering::Relaxed) {
+                return Err("cancelled".to_string());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+    }
 }
 
 /// ワークツリーの `.claude/settings.local.json` に Claude Code 通知フックを書き込む

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -1094,17 +1094,23 @@ pub fn worktree_remove_persistent(
     on_enter_persistent: Option<&dyn Fn()>,
 ) -> Result<(), String> {
     // Phase 1: 通常の5回リトライ
-    match worktree_remove(repo_path, worktree_path) {
+    let phase1_err = match worktree_remove(repo_path, worktree_path) {
         Ok(()) => return Ok(()),
-        Err(e) => {
-            log::warn!(
-                "worktree_remove failed, entering persistent retry: {}",
-                e
-            );
-        }
+        Err(e) => e,
+    };
+
+    // ロック起因エラーの場合のみ永続リトライへ移行する。
+    // メタデータ破損・リポジトリパス不正など回復不能なエラーは即座に返す。
+    if !is_lock_error(&phase1_err) {
+        return Err(phase1_err);
     }
 
-    // Phase 2: 永続リトライ
+    log::warn!(
+        "worktree_remove failed with lock error, entering persistent retry: {}",
+        phase1_err
+    );
+
+    // Phase 2: 永続リトライ（ロックエラー専用）
     if let Some(cb) = on_enter_persistent {
         cb();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,16 +173,9 @@ async fn git_worktree_remove(
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 
-    // NtAPIでPTY管理外のプロセス（IDE、cd済みシェル等）もkill
-    let wp_for_kill = worktree_path.clone();
-    let external_killed = tokio::task::spawn_blocking(move || {
-        process_utils::kill_external_processes_in_dir(&wp_for_kill)
-    })
-    .await
-    .unwrap_or(0);
-    if external_killed > 0 {
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-    }
+    // NtAPI による外部プロセスkillは worktree_remove_persistent の Phase 2 ループ内で実行する。
+    // ここで呼ぶと git がパスを正規のワークツリーと確認する前にプロセスをkillしてしまい、
+    // 不正なパスを渡された場合に無関係なプロセスを終了するリスクがある。
 
     let cancel_flag = remove_manager.create_cancel_flag(&worktree_path);
     let wp = worktree_path.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod terminal_session;
 mod acrylic;
 
 use fs_watcher::FsWatcherManager;
+use process_utils::WorktreeRemoveManager;
 use pty_manager::{AiAgentChangedPayload, PtyManager};
 use settings::{AppSettings, SettingsManager};
 use tauri::{Emitter, Manager, State};
@@ -161,21 +162,71 @@ async fn git_worktree_add(
 async fn git_worktree_remove(
     app_handle: tauri::AppHandle,
     pty_manager: State<'_, PtyManager>,
+    remove_manager: State<'_, WorktreeRemoveManager>,
     repo_path: String,
     worktree_path: String,
 ) -> Result<(), String> {
-    // 削除対象ディレクトリをcwdとして掴んでいる子プロセスを先にkill
+    // 削除対象ディレクトリをcwdとして掴んでいるPTYセッションを先にkill
     let killed = pty_manager.kill_sessions_in_dir(&worktree_path);
     if killed > 0 {
         // プロセスが完全に終了してファイルハンドルを解放するまで待機
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
+
+    // NtAPIでPTY管理外のプロセス（IDE、cd済みシェル等）もkill
+    let wp_for_kill = worktree_path.clone();
+    let external_killed = tokio::task::spawn_blocking(move || {
+        process_utils::kill_external_processes_in_dir(&wp_for_kill)
+    })
+    .await
+    .unwrap_or(0);
+    if external_killed > 0 {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    }
+
+    let cancel_flag = remove_manager.create_cancel_flag(&worktree_path);
     let wp = worktree_path.clone();
-    run_git(move || git_worktree::worktree_remove(&repo_path, &worktree_path)).await?;
+    let wp2 = worktree_path.clone();
+    let ah = app_handle.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        git_worktree::worktree_remove_persistent(
+            &repo_path,
+            &worktree_path,
+            cancel_flag,
+            Some(&|| {
+                let _ = ah.emit(
+                    "worktree-remove-retrying",
+                    serde_json::json!({ "worktreePath": wp2 }),
+                );
+            }),
+        )
+    })
+    .await
+    .map_err(|e| format!("task join error: {}", e))?;
+
+    remove_manager.remove(&wp);
+
+    // キャンセルはエラーとして伝播（フロントエンドで特別処理）
+    result?;
+
     if let Some(pool) = app_handle.try_state::<report_db::ReportPool>() {
         let _ = report_db::insert(&pool.0, "worktree_change:remove", &wp).await;
     }
     Ok(())
+}
+
+#[tauri::command]
+fn cancel_worktree_remove(
+    remove_manager: State<'_, WorktreeRemoveManager>,
+    worktree_path: String,
+) -> Result<(), String> {
+    if remove_manager.cancel(&worktree_path) {
+        Ok(())
+    } else {
+        // すでに完了または存在しない場合は無視
+        Ok(())
+    }
 }
 
 #[tauri::command]
@@ -692,6 +743,7 @@ pub fn run() {
 
     let app = builder
         .manage(PtyManager::new())
+        .manage(WorktreeRemoveManager::new())
         .manage(SettingsManager::new())
         .manage(mcp_server::McpServerManager::new())
         .manage(mcp_server::McpPeerRegistry(std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()))))
@@ -713,6 +765,7 @@ pub fn run() {
             git_pull,
             git_worktree_add,
             git_worktree_remove,
+            cancel_worktree_remove,
             git_worktree_restore,
             git_list_branches,
             detect_package_manager,

--- a/src-tauri/src/process_utils.rs
+++ b/src-tauri/src/process_utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::process::Command;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -204,5 +205,281 @@ pub fn kill_process_tree(pid: u32) {
             libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
             libc::kill(pid as libc::pid_t, libc::SIGKILL);
         }
+    }
+}
+
+// ============================================================
+// Windows: NtAPI (PEB経由CWD読取) によるプロセス検索・kill
+// CreateToolhelp32Snapshot + NtQueryInformationProcess + ReadProcessMemory
+// ============================================================
+
+/// 指定ディレクトリ以下をカレントディレクトリとして持つ外部プロセスを検索してkillする。
+/// PTYManagerが管理しないプロセス（IDE、シェルがcd済みのもの等）も対象にする。
+/// 返り値: killしたプロセス数
+#[cfg(target_os = "windows")]
+pub fn kill_external_processes_in_dir(dir: &str) -> usize {
+    let pids = find_processes_by_cwd(dir);
+    let count = pids.len();
+    for pid in pids {
+        kill_process_tree(pid);
+    }
+    count
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn kill_external_processes_in_dir(_dir: &str) -> usize {
+    0
+}
+
+/// 指定ディレクトリ以下をcwdとして持つプロセスのPIDリストを返す（Windows専用）。
+/// 自プロセスは除外する。
+#[cfg(target_os = "windows")]
+fn find_processes_by_cwd(dir: &str) -> Vec<u32> {
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+
+    let our_pid = std::process::id();
+    // パスを正規化: 末尾スラッシュを除去してから小文字化
+    let target = normalize_path_for_cmp(dir);
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        log::warn!("find_processes_by_cwd: CreateToolhelp32Snapshot failed");
+        return vec![];
+    }
+
+    let mut results = Vec::new();
+    let mut entry: PROCESSENTRY32W = unsafe { std::mem::zeroed() };
+    entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+
+    if unsafe { Process32FirstW(snapshot, &mut entry) } != 0 {
+        loop {
+            let pid = entry.th32ProcessID;
+            if pid != our_pid && pid != 0 {
+                if let Some(cwd) = get_process_cwd(pid) {
+                    let cwd_norm = normalize_path_for_cmp(&cwd);
+                    if cwd_norm.starts_with(&target) {
+                        // target がパスの途中に一致しないよう境界チェック
+                        let rest = &cwd_norm[target.len()..];
+                        if rest.is_empty() || rest.starts_with('\\') || rest.starts_with('/') {
+                            log::info!(
+                                "find_processes_by_cwd: pid={} cwd={} matches target={}",
+                                pid, cwd, dir
+                            );
+                            results.push(pid);
+                        }
+                    }
+                }
+            }
+            if unsafe { Process32NextW(snapshot, &mut entry) } == 0 {
+                break;
+            }
+        }
+    }
+
+    unsafe { windows_sys::Win32::Foundation::CloseHandle(snapshot) };
+    results
+}
+
+/// パスを比較用に正規化: バックスラッシュをフォワードスラッシュに統一、末尾スラッシュ除去、小文字化
+#[cfg(target_os = "windows")]
+fn normalize_path_for_cmp(path: &str) -> String {
+    path.replace('\\', "/")
+        .trim_end_matches('/')
+        .to_lowercase()
+}
+
+/// NtQueryInformationProcess + ReadProcessMemory で PEB から CWD を読み取る（Windows専用）。
+/// アクセス不可・失敗時は None を返す。
+#[cfg(target_os = "windows")]
+fn get_process_cwd(pid: u32) -> Option<String> {
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+    };
+    use windows_sys::Win32::Foundation::CloseHandle;
+
+    // ntdll の NtQueryInformationProcess を動的に取得
+    // HANDLE は windows-sys 0.59 では *mut c_void
+    type NtQueryFn = unsafe extern "system" fn(
+        *mut std::ffi::c_void,  // ProcessHandle
+        u32,                    // ProcessInformationClass
+        *mut u8,                // ProcessInformation
+        u32,                    // ProcessInformationLength
+        *mut u32,               // ReturnLength
+    ) -> i32;
+
+    let ntdll = unsafe {
+        windows_sys::Win32::System::LibraryLoader::GetModuleHandleW(
+            windows_sys::core::w!("ntdll.dll")
+        )
+    };
+    if ntdll.is_null() {
+        return None;
+    }
+
+    let fn_name = b"NtQueryInformationProcess\0";
+    let nt_query: NtQueryFn = unsafe {
+        let addr = windows_sys::Win32::System::LibraryLoader::GetProcAddress(ntdll, fn_name.as_ptr());
+        std::mem::transmute(addr?)
+    };
+
+    let handle = unsafe {
+        OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, 0, pid)
+    };
+    if handle.is_null() {
+        return None;
+    }
+
+    let result = read_cwd_from_process(handle, nt_query);
+    unsafe { CloseHandle(handle) };
+    result
+}
+
+/// プロセスハンドルから PEB → ProcessParameters → CurrentDirectory を読み取る。
+#[cfg(target_os = "windows")]
+fn read_cwd_from_process(
+    handle: *mut std::ffi::c_void,
+    nt_query: unsafe extern "system" fn(*mut std::ffi::c_void, u32, *mut u8, u32, *mut u32) -> i32,
+) -> Option<String> {
+    use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
+
+    // PROCESS_BASIC_INFORMATION: 6 × pointer-sized fields
+    // PebBaseAddress は offset 1 (index 1)
+    const PBI_SIZE: usize = 6 * 8; // 64bit 固定
+    let mut pbi = [0u8; PBI_SIZE];
+    let mut ret_len: u32 = 0;
+    let status = unsafe {
+        nt_query(handle, 0 /*ProcessBasicInformation*/, pbi.as_mut_ptr(), PBI_SIZE as u32, &mut ret_len)
+    };
+    if status != 0 {
+        return None;
+    }
+
+    // PebBaseAddress: offset 8 (2nd pointer, 8 bytes each on x64)
+    let peb_addr = i64::from_ne_bytes(pbi[8..16].try_into().ok()?) as usize;
+    if peb_addr == 0 {
+        return None;
+    }
+
+    // PEB を読む (最低 0x28 バイト必要)
+    let mut peb_buf = [0u8; 0x28];
+    let mut bytes_read: usize = 0;
+    let ok = unsafe {
+        ReadProcessMemory(
+            handle,
+            peb_addr as *const _,
+            peb_buf.as_mut_ptr() as *mut _,
+            peb_buf.len(),
+            &mut bytes_read,
+        )
+    };
+    if ok == 0 || bytes_read < 0x28 {
+        return None;
+    }
+
+    // ProcessParameters アドレス: PEB+0x20 (x64)
+    let proc_params_addr = usize::from_ne_bytes(peb_buf[0x20..0x28].try_into().ok()?);
+    if proc_params_addr == 0 {
+        return None;
+    }
+
+    // RTL_USER_PROCESS_PARAMETERS を読む (CurrentDirectory は offset 0x38 から)
+    // UNICODE_STRING: Length(u16) + MaximumLength(u16) + [padding 4 bytes] + Buffer(*u16)
+    // offset 0x38: Length (u16)
+    // offset 0x3A: MaximumLength (u16)
+    // offset 0x40: Buffer (u64 on x64)
+    let read_size = 0x48usize;
+    let mut pp_buf = vec![0u8; read_size];
+    let mut bytes_read: usize = 0;
+    let ok = unsafe {
+        ReadProcessMemory(
+            handle,
+            proc_params_addr as *const _,
+            pp_buf.as_mut_ptr() as *mut _,
+            read_size,
+            &mut bytes_read,
+        )
+    };
+    if ok == 0 || bytes_read < read_size {
+        return None;
+    }
+
+    let cwd_len = u16::from_ne_bytes(pp_buf[0x38..0x3A].try_into().ok()?) as usize;
+    let cwd_buf_addr = usize::from_ne_bytes(pp_buf[0x40..0x48].try_into().ok()?);
+    if cwd_len == 0 || cwd_buf_addr == 0 || cwd_len > 0x800 {
+        return None;
+    }
+
+    // CWD 文字列（UTF-16LE）を読む
+    let mut str_buf = vec![0u8; cwd_len];
+    let mut bytes_read: usize = 0;
+    let ok = unsafe {
+        ReadProcessMemory(
+            handle,
+            cwd_buf_addr as *const _,
+            str_buf.as_mut_ptr() as *mut _,
+            cwd_len,
+            &mut bytes_read,
+        )
+    };
+    if ok == 0 || bytes_read < cwd_len {
+        return None;
+    }
+
+    // UTF-16LE → String
+    let u16_slice: Vec<u16> = str_buf
+        .chunks_exact(2)
+        .map(|b| u16::from_ne_bytes([b[0], b[1]]))
+        .collect();
+    // 末尾の NUL および末尾スラッシュを除去
+    let s = String::from_utf16_lossy(&u16_slice);
+    let s = s.trim_end_matches('\0').trim_end_matches(['\\', '/']).to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+// ============================================================
+// WorktreeRemoveManager: ワークツリー削除のキャンセルフラグ管理
+// ============================================================
+
+/// ワークツリー削除の永続リトライをキャンセルするためのフラグ管理。
+/// キーは worktree_path（バックエンドコマンドが受け取るパスと一致させる）。
+pub struct WorktreeRemoveManager {
+    cancel_flags: Mutex<HashMap<String, Arc<AtomicBool>>>,
+}
+
+impl WorktreeRemoveManager {
+    pub fn new() -> Self {
+        Self {
+            cancel_flags: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// キャンセルフラグを作成して返す（削除開始時に呼ぶ）
+    pub fn create_cancel_flag(&self, key: &str) -> Arc<AtomicBool> {
+        let flag = Arc::new(AtomicBool::new(false));
+        let mut map = self.cancel_flags.lock().unwrap_or_else(|e| e.into_inner());
+        map.insert(key.to_string(), flag.clone());
+        flag
+    }
+
+    /// キャンセルフラグをセットする（キャンセル要求時に呼ぶ）。
+    /// フラグが存在した場合 true を返す。
+    pub fn cancel(&self, key: &str) -> bool {
+        let map = self.cancel_flags.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(flag) = map.get(key) {
+            flag.store(true, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// フラグを削除する（削除完了/キャンセル完了時に呼ぶ）
+    pub fn remove(&self, key: &str) {
+        let mut map = self.cancel_flags.lock().unwrap_or_else(|e| e.into_inner());
+        map.remove(key);
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -286,9 +286,11 @@ const {
   removeTargetWorktree,
   removeBranches,
   removeDirtyFiles,
+  cancellableWorktrees,
   onRemoveWorktree,
   onRemoveWorktreeConfirm,
   onArchiveWorktreeConfirm,
+  cancelWorktreeRemove,
   dismissDialog: onRemoveWorktreeDismiss,
 } = useRemoveWorktreeDialog({
   loadingWorktrees,
@@ -1445,6 +1447,7 @@ onMounted(async () => {
         :hotkey-chars="hotkeyChars"
         :artifact-counts="artifactCounts"
         :loading-worktrees="loadingWorktrees"
+        :cancellable-worktrees="cancellableWorktrees"
         :auto-approvals="autoApprovalMap"
         :ai-judging-worktrees="aiJudgingWorktrees"
         @select-terminal="switchToTerminal"
@@ -1460,6 +1463,7 @@ onMounted(async () => {
         @set-hotkey-char="onSetHotkeyChar"
         @toggle-auto-approval="onToggleAutoApproval"
         @cancel-ai-judging="onCancelAiJudging"
+        @cancel-remove="cancelWorktreeRemove"
         @duplicate-worktree="onDuplicateWorktree"
         @reorder-worktrees="reorderWorktree"
         @commit-reorder="saveWorktreeOrder"
@@ -1653,6 +1657,7 @@ onMounted(async () => {
     "taskCompletedDetail": "All steps completed",
     "taskFailedSummary": "Task Failed",
     "deletingText": "Deleting...",
+    "retryingDeleteText": "Retrying deletion...",
     "archivingText": "Archiving...",
     "creatingText": "Creating...",
     "duplicatingText": "Duplicating...",
@@ -1683,6 +1688,7 @@ onMounted(async () => {
     "taskCompletedDetail": "すべてのステップが完了しました",
     "taskFailedSummary": "タスク失敗",
     "deletingText": "削除中...",
+    "retryingDeleteText": "削除をリトライ中...",
     "archivingText": "アーカイブ中...",
     "creatingText": "作成中...",
     "duplicatingText": "複製中...",

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -166,6 +166,7 @@ const props = defineProps<{
   hotkeyChars: Map<string, string>;
   artifactCounts: Map<string, number>;
   loadingWorktrees: Map<string, string>;
+  cancellableWorktrees: Set<string>;
   autoApprovals: Map<string, boolean>;
   aiJudgingWorktrees: Set<string>;
 }>();
@@ -187,6 +188,7 @@ const emit = defineEmits<{
   setHotkeyChar: [worktreeId: string];
   toggleAutoApproval: [worktreeId: string];
   cancelAiJudging: [worktreeId: string];
+  cancelRemove: [worktreeId: string];
   duplicateWorktree: [worktreeId: string];
   addTask: [];
   removeTask: [taskId: string];
@@ -366,6 +368,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
               :artifact-count="artifactCounts.get(worktree.id) ?? 0"
               :loading="loadingWorktrees.has(worktree.id)"
               :loading-text="loadingWorktrees.get(worktree.id)"
+              :cancellable="cancellableWorktrees.has(worktree.id)"
               :auto-approval="autoApprovals.get(worktree.id) ?? false"
               :ai-judging="aiJudgingWorktrees.has(worktree.id)"
               @drag-start="onCardDragStart"
@@ -381,6 +384,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
               @set-hotkey-char="emit('setHotkeyChar', $event)"
               @toggle-auto-approval="emit('toggleAutoApproval', $event)"
               @cancel-ai-judging="emit('cancelAiJudging', $event)"
+              @cancel-remove="emit('cancelRemove', $event)"
               @duplicate-worktree="emit('duplicateWorktree', $event)"
             />
           </div>

--- a/src/components/WorktreeCard.vue
+++ b/src/components/WorktreeCard.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
   artifactCount?: number;
   loading?: boolean;
   loadingText?: string;
+  cancellable?: boolean;
   autoApproval?: boolean;
   aiJudging?: boolean;
 }>();
@@ -27,6 +28,7 @@ const emit = defineEmits<{
   dragEnd: [];
   addTerminal: [worktreeId: string];
   removeWorktree: [worktreeId: string];
+  cancelRemove: [worktreeId: string];
   openInIde: [worktreeId: string];
   moveToSubWindow: [worktreeId: string];
   moveToMainWindow: [worktreeId: string];
@@ -196,6 +198,13 @@ const terminalList = computed(() =>
     <div v-if="loading" class="loading-overlay">
       <span class="pi pi-spinner pi-spin loading-icon" />
       <span class="loading-text">{{ loadingText ?? t('deletingText') }}</span>
+      <button
+        v-if="cancellable"
+        class="cancel-remove-btn"
+        @click.stop="emit('cancelRemove', worktree.id)"
+      >
+        {{ t('cancelRemove') }}
+      </button>
     </div>
   </div>
 </template>
@@ -416,6 +425,22 @@ const terminalList = computed(() =>
   font-size: 12px;
   color: #a6adc8;
 }
+
+.cancel-remove-btn {
+  margin-top: 4px;
+  padding: 4px 12px;
+  font-size: 11px;
+  color: #cdd6f4;
+  background: rgba(243, 139, 168, 0.15);
+  border: 1px solid rgba(243, 139, 168, 0.4);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.cancel-remove-btn:hover {
+  background: rgba(243, 139, 168, 0.3);
+}
 </style>
 
 <i18n lang="json">
@@ -429,6 +454,7 @@ const terminalList = computed(() =>
     "addTerminal": "Add terminal",
     "noTerminals": "No terminals",
     "deletingText": "Deleting...",
+    "cancelRemove": "Cancel",
     "menu": {
       "autoApproval": "Auto approval",
       "setHotkey": "Assign hotkey",
@@ -448,6 +474,7 @@ const terminalList = computed(() =>
     "addTerminal": "ターミナルを追加",
     "noTerminals": "ターミナルがありません",
     "deletingText": "削除中...",
+    "cancelRemove": "キャンセル",
     "menu": {
       "autoApproval": "自動承認",
       "setHotkey": "ホットキー割り当て",

--- a/src/composables/useRemoveWorktreeDialog.ts
+++ b/src/composables/useRemoveWorktreeDialog.ts
@@ -165,14 +165,15 @@ export function useRemoveWorktreeDialog(options: {
       await closeArtifactWindow(worktreeId);
       await cancelApproval(worktreeId);
 
+      // ターミナルプロセスをkillする（ディレクトリのファイルハンドル解放が目的）。
+      // ただし UI 状態のクリア（terminals.splice / frameBundles.delete）は削除成功後に行う。
+      // キャンセル時にワークツリーが UI に残った際、空ターミナルではなく停止済み状態で表示できるようにする。
       const bundle = worktreeFrameBundles.get(worktreeId);
-      for (const terminal of [...worktree.terminals]) {
+      const terminalsSnapshot = [...worktree.terminals];
+      for (const terminal of terminalsSnapshot) {
         const term = bundle?.terminalRefs.get(terminal.id) ?? getTerminalRef(terminal.id);
         if (term?.isRunning) await term.kill();
-        terminalWorktreeMap.delete(terminal.id);
       }
-      worktree.terminals.splice(0);
-      worktreeFrameBundles.delete(worktreeId);
 
       if (activeWorktreeId.value === worktreeId) goHome();
 
@@ -190,6 +191,12 @@ export function useRemoveWorktreeDialog(options: {
             savedPositions = homeViewRef.value?.hideCard(worktreeId);
           },
         );
+        // 削除成功後に UI 状態をクリア
+        for (const terminal of terminalsSnapshot) {
+          terminalWorktreeMap.delete(terminal.id);
+        }
+        worktree.terminals.splice(0);
+        worktreeFrameBundles.delete(worktreeId);
         // git 操作成功後の後処理（MCP通知など）
         if (afterRemove) {
           try { await afterRemove(worktree); } catch { /* 通知失敗はワークツリー削除の成否に影響しない */ }

--- a/src/composables/useRemoveWorktreeDialog.ts
+++ b/src/composables/useRemoveWorktreeDialog.ts
@@ -1,6 +1,7 @@
-import { ref, nextTick } from "vue";
+import { ref, reactive, nextTick } from "vue";
 import type { Ref } from "vue";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { message } from "@tauri-apps/plugin-dialog";
 import { useWorktrees } from "./useWorktrees";
 import { cancelApproval } from "../utils/autoApproval";
@@ -57,6 +58,31 @@ export function useRemoveWorktreeDialog(options: {
   } = options;
 
   const { worktrees, removeWorktree, listBranches } = useWorktrees();
+
+  // 永続リトライ中のワークツリーID（キャンセルボタン表示用）
+  const cancellableWorktrees = reactive(new Set<string>());
+
+  // バックエンドから永続リトライ開始イベントを受信したらキャンセル可能状態に移行
+  listen<{ worktreePath: string }>("worktree-remove-retrying", (event) => {
+    const worktree = worktrees.value.find(
+      (w) => w.path === event.payload.worktreePath
+    );
+    if (worktree) {
+      cancellableWorktrees.add(worktree.id);
+      loadingWorktrees.set(worktree.id, t("retryingDeleteText"));
+    }
+  });
+
+  /** 永続リトライ中の削除をキャンセルする */
+  async function cancelWorktreeRemove(worktreeId: string): Promise<void> {
+    const worktree = worktrees.value.find((w) => w.id === worktreeId);
+    if (!worktree) return;
+    try {
+      await invoke("cancel_worktree_remove", { worktreePath: worktree.path });
+    } catch {
+      // すでに完了している場合は無視
+    }
+  }
 
   // ダイアログ state
   const showRemoveDialog = ref(false);
@@ -176,9 +202,13 @@ export function useRemoveWorktreeDialog(options: {
         if (onRemoveFailed) {
           try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
         }
-        await message(t("deleteFailed", { error: e }), { kind: "error" });
+        // "cancelled" はユーザー操作によるキャンセルなのでエラーダイアログを出さない
+        if (String(e) !== "cancelled") {
+          await message(t("deleteFailed", { error: e }), { kind: "error" });
+        }
       } finally {
         homeViewRef.value?.unhideCard(worktreeId);
+        cancellableWorktrees.delete(worktreeId);
       }
     } catch (e) {
       // UI 後処理ステップ（moveToMainWindow・closeArtifactWindow 等）が失敗した場合。
@@ -186,9 +216,12 @@ export function useRemoveWorktreeDialog(options: {
       if (onRemoveFailed) {
         try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
       }
-      await message(t("deleteFailed", { error: e }), { kind: "error" });
+      if (String(e) !== "cancelled") {
+        await message(t("deleteFailed", { error: e }), { kind: "error" });
+      }
     } finally {
       loadingWorktrees.delete(worktreeId);
+      cancellableWorktrees.delete(worktreeId);
     }
   }
 
@@ -244,9 +277,11 @@ export function useRemoveWorktreeDialog(options: {
     removeTargetWorktree,
     removeBranches,
     removeDirtyFiles,
+    cancellableWorktrees,
     onRemoveWorktree,
     onRemoveWorktreeConfirm,
     onArchiveWorktreeConfirm,
+    cancelWorktreeRemove,
     dismissDialog,
   };
 }


### PR DESCRIPTION
## Summary

- **NtAPIによる外部プロセスkill**: `NtQueryInformationProcess` + `ReadProcessMemory` でPEBのCurrentDirectoryを読み取り、削除対象ディレクトリをCWDに持つ外部プロセスを検出してkillする（既存のPTYセッションkillでは拾えないプロセスも対象）
- **永続リトライ**: Phase 1（既存の5回リトライ）でロックエラーが続く場合、Phase 2の永続リトライループに移行。各イテレーションでNtAPIによるプロセスkill → `git worktree remove --force` → `remove_dir_all` を試みる
- **キャンセルボタン**: Phase 2入り時にフロントエンドへ `worktree-remove-retrying` イベントを送信。ワークツリーカードにキャンセルボタンを表示し、押下で削除を中断できる（ワークツリーは残る）

## Changes

- `src-tauri/src/process_utils.rs`: `kill_external_processes_in_dir()`, `find_processes_by_cwd()`, `get_process_cwd()` 追加、`WorktreeRemoveManager` 追加
- `src-tauri/src/git_worktree.rs`: `worktree_remove_persistent()` 追加（Phase 1/2のリトライロジック）
- `src-tauri/src/lib.rs`: `git_worktree_remove` を `worktree_remove_persistent` に切り替え、`cancel_worktree_remove` コマンド追加、`WorktreeRemoveManager` をStateに登録
- `src/composables/useRemoveWorktreeDialog.ts`: リトライイベント購読、キャンセル処理、`cancellableWorktrees` 追加、キャンセル時のUI状態保全
- `src/components/WorktreeCard.vue`, `HomeView.vue`, `App.vue`: キャンセルボタンUI追加

## Test plan

- [ ] ワークツリー内でターミナルプロセスを起動した状態で削除 → 正常に削除される
- [ ] 外部エディタ等がディレクトリを掴んでいる状態で削除 → Phase 2リトライに入りキャンセルボタンが表示される
- [ ] キャンセルボタン押下 → 削除が中断されワークツリーカードが残り操作可能な状態になる
- [ ] 非ロックエラー（権限不足等）での削除失敗 → 永続リトライに入らずエラーダイアログが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)