### PR TITLE
feat: modular React artifact support with MCP tools

### DIFF
--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -146,6 +146,10 @@ pub struct ArtifactParams {
     pub old_str: Option<String>,
     #[schemars(description = "update時: 置き換え後の文字列")]
     pub new_str: Option<String>,
+    #[schemars(description = "get時: 取得開始行 (0始まり、省略時は0)")]
+    pub offset: Option<u32>,
+    #[schemars(description = "get時: 取得する行数 (省略時は全行)")]
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -191,6 +195,10 @@ pub struct ArtifactModuleParams {
     pub old_str: Option<String>,
     #[schemars(description = "update時: 置き換え後の文字列")]
     pub new_str: Option<String>,
+    #[schemars(description = "get時: 取得開始行 (0始まり、省略時は0)")]
+    pub offset: Option<u32>,
+    #[schemars(description = "get時: 取得する行数 (省略時は全行)")]
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -255,7 +263,7 @@ impl NotifyService {
         }
     }
 
-    #[tool(description = "アーティファクトを操作する。create: 新規作成, update: 差分更新(old_str→new_str), rewrite: 全置換, get: 1件取得(全フィールド含む)")]
+    #[tool(description = "アーティファクトを操作する。create: 新規作成, update: 差分更新(old_str→new_str), rewrite: 全置換, get: 1件取得(offset/limitで行範囲指定可)")]
     async fn artifact(
         &self,
         Parameters(ArtifactParams {
@@ -269,6 +277,8 @@ impl NotifyService {
             language,
             old_str,
             new_str,
+            offset,
+            limit,
         }): Parameters<ArtifactParams>,
     ) -> Result<CallToolResult, McpError> {
         let settings_manager = self.app_handle.state::<SettingsManager>();
@@ -306,8 +316,25 @@ impl NotifyService {
         if command == "get" {
             let raw = tokio_fs::read_to_string(&artifact_path).await
                 .map_err(|_| McpError::invalid_params(format!("アーティファクト '{}' が存在しません", id), None))?;
-            log::info!("[mcp] artifact command=get id={} worktree_id={}", id, worktree_id);
-            return Ok(CallToolResult::success(vec![Content::text(raw)]));
+            let mut data: ArtifactData = serde_json::from_str(&raw)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            let total_lines = data.content.lines().count();
+            let off = offset.unwrap_or(0) as usize;
+            if let Some(lim) = limit {
+                data.content = data.content.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n");
+            } else if off > 0 {
+                data.content = data.content.lines().skip(off).collect::<Vec<_>>().join("\n");
+            }
+            let mut json_val = serde_json::to_value(&data)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            if offset.is_some() || limit.is_some() {
+                json_val["content_total_lines"] = serde_json::Value::Number(total_lines.into());
+                json_val["content_offset"] = serde_json::Value::Number(off.into());
+            }
+            let json = serde_json::to_string_pretty(&json_val)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            log::info!("[mcp] artifact command=get id={} offset={:?} limit={:?} worktree_id={}", id, offset, limit, worktree_id);
+            return Ok(CallToolResult::success(vec![Content::text(json)]));
         }
 
         if command == "outline" {
@@ -444,12 +471,13 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "Reactアーティファクトのモジュールを操作する。大規模アーティファクトをファイル単位で管理するために使用。list: モジュール一覧(行数のみ), get: 1モジュール取得, create: 追加, update: 差分更新, rewrite: 全置換, delete: 削除")]
+    #[tool(description = "Reactアーティファクトのモジュールを操作する。大規模アーティファクトをファイル単位で管理するために使用。list: モジュール一覧(行数のみ), get: 1モジュール取得(offset/limitで行範囲指定可), create: 追加, update: 差分更新, rewrite: 全置換, delete: 削除")]
     async fn artifact_module(
         &self,
         Parameters(ArtifactModuleParams {
             command, id, repository, branch,
             module_name, content, old_str, new_str,
+            offset, limit,
         }): Parameters<ArtifactModuleParams>,
     ) -> Result<CallToolResult, McpError> {
         // モジュール名バリデーション
@@ -473,6 +501,11 @@ impl NotifyService {
                 None,
             ))?;
         let worktree_id = wt.id.clone();
+
+        // artifact ID のパストラバーサル防止
+        if id.contains("..") || id.contains('/') || id.contains('\\') || id.contains('\0') {
+            return Err(McpError::invalid_params("不正なアーティファクトIDです".to_string(), None));
+        }
 
         let artifacts_dir = self.app_handle.path().app_data_dir()
             .map_err(|e| McpError::internal_error(e.to_string(), None))?
@@ -503,11 +536,45 @@ impl NotifyService {
                 validate_module_name(name)?;
                 let src = data.modules.get(name)
                     .ok_or_else(|| McpError::invalid_params(format!("モジュール '{}' が存在しません", name), None))?;
-                serde_json::to_string_pretty(&serde_json::json!({
-                    "id": id, "module_name": name, "content": src,
-                })).map_err(|e| McpError::internal_error(e.to_string(), None))?
+                let total_lines = src.lines().count();
+                let off = offset.unwrap_or(0) as usize;
+                let sliced = if let Some(lim) = limit {
+                    src.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n")
+                } else if off > 0 {
+                    src.lines().skip(off).collect::<Vec<_>>().join("\n")
+                } else {
+                    src.clone()
+                };
+                let mut val = serde_json::json!({ "id": id, "module_name": name, "content": sliced });
+                if offset.is_some() || limit.is_some() {
+                    val["content_total_lines"] = serde_json::Value::Number(total_lines.into());
+                    val["content_offset"] = serde_json::Value::Number(off.into());
+                }
+                serde_json::to_string_pretty(&val).map_err(|e| McpError::internal_error(e.to_string(), None))?
             }
-            "create" | "rewrite" => {
+            "create" => {
+                let name = module_name.as_deref()
+                    .ok_or_else(|| McpError::invalid_params("module_name が必要です", None))?;
+                validate_module_name(name)?;
+                if data.modules.contains_key(name) {
+                    return Err(McpError::invalid_params(
+                        format!("モジュール '{}' は既に存在します。上書きするには rewrite を使用してください", name), None,
+                    ));
+                }
+                let src = content
+                    .ok_or_else(|| McpError::invalid_params("content が必要です", None))?;
+                data.modules.insert(name.to_string(), src);
+                data.updated_at = now;
+                let json = serde_json::to_string_pretty(&data)
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                tokio_fs::write(&artifact_path, &json).await
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
+                    "worktreeId": worktree_id, "artifactId": id, "command": "create",
+                })) { log::warn!("Failed to emit artifact-changed: {}", e); }
+                json
+            }
+            "rewrite" => {
                 let name = module_name.as_deref()
                     .ok_or_else(|| McpError::invalid_params("module_name が必要です", None))?;
                 validate_module_name(name)?;
@@ -520,7 +587,7 @@ impl NotifyService {
                 tokio_fs::write(&artifact_path, &json).await
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
                 if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
-                    "worktreeId": worktree_id, "artifactId": id, "command": command,
+                    "worktreeId": worktree_id, "artifactId": id, "command": "rewrite",
                 })) { log::warn!("Failed to emit artifact-changed: {}", e); }
                 json
             }

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -125,7 +125,7 @@ pub struct NotifyWorktreeEvent {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ArtifactParams {
-    #[schemars(description = "操作の種類: \"create\"(新規作成) / \"update\"(差分更新) / \"rewrite\"(全置換) / \"get\"(1件取得)")]
+    #[schemars(description = "操作の種類: \"create\"(新規作成) / \"update\"(差分更新) / \"rewrite\"(全置換) / \"get\"(1件取得) / \"outline\"(構造概要取得。contentを除く)")]
     pub command: String,
     #[schemars(description = "アーティファクトを識別する一意なID")]
     pub id: String,
@@ -157,6 +157,8 @@ struct ArtifactData {
     content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     language: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    modules: HashMap<String, String>,
     created_at: u64,
     updated_at: u64,
 }
@@ -169,6 +171,26 @@ pub struct SearchArtifactParams {
     pub branch: String,
     #[schemars(description = "検索キーワード (省略時は全件返却)。title, content, type, language を対象に部分一致検索")]
     pub query: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ArtifactModuleParams {
+    #[schemars(description = "操作の種類: \"list\"(一覧), \"get\"(取得), \"create\"(作成), \"update\"(差分更新), \"rewrite\"(全置換), \"delete\"(削除)")]
+    pub command: String,
+    #[schemars(description = "アーティファクトID")]
+    pub id: String,
+    #[schemars(description = "リポジトリ名")]
+    pub repository: String,
+    #[schemars(description = "ブランチ名")]
+    pub branch: String,
+    #[schemars(description = "モジュール名 (例: \"components/Header\", \"screens/Login\")。list時は省略可")]
+    pub module_name: Option<String>,
+    #[schemars(description = "モジュールのソースコード (create/rewrite時必須)")]
+    pub content: Option<String>,
+    #[schemars(description = "update時: 置き換え元の文字列 (モジュール内に1箇所だけ存在すること)")]
+    pub old_str: Option<String>,
+    #[schemars(description = "update時: 置き換え後の文字列")]
+    pub new_str: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -288,6 +310,59 @@ impl NotifyService {
             return Ok(CallToolResult::success(vec![Content::text(raw)]));
         }
 
+        if command == "outline" {
+            let raw = tokio_fs::read_to_string(&artifact_path).await
+                .map_err(|_| McpError::invalid_params(format!("アーティファクト '{}' が存在しません", id), None))?;
+            let data: ArtifactData = serde_json::from_str(&raw)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+            fn extract_exports(src: &str) -> Vec<String> {
+                let mut names = Vec::new();
+                for line in src.lines() {
+                    let trimmed = line.trim();
+                    // export default function/class Name
+                    if trimmed.starts_with("export default function ") || trimmed.starts_with("export default class ") {
+                        let rest = trimmed.trim_start_matches("export default function ").trim_start_matches("export default class ");
+                        let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
+                        if !name.is_empty() { names.push(name); }
+                    }
+                    // export function/const/class Name
+                    else if trimmed.starts_with("export function ") || trimmed.starts_with("export const ") || trimmed.starts_with("export class ") {
+                        let rest = trimmed
+                            .trim_start_matches("export function ")
+                            .trim_start_matches("export const ")
+                            .trim_start_matches("export class ");
+                        let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
+                        if !name.is_empty() { names.push(name); }
+                    }
+                }
+                names.dedup();
+                names
+            }
+
+            let entry_lines = data.content.lines().count();
+            let entry_exports = extract_exports(&data.content);
+            let modules_outline: serde_json::Value = data.modules.iter().map(|(name, src)| {
+                (name.clone(), serde_json::json!({
+                    "lines": src.lines().count(),
+                    "exports": extract_exports(src),
+                }))
+            }).collect::<serde_json::Map<_, _>>().into();
+
+            let outline = serde_json::json!({
+                "id": data.id,
+                "title": data.title,
+                "type": data.content_type,
+                "entry_lines": entry_lines,
+                "entry_exports": entry_exports,
+                "modules": modules_outline,
+            });
+            let json = serde_json::to_string_pretty(&outline)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            log::info!("[mcp] artifact command=outline id={} worktree_id={}", id, worktree_id);
+            return Ok(CallToolResult::success(vec![Content::text(json)]));
+        }
+
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -306,7 +381,7 @@ impl NotifyService {
                 })?;
                 tokio_fs::create_dir_all(&artifacts_dir).await
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-                ArtifactData { id: id.clone(), content_type, title, content, language, created_at: now, updated_at: now }
+                ArtifactData { id: id.clone(), content_type, title, content, language, modules: HashMap::new(), created_at: now, updated_at: now }
             }
             "update" => {
                 let old_str = old_str.ok_or_else(|| {
@@ -343,7 +418,7 @@ impl NotifyService {
                 data
             }
             other => return Err(McpError::invalid_params(
-                format!("不明なコマンド '{}'. create / update / rewrite / get のいずれかを指定してください", other),
+                format!("不明なコマンド '{}'. create / update / rewrite / get / outline のいずれかを指定してください", other),
                 None,
             )),
         };
@@ -367,6 +442,139 @@ impl NotifyService {
             }
         }
         Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "Reactアーティファクトのモジュールを操作する。大規模アーティファクトをファイル単位で管理するために使用。list: モジュール一覧(行数のみ), get: 1モジュール取得, create: 追加, update: 差分更新, rewrite: 全置換, delete: 削除")]
+    async fn artifact_module(
+        &self,
+        Parameters(ArtifactModuleParams {
+            command, id, repository, branch,
+            module_name, content, old_str, new_str,
+        }): Parameters<ArtifactModuleParams>,
+    ) -> Result<CallToolResult, McpError> {
+        // モジュール名バリデーション
+        fn validate_module_name(name: &str) -> Result<(), McpError> {
+            if name.contains("..") || name.starts_with('/') || name.contains('\\') || name.contains('\0') {
+                return Err(McpError::invalid_params(
+                    format!("無効なモジュール名: '{}'", name), None,
+                ));
+            }
+            Ok(())
+        }
+
+        let settings_manager = self.app_handle.state::<SettingsManager>();
+        let settings = settings_manager.get();
+        let wt = settings
+            .worktrees
+            .iter()
+            .find(|wt| wt.repository_name == repository && wt.branch_name == branch)
+            .ok_or_else(|| McpError::invalid_params(
+                format!("repository='{}', branch='{}' に一致するワークツリーが存在しません", repository, branch),
+                None,
+            ))?;
+        let worktree_id = wt.id.clone();
+
+        let artifacts_dir = self.app_handle.path().app_data_dir()
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?
+            .join("artifacts")
+            .join(&worktree_id);
+        let artifact_path = artifacts_dir.join(format!("{}.json", id));
+
+        let raw = tokio_fs::read_to_string(&artifact_path).await
+            .map_err(|_| McpError::invalid_params(format!("アーティファクト '{}' が存在しません", id), None))?;
+        let mut data: ArtifactData = serde_json::from_str(&raw)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+
+        let result_json: String = match command.as_str() {
+            "list" => {
+                let list: Vec<serde_json::Value> = data.modules.iter().map(|(name, src)| {
+                    serde_json::json!({ "module_name": name, "lines": src.lines().count() })
+                }).collect();
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "id": id,
+                    "modules": list,
+                })).map_err(|e| McpError::internal_error(e.to_string(), None))?
+            }
+            "get" => {
+                let name = module_name.as_deref()
+                    .ok_or_else(|| McpError::invalid_params("module_name が必要です", None))?;
+                validate_module_name(name)?;
+                let src = data.modules.get(name)
+                    .ok_or_else(|| McpError::invalid_params(format!("モジュール '{}' が存在しません", name), None))?;
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "id": id, "module_name": name, "content": src,
+                })).map_err(|e| McpError::internal_error(e.to_string(), None))?
+            }
+            "create" | "rewrite" => {
+                let name = module_name.as_deref()
+                    .ok_or_else(|| McpError::invalid_params("module_name が必要です", None))?;
+                validate_module_name(name)?;
+                let src = content
+                    .ok_or_else(|| McpError::invalid_params("content が必要です", None))?;
+                data.modules.insert(name.to_string(), src);
+                data.updated_at = now;
+                let json = serde_json::to_string_pretty(&data)
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                tokio_fs::write(&artifact_path, &json).await
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
+                    "worktreeId": worktree_id, "artifactId": id, "command": command,
+                })) { log::warn!("Failed to emit artifact-changed: {}", e); }
+                json
+            }
+            "update" => {
+                let name = module_name.as_deref()
+                    .ok_or_else(|| McpError::invalid_params("module_name が必要です", None))?;
+                validate_module_name(name)?;
+                let old = old_str.ok_or_else(|| McpError::invalid_params("old_str が必要です", None))?;
+                let new = new_str.ok_or_else(|| McpError::invalid_params("new_str が必要です", None))?;
+                let src = data.modules.get_mut(name)
+                    .ok_or_else(|| McpError::invalid_params(format!("モジュール '{}' が存在しません", name), None))?;
+                let count = src.matches(old.as_str()).count();
+                if count == 0 {
+                    return Err(McpError::invalid_params(format!("old_str がモジュール '{}' 内に見つかりません", name), None));
+                }
+                if count > 1 {
+                    return Err(McpError::invalid_params(format!("old_str がモジュール '{}' 内に{}箇所あります。1箇所だけにしてください", name, count), None));
+                }
+                *src = src.replacen(old.as_str(), new.as_str(), 1);
+                data.updated_at = now;
+                let json = serde_json::to_string_pretty(&data)
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                tokio_fs::write(&artifact_path, &json).await
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
+                    "worktreeId": worktree_id, "artifactId": id, "command": "update",
+                })) { log::warn!("Failed to emit artifact-changed: {}", e); }
+                json
+            }
+            "delete" => {
+                let name = module_name.as_deref()
+                    .ok_or_else(|| McpError::invalid_params("module_name が必要です", None))?;
+                validate_module_name(name)?;
+                if data.modules.remove(name).is_none() {
+                    return Err(McpError::invalid_params(format!("モジュール '{}' が存在しません", name), None));
+                }
+                data.updated_at = now;
+                let json = serde_json::to_string_pretty(&data)
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                tokio_fs::write(&artifact_path, &json).await
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
+                    "worktreeId": worktree_id, "artifactId": id, "command": "delete_module",
+                })) { log::warn!("Failed to emit artifact-changed: {}", e); }
+                json
+            }
+            other => return Err(McpError::invalid_params(
+                format!("不明なコマンド '{}'. list/get/create/update/rewrite/delete のいずれかを指定してください", other),
+                None,
+            )),
+        };
+
+        log::info!("[mcp] artifact_module command={} id={} module={:?}", command, id, module_name);
+        Ok(CallToolResult::success(vec![Content::text(result_json)]))
     }
 
     #[tool(description = "ワークツリーに通知を送信する")]

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -518,13 +518,24 @@ impl NotifyService {
         let mut data: ArtifactData = serde_json::from_str(&raw)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
 
+        // モジュール操作は application/vnd.ant.react のみ対象
+        if data.content_type != "application/vnd.ant.react" {
+            return Err(McpError::invalid_params(
+                format!("artifact_module は application/vnd.ant.react のみ対象です (現在: {})", data.content_type),
+                None,
+            ));
+        }
+
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
 
         let result_json: String = match command.as_str() {
             "list" => {
-                let list: Vec<serde_json::Value> = data.modules.iter().map(|(name, src)| {
+                let mut list: Vec<serde_json::Value> = data.modules.iter().map(|(name, src)| {
                     serde_json::json!({ "module_name": name, "lines": src.lines().count() })
                 }).collect();
+                list.sort_by(|a, b| {
+                    a["module_name"].as_str().unwrap_or("").cmp(b["module_name"].as_str().unwrap_or(""))
+                });
                 serde_json::to_string_pretty(&serde_json::json!({
                     "id": id,
                     "modules": list,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -320,12 +320,12 @@ impl NotifyService {
                 .map_err(|e| McpError::internal_error(e.to_string(), None))?;
             let total_lines = data.content.lines().count();
             let off = offset.unwrap_or(0) as usize;
+            let had_trailing_newline = data.content.ends_with('\n');
             if let Some(lim) = limit {
-                let had_trailing_newline = data.content.ends_with('\n');
+                let at_end = off + lim as usize >= total_lines;
                 let sliced = data.content.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n");
-                data.content = if had_trailing_newline { sliced + "\n" } else { sliced };
+                data.content = if had_trailing_newline && at_end { sliced + "\n" } else { sliced };
             } else if off > 0 {
-                let had_trailing_newline = data.content.ends_with('\n');
                 let sliced = data.content.lines().skip(off).collect::<Vec<_>>().join("\n");
                 data.content = if had_trailing_newline { sliced + "\n" } else { sliced };
             }
@@ -555,16 +555,14 @@ impl NotifyService {
                 let off = offset.unwrap_or(0) as usize;
                 let had_trailing_newline = src.ends_with('\n');
                 let sliced = if let Some(lim) = limit {
-                    src.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n")
+                    let at_end = off + lim as usize >= total_lines;
+                    let s = src.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n");
+                    if had_trailing_newline && at_end { s + "\n" } else { s }
                 } else if off > 0 {
-                    src.lines().skip(off).collect::<Vec<_>>().join("\n")
+                    let s = src.lines().skip(off).collect::<Vec<_>>().join("\n");
+                    if had_trailing_newline { s + "\n" } else { s }
                 } else {
                     src.clone()
-                };
-                let sliced = if (offset.is_some() || limit.is_some()) && had_trailing_newline {
-                    sliced + "\n"
-                } else {
-                    sliced
                 };
                 let mut val = serde_json::json!({ "id": id, "module_name": name, "content": sliced });
                 if offset.is_some() || limit.is_some() {

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -321,9 +321,13 @@ impl NotifyService {
             let total_lines = data.content.lines().count();
             let off = offset.unwrap_or(0) as usize;
             if let Some(lim) = limit {
-                data.content = data.content.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n");
+                let had_trailing_newline = data.content.ends_with('\n');
+                let sliced = data.content.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n");
+                data.content = if had_trailing_newline { sliced + "\n" } else { sliced };
             } else if off > 0 {
-                data.content = data.content.lines().skip(off).collect::<Vec<_>>().join("\n");
+                let had_trailing_newline = data.content.ends_with('\n');
+                let sliced = data.content.lines().skip(off).collect::<Vec<_>>().join("\n");
+                data.content = if had_trailing_newline { sliced + "\n" } else { sliced };
             }
             let mut json_val = serde_json::to_value(&data)
                 .map_err(|e| McpError::internal_error(e.to_string(), None))?;
@@ -549,12 +553,18 @@ impl NotifyService {
                     .ok_or_else(|| McpError::invalid_params(format!("モジュール '{}' が存在しません", name), None))?;
                 let total_lines = src.lines().count();
                 let off = offset.unwrap_or(0) as usize;
+                let had_trailing_newline = src.ends_with('\n');
                 let sliced = if let Some(lim) = limit {
                     src.lines().skip(off).take(lim as usize).collect::<Vec<_>>().join("\n")
                 } else if off > 0 {
                     src.lines().skip(off).collect::<Vec<_>>().join("\n")
                 } else {
                     src.clone()
+                };
+                let sliced = if (offset.is_some() || limit.is_some()) && had_trailing_newline {
+                    sliced + "\n"
+                } else {
+                    sliced
                 };
                 let mut val = serde_json::json!({ "id": id, "module_name": name, "content": sliced });
                 if offset.is_some() || limit.is_some() {

--- a/src/ArtifactViewerApp.vue
+++ b/src/ArtifactViewerApp.vue
@@ -181,6 +181,7 @@ onUnmounted(() => {
           <ArtifactReactView
             v-else-if="selectedArtifact.content_type === 'application/vnd.ant.react'"
             :content="selectedArtifact.content"
+            :modules="selectedArtifact.modules"
           />
           <ArtifactCodeView
             v-else

--- a/src/components/artifact/ArtifactReactView.vue
+++ b/src/components/artifact/ArtifactReactView.vue
@@ -68,6 +68,19 @@ const srcdocHtml = computed(() => {
 
 const moduleNames = computed(() => Object.keys(props.modules ?? {}));
 
+// 同名ファイルが複数ある場合は親ディレクトリを含めて表示
+const moduleLabel = computed(() => {
+  const names = moduleNames.value;
+  const basenames = names.map(n => n.split('/').pop() ?? n);
+  return (name: string) => {
+    const base = name.split('/').pop() ?? name;
+    const isDuplicate = basenames.filter(b => b === base).length > 1;
+    if (!isDuplicate) return base;
+    const parts = name.split('/');
+    return parts.length >= 2 ? `${parts[parts.length - 2]}/${base}` : name;
+  };
+});
+
 const codeContent = computed(() =>
   selectedFile.value === "" ? props.content : (props.modules?.[selectedFile.value] ?? "")
 );
@@ -118,8 +131,9 @@ const codeContent = computed(() =>
           v-for="name in moduleNames"
           :key="name"
           :class="{ active: selectedFile === name }"
+          :title="name"
           @click="selectedFile = name"
-        >{{ name.split('/').pop() }}</button>
+        >{{ moduleLabel(name) }}</button>
       </div>
       <ArtifactCodeView
         :content="codeContent"

--- a/src/components/artifact/ArtifactReactView.vue
+++ b/src/components/artifact/ArtifactReactView.vue
@@ -31,10 +31,13 @@ function loadVendors(): Promise<VendorScripts> {
 
 const props = defineProps<{
   content: string;
+  modules?: Record<string, string>;
 }>();
 
 type Mode = "preview" | "code";
 const mode = ref<Mode>("preview");
+// コードビューで選択中のファイル: "" = エントリポイント、それ以外はモジュール名
+const selectedFile = ref<string>("");
 
 const vendorScripts = ref<VendorScripts | null>(null);
 const vendorLoading = ref(true);
@@ -60,8 +63,14 @@ const vendorHead = computed(() => {
 // content が変わっても vendorHead は再計算されない
 const srcdocHtml = computed(() => {
   if (!vendorHead.value) return "";
-  return buildReactSrcdoc(vendorHead.value, props.content);
+  return buildReactSrcdoc(vendorHead.value, props.content, props.modules);
 });
+
+const moduleNames = computed(() => Object.keys(props.modules ?? {}));
+
+const codeContent = computed(() =>
+  selectedFile.value === "" ? props.content : (props.modules?.[selectedFile.value] ?? "")
+);
 </script>
 
 <template>
@@ -99,11 +108,24 @@ const srcdocHtml = computed(() => {
       />
     </div>
 
-    <ArtifactCodeView
-      v-else
-      :content="content"
-      language="typescriptreact"
-    />
+    <div v-else class="code-area">
+      <div v-if="moduleNames.length > 0" class="module-tabs">
+        <button
+          :class="{ active: selectedFile === '' }"
+          @click="selectedFile = ''"
+        >index</button>
+        <button
+          v-for="name in moduleNames"
+          :key="name"
+          :class="{ active: selectedFile === name }"
+          @click="selectedFile = name"
+        >{{ name.split('/').pop() }}</button>
+      </div>
+      <ArtifactCodeView
+        :content="codeContent"
+        language="typescriptreact"
+      />
+    </div>
   </div>
 </template>
 
@@ -185,5 +207,44 @@ const srcdocHtml = computed(() => {
   flex: 1;
   border: none;
   background: #fff;
+}
+
+.code-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.module-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 4px 8px;
+  background: #181825;
+  border-bottom: 1px solid #313244;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.module-tabs button {
+  padding: 2px 10px;
+  border: 1px solid #313244;
+  border-radius: 3px;
+  background: transparent;
+  color: #6c7086;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.module-tabs button:hover {
+  background: #313244;
+  color: #cdd6f4;
+}
+
+.module-tabs button.active {
+  background: #313244;
+  color: #cdd6f4;
+  border-color: #45475a;
 }
 </style>

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -9,6 +9,7 @@ export interface ArtifactMeta {
 
 export interface ArtifactData extends ArtifactMeta {
   content: string;
+  modules?: Record<string, string>;
 }
 
 export interface ArtifactChangedEvent {

--- a/src/utils/reactArtifactSrcdoc.ts
+++ b/src/utils/reactArtifactSrcdoc.ts
@@ -43,15 +43,29 @@ const RUNTIME_JS =
   "}" +
   "window.onerror=function(msg,src,line,col,err){showError(err||new Error(msg));return true;};" +
   "try{" +
+  "  var moduleSources=JSON.parse(document.getElementById('_modules').value||'{}');" +
+  "  var moduleCache={};" +
+  "  function makeRequire(){" +
+  "    var libs={'react':React,'react-dom':ReactDOM,'react-dom/client':ReactDOM,'react/jsx-runtime':React};" +
+  "    function req(name){" +
+  "      if(libs[name]!==undefined)return libs[name];" +
+  "      var key=name.replace(/^\\.\\//, '');" +
+  "      if(moduleSources[key]===undefined)throw new Error('Module not found: '+name);" +
+  "      if(moduleCache[key])return moduleCache[key].exports;" +
+  "      var mod={exports:{}};" +
+  "      moduleCache[key]=mod;" +
+  "      var code=Babel.transform(moduleSources[key],{presets:['env','react','typescript'],filename:key+'.tsx'}).code;" +
+  "      var fn=new Function('React','ReactDOM','exports','module','require',code);" +
+  "      fn(React,ReactDOM,mod.exports,mod,req);" +
+  "      return mod.exports;" +
+  "    }" +
+  "    return req;" +
+  "  }" +
+  "  var require=makeRequire();" +
   "  var source=document.getElementById('_source').value;" +
   "  var transformed=Babel.transform(source,{presets:['env','react','typescript'],filename:'artifact.tsx'}).code;" +
   "  var exports={};" +
   "  var module={exports:exports};" +
-  "  var require=function(name){" +
-  "    var libs={'react':React,'react-dom':ReactDOM,'react-dom/client':ReactDOM,'react/jsx-runtime':React};" +
-  "    if(libs[name]!==undefined)return libs[name];" +
-  "    throw new Error('Module not found: '+name);" +
-  "  };" +
   "  var fn=new Function('React','ReactDOM','exports','module','require',transformed);" +
   "  fn(React,ReactDOM,exports,module,require);" +
   "  var Component=exports['default']||module.exports['default']||module.exports;" +
@@ -105,14 +119,19 @@ export function buildVendorHead(react: string, reactDom: string, babel: string, 
 /**
  * vendorHead（buildVendorHead の結果）と content を組み合わせて完全な srcdoc を生成する。
  * content が変わるたびに呼ばれるが、ベンダー部分は含まない。
+ * modules が指定された場合、各モジュールは require() で解決可能になる。
  */
-export function buildReactSrcdoc(vendorHead: string, content: string): string {
+export function buildReactSrcdoc(vendorHead: string, content: string, modules?: Record<string, string>): string {
+  const modulesJson = modules && Object.keys(modules).length > 0
+    ? htmlEscape(JSON.stringify(modules))
+    : "{}";
   return (
     vendorHead +
     "<body>\n" +
     '<div id="root"></div>\n' +
     '<div id="error-display" class="error-overlay" style="display:none"></div>\n' +
     '<textarea id="_source" style="display:none">' + htmlEscape(content) + "</textarea>\n" +
+    '<textarea id="_modules" style="display:none">' + modulesJson + "</textarea>\n" +
     openTag(RUNTIME_JS) + "\n" +
     "</body>\n</html>"
   );

--- a/src/utils/reactArtifactSrcdoc.ts
+++ b/src/utils/reactArtifactSrcdoc.ts
@@ -46,16 +46,32 @@ const RUNTIME_JS =
   "  var moduleSources=JSON.parse(document.getElementById('_modules').value||'{}');" +
   "  var moduleCache={};" +
   "  function resolvePath(base,rel){" +
-  "    if(!rel.startsWith('./')){return rel;}" +
-  "    var dir=base.includes('/')?base.substring(0,base.lastIndexOf('/')):'';" +
-  "    return dir?dir+'/'+rel.slice(2):rel.slice(2);" +
+  "    var parts=(base.includes('/')?base.substring(0,base.lastIndexOf('/')):'')" +
+  "      .split('/').filter(function(p){return p!==''&&p!=='.'});" +
+  "    var relParts=rel.split('/');" +
+  "    for(var i=0;i<relParts.length;i++){" +
+  "      var p=relParts[i];" +
+  "      if(p==='..')parts.pop();" +
+  "      else if(p!=='.')parts.push(p);" +
+  "    }" +
+  "    return parts.join('/');" +
+  "  }" +
+  "  var EXT_RE=/\\.(tsx?|jsx?)$/;" +
+  "  function resolveModuleKey(key){" +
+  "    if(moduleSources[key]!==undefined)return key;" +
+  "    var noExt=key.replace(EXT_RE,'');" +
+  "    if(moduleSources[noExt]!==undefined)return noExt;" +
+  "    var withTsx=noExt+'.tsx';" +
+  "    if(moduleSources[withTsx]!==undefined)return withTsx;" +
+  "    return null;" +
   "  }" +
   "  function makeRequire(currentKey){" +
   "    var libs={'react':React,'react-dom':ReactDOM,'react-dom/client':ReactDOM,'react/jsx-runtime':React};" +
   "    return function req(name){" +
   "      if(libs[name]!==undefined)return libs[name];" +
-  "      var key=(name.startsWith('./'))?resolvePath(currentKey,name):name;" +
-  "      if(moduleSources[key]===undefined)throw new Error('Module not found: '+name+' (resolved: '+key+')');" +
+  "      var resolved=(name.startsWith('./')||name.startsWith('../'))?resolvePath(currentKey,name):name;" +
+  "      var key=resolveModuleKey(resolved);" +
+  "      if(key===null)throw new Error('Module not found: '+name+' (resolved: '+resolved+')');" +
   "      if(moduleCache[key])return moduleCache[key].exports;" +
   "      var mod={exports:{}};" +
   "      moduleCache[key]=mod;" +

--- a/src/utils/reactArtifactSrcdoc.ts
+++ b/src/utils/reactArtifactSrcdoc.ts
@@ -57,12 +57,12 @@ const RUNTIME_JS =
   "    return parts.join('/');" +
   "  }" +
   "  var EXT_RE=/\\.(tsx?|jsx?)$/;" +
+  "  var TRY_EXTS=['.tsx','.ts','.jsx','.js'];" +
   "  function resolveModuleKey(key){" +
   "    if(moduleSources[key]!==undefined)return key;" +
   "    var noExt=key.replace(EXT_RE,'');" +
-  "    if(moduleSources[noExt]!==undefined)return noExt;" +
-  "    var withTsx=noExt+'.tsx';" +
-  "    if(moduleSources[withTsx]!==undefined)return withTsx;" +
+  "    if(noExt!==key&&moduleSources[noExt]!==undefined)return noExt;" +
+  "    for(var i=0;i<TRY_EXTS.length;i++){var k=noExt+TRY_EXTS[i];if(moduleSources[k]!==undefined)return k;}" +
   "    return null;" +
   "  }" +
   "  function makeRequire(currentKey){" +

--- a/src/utils/reactArtifactSrcdoc.ts
+++ b/src/utils/reactArtifactSrcdoc.ts
@@ -45,23 +45,27 @@ const RUNTIME_JS =
   "try{" +
   "  var moduleSources=JSON.parse(document.getElementById('_modules').value||'{}');" +
   "  var moduleCache={};" +
-  "  function makeRequire(){" +
+  "  function resolvePath(base,rel){" +
+  "    if(!rel.startsWith('./')){return rel;}" +
+  "    var dir=base.includes('/')?base.substring(0,base.lastIndexOf('/')):'';" +
+  "    return dir?dir+'/'+rel.slice(2):rel.slice(2);" +
+  "  }" +
+  "  function makeRequire(currentKey){" +
   "    var libs={'react':React,'react-dom':ReactDOM,'react-dom/client':ReactDOM,'react/jsx-runtime':React};" +
-  "    function req(name){" +
+  "    return function req(name){" +
   "      if(libs[name]!==undefined)return libs[name];" +
-  "      var key=name.replace(/^\\.\\//, '');" +
-  "      if(moduleSources[key]===undefined)throw new Error('Module not found: '+name);" +
+  "      var key=(name.startsWith('./'))?resolvePath(currentKey,name):name;" +
+  "      if(moduleSources[key]===undefined)throw new Error('Module not found: '+name+' (resolved: '+key+')');" +
   "      if(moduleCache[key])return moduleCache[key].exports;" +
   "      var mod={exports:{}};" +
   "      moduleCache[key]=mod;" +
   "      var code=Babel.transform(moduleSources[key],{presets:['env','react','typescript'],filename:key+'.tsx'}).code;" +
   "      var fn=new Function('React','ReactDOM','exports','module','require',code);" +
-  "      fn(React,ReactDOM,mod.exports,mod,req);" +
+  "      fn(React,ReactDOM,mod.exports,mod,makeRequire(key));" +
   "      return mod.exports;" +
-  "    }" +
-  "    return req;" +
+  "    };" +
   "  }" +
-  "  var require=makeRequire();" +
+  "  var require=makeRequire('');" +
   "  var source=document.getElementById('_source').value;" +
   "  var transformed=Babel.transform(source,{presets:['env','react','typescript'],filename:'artifact.tsx'}).code;" +
   "  var exports={};" +


### PR DESCRIPTION
## Summary

- React アーティファクトにモジュール分割機能を追加。1ファイルに集中していた大規模コードを複数モジュールに分割して管理できるようにした
- 新 MCP ツール `artifact_module`（list/get/create/update/rewrite/delete）でモジュール単位の読み書きが可能に
- `artifact(command="outline")` で全文取得なしに構造概要（モジュール名・行数・エクスポート名）を取得可能
- `artifact`・`artifact_module` の `get` コマンドに `offset`/`limit` による行範囲指定を追加
- iframe ランタイムの `require()` を CommonJS スタイルのモジュール解決に拡張（`./`・`../` 相対パス、拡張子フォールバック対応）

## Changes

### Backend (`src-tauri/src/mcp_server.rs`)
- `ArtifactData` に `modules: HashMap<String, String>` フィールド追加
- `artifact_module` MCP ツール追加（list/get/create/update/rewrite/delete）
- `artifact` ツールに `outline` コマンド追加（正規表現ベースのエクスポート名抽出）
- `artifact`・`artifact_module` の `get` に `offset`/`limit` パラメータ追加
- `artifact_module` にパストラバーサル防止、React アーティファクト限定チェックを追加

### Frontend (`src/`)
- `ArtifactData` 型に `modules?: Record<string, string>` 追加
- `ArtifactReactView.vue`: `modules` prop 追加、コードビューにモジュールタブ UI 追加（同名ファイル時は親ディレクトリ付きラベル）
- `ArtifactViewerApp.vue`: `modules` prop の受け渡し追加
- `reactArtifactSrcdoc.ts`: `buildReactSrcdoc` に `modules` 引数追加、`RUNTIME_JS` に CommonJS 風モジュール解決を実装

## Test plan

- [ ] `pnpm run tauri dev` で起動し、アーティファクトビューアで `wireframe-modular` を開いてプレビューが動作することを確認
- [ ] コードビューでモジュールタブ（index / Login / Dashboard / Settings）が表示されること
- [ ] MCP: `artifact(command="outline")` で構造概要が取得できること
- [ ] MCP: `artifact_module(command="get", module_name="screens/Login")` で1モジュールのみ取得できること
- [ ] MCP: `artifact_module(command="create")` で重複時エラーになること
- [ ] MCP: `artifact_module` を非 React アーティファクトに呼ぶとエラーになること
- [ ] `cargo check` と `pnpm run type-check` がエラーなしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)