### PR TITLE
feat: React アーティファクトで Tailwind CSS を利用可能にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@intlify/unplugin-vue-i18n": "^11.0.7",
+    "@tailwindcss/browser": "^4.2.1",
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/cli": "^2",
     "@types/dompurify": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "monaco-editor": "^0.55.1",
     "primeicons": "^7.0.0",
     "primevue": "^4.5.4",
+    "@tailwindcss/browser": "^4.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tauri-plugin-liquid-glass-api": "^0.1.6",
@@ -50,7 +51,6 @@
   },
   "devDependencies": {
     "@intlify/unplugin-vue-i18n": "^11.0.7",
-    "@tailwindcss/browser": "^4.2.1",
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/cli": "^2",
     "@types/dompurify": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.7
         version: 11.0.7(@vue/compiler-dom@3.5.29)(eslint@10.0.3(jiti@2.6.1))(rollup@4.59.0)(typescript@5.6.3)(vue-i18n@11.3.0(vue@3.5.29(typescript@5.6.3)))(vue@3.5.29(typescript@5.6.3))
+      '@tailwindcss/browser':
+        specifier: ^4.2.1
+        version: 4.2.2
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
@@ -798,6 +801,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tailwindcss/browser@4.2.2':
+    resolution: {integrity: sha512-JVdJBWWtvKxliBI9CtpOrqxgk8aijUWGsn0STxcOcXAYsUFAbOxN5PwawOJ+v0PoQfPcOK9eZoj9LTwvBV0Vmw==}
 
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
@@ -3071,6 +3077,8 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tailwindcss/browser@4.2.2': {}
 
   '@tailwindcss/node@4.2.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@primeuix/themes':
         specifier: ^2.0.3
         version: 2.0.3
+      '@tailwindcss/browser':
+        specifier: ^4.2.1
+        version: 4.2.2
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
@@ -105,9 +108,6 @@ importers:
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.7
         version: 11.0.7(@vue/compiler-dom@3.5.29)(eslint@10.0.3(jiti@2.6.1))(rollup@4.59.0)(typescript@5.6.3)(vue-i18n@11.3.0(vue@3.5.29(typescript@5.6.3)))(vue@3.5.29(typescript@5.6.3))
-      '@tailwindcss/browser':
-        specifier: ^4.2.1
-        version: 4.2.2
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))

--- a/scripts/copy-vendor.mjs
+++ b/scripts/copy-vendor.mjs
@@ -15,6 +15,7 @@ fs.mkdirSync(destDir, { recursive: true });
 const files = [
   ["react/umd/react.production.min.js", "react.production.min.js"],
   ["react-dom/umd/react-dom.production.min.js", "react-dom.production.min.js"],
+  ["@tailwindcss/browser/dist/index.global.js", "tailwindcss-browser.js"],
 ];
 
 for (const [src, dest] of files) {

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -133,7 +133,7 @@ pub struct ArtifactParams {
     pub repository: String,
     #[schemars(description = "ブランチ名")]
     pub branch: String,
-    #[schemars(description = "コンテンツの種類 (create時必須): application/vnd.ant.code, text/markdown, text/html, image/svg+xml, application/vnd.ant.mermaid, application/vnd.ant.react")]
+    #[schemars(description = "コンテンツの種類 (create時必須): application/vnd.ant.code, text/markdown, text/html, image/svg+xml, application/vnd.ant.mermaid, application/vnd.ant.react (Tailwind CSSユーティリティクラス利用可)")]
     #[serde(rename = "type")]
     pub content_type: Option<String>,
     #[schemars(description = "アーティファクトのタイトル (create時必須)")]

--- a/src/components/artifact/ArtifactReactView.vue
+++ b/src/components/artifact/ArtifactReactView.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from "vue";
 import ArtifactCodeView from "./ArtifactCodeView.vue";
 import { buildVendorHead, buildReactSrcdoc } from "../../utils/reactArtifactSrcdoc";
 
-type VendorScripts = { react: string; reactDom: string; babel: string };
+type VendorScripts = { react: string; reactDom: string; babel: string; tailwind: string };
 
 // Promise キャッシュ: 同時マウント時も重複フェッチしない。失敗時は null にリセットしてリトライ可能にする。
 let _vendorPromise: Promise<VendorScripts> | null = null;
@@ -19,7 +19,8 @@ function loadVendors(): Promise<VendorScripts> {
       fetchText("/vendor/react.production.min.js"),
       fetchText("/vendor/react-dom.production.min.js"),
       import("@babel/standalone/babel.min.js?raw").then((m) => m.default),
-    ]).then(([react, reactDom, babel]) => ({ react, reactDom, babel }))
+      fetchText("/vendor/tailwindcss-browser.js"),
+    ]).then(([react, reactDom, babel, tailwind]) => ({ react, reactDom, babel, tailwind }))
       .catch((e) => {
         _vendorPromise = null; // 失敗時はリトライ可能にする
         throw e;
@@ -52,8 +53,8 @@ onMounted(async () => {
 // ベンダーヘッド（~2MB）は vendorScripts が変化したときのみ再計算する
 const vendorHead = computed(() => {
   if (!vendorScripts.value) return "";
-  const { react, reactDom, babel } = vendorScripts.value;
-  return buildVendorHead(react, reactDom, babel);
+  const { react, reactDom, babel, tailwind } = vendorScripts.value;
+  return buildVendorHead(react, reactDom, babel, tailwind);
 });
 
 // content が変わっても vendorHead は再計算されない

--- a/src/utils/reactArtifactSrcdoc.ts
+++ b/src/utils/reactArtifactSrcdoc.ts
@@ -78,10 +78,10 @@ const RUNTIME_JS =
   "})();";
 
 /**
- * ベンダースクリプト（React/ReactDOM/Babel）から静的な <head> 部分を構築する。
+ * ベンダースクリプト（React/ReactDOM/Babel/Tailwind）から静的な <head> 部分を構築する。
  * content が変わっても再計算不要なため、呼び出し側でキャッシュすること。
  */
-export function buildVendorHead(react: string, reactDom: string, babel: string): string {
+export function buildVendorHead(react: string, reactDom: string, babel: string, tailwind: string): string {
   return (
     "<!DOCTYPE html>\n<html>\n<head>\n" +
     '<meta charset="utf-8" />\n' +
@@ -92,9 +92,12 @@ export function buildVendorHead(react: string, reactDom: string, babel: string):
     // 親ウィンドウ・Cookie・localStorage へのアクセスは遮断されている。
     '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; script-src \'unsafe-inline\' \'unsafe-eval\'; style-src \'unsafe-inline\'; img-src data: blob:;" />\n' +
     "<style>" + STYLES + "</style>\n" +
+    // @tailwindcss/browser の初期化エントリポイント
+    '<style type="text/tailwindcss">@import "tailwindcss";</style>\n' +
     openTag(react) + "\n" +
     openTag(reactDom) + "\n" +
     openTag(babel) + "\n" +
+    openTag(tailwind) + "\n" +
     "</head>\n"
   );
 }


### PR DESCRIPTION
## Summary

- `@tailwindcss/browser` を vendor として iframe の srcdoc に注入し、React アーティファクト内で Tailwind CSS ユーティリティクラスを使えるようにする
- `sandbox="allow-scripts"` + CSP の制約内で動作（外部通信不要、全て inline）
- ベンダーヘッドのキャッシュ設計を維持し、パフォーマンスへの影響を最小化

## Changes

- `package.json` — `@tailwindcss/browser: ^4.2.1` を dependencies に追加
- `scripts/copy-vendor.mjs` — `@tailwindcss/browser/dist/index.global.js` → `public/vendor/tailwindcss-browser.js` のコピーを追加
- `src/utils/reactArtifactSrcdoc.ts` — `buildVendorHead` に Tailwind ブラウザランタイムと `<style type="text/tailwindcss">` 初期化タグを注入
- `src/components/artifact/ArtifactReactView.vue` — `VendorScripts` 型と `loadVendors()` に `tailwindcss-browser.js` のフェッチを追加

## Test plan

- [ ] `pnpm install` 後に `public/vendor/tailwindcss-browser.js` が生成されることを確認
- [ ] `pnpm run type-check` がエラーなしで通ることを確認
- [ ] React アーティファクトのプレビューで `className="bg-blue-500 text-white p-4 rounded-lg"` 等の Tailwind クラスが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)