### PR TITLE
fix: MCP close_worktree をUI経由のアーカイブ処理と統一

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,7 @@ import type { FrameNode } from "./types/frame";
 import { useWorktreeFrameBundles } from "./composables/useWorktreeFrameBundles";
 import { useCodeReviewChatListener } from "./composables/useCodeReviewLineChat";
 import { saveWindowState, StateFlags } from "@tauri-apps/plugin-window-state";
+import { useWorktreeRemove } from "./composables/useWorktreeRemove";
 import { useRemoveWorktreeDialog } from "./composables/useRemoveWorktreeDialog";
 import { useAutoHotkey } from "./composables/useAutoHotkey";
 import { useAppAutoApproval } from "./composables/useAppAutoApproval";
@@ -278,20 +279,8 @@ const { showAddTaskDialog, rerunTaskId, rerunPrompt, onAddTaskConfirm, onAddTask
     }
   });
 
-// ワークツリー削除/アーカイブダイアログ
-const {
-  showRemoveDialog,
-  removeTargetWorktree,
-  removeBranches,
-  removeDirtyFiles,
-  cancellableWorktrees,
-  onRemoveWorktree,
-  onRemoveWorktreeConfirm,
-  onArchiveWorktreeConfirm,
-  archiveWorktreeByMcp,
-  cancelWorktreeRemove,
-  dismissDialog: onRemoveWorktreeDismiss,
-} = useRemoveWorktreeDialog({
+// ワークツリー削除/アーカイブ コア処理
+const worktreeRemoveCore = useWorktreeRemove({
   loadingWorktrees,
   clearNotification,
   isDetached,
@@ -306,6 +295,19 @@ const {
   homeViewRef,
   t,
 });
+const { cancellableWorktrees, cancelWorktreeRemove, archiveWorktree } = worktreeRemoveCore;
+
+// ワークツリー削除/アーカイブダイアログ
+const {
+  showRemoveDialog,
+  removeTargetWorktree,
+  removeBranches,
+  removeDirtyFiles,
+  onRemoveWorktree,
+  onRemoveWorktreeConfirm,
+  onArchiveWorktreeConfirm,
+  dismissDialog: onRemoveWorktreeDismiss,
+} = useRemoveWorktreeDialog(worktreeRemoveCore);
 
 // IDE 選択
 const { showIdeDialog, detectedIdes, openInIde, onIdeSelected } = useIdeSelect();
@@ -974,7 +976,7 @@ onMounted(async () => {
   // MCPからのワークツリークローズ（アーカイブ）
   await listen<{ worktree_id: string; worktree_name: string; merge_to: string; delete_branch: boolean; force_branch: boolean }>("mcp-close-worktree", async (event) => {
     const { worktree_id, merge_to, delete_branch, force_branch } = event.payload;
-    await archiveWorktreeByMcp(worktree_id, {
+    await archiveWorktree(worktree_id, {
       mergeTo: merge_to,
       deleteBranch: delete_branch,
       forceBranch: force_branch,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1018,6 +1018,12 @@ onMounted(async () => {
       await closeArtifactWindow(worktree_id);
       await cancelApproval(worktree_id);
       if (activeWorktreeId.value === worktree_id) goHome();
+      // MCPクライアントへアーカイブ完了を通知
+      await invoke("notify_worktree_archived", {
+        id: worktree.id,
+        name: worktree.name,
+        branchName: worktree.branchName,
+      }).catch(() => { /* 通知失敗はワークツリー削除の成否に影響しない */ });
     } catch {
       // 失敗時: ワークツリーパスの有無でケースを判定する
       const pathStillExists = await invoke<boolean>("path_exists", { path: worktree.path }).catch(() => false);
@@ -1029,6 +1035,12 @@ onMounted(async () => {
         await closeArtifactWindow(worktree_id);
         await cancelApproval(worktree_id);
         if (activeWorktreeId.value === worktree_id) goHome();
+        // MCPクライアントへアーカイブ完了を通知
+        await invoke("notify_worktree_archived", {
+          id: worktree.id,
+          name: worktree.name,
+          branchName: worktree.branchName,
+        }).catch(() => { /* 通知失敗はワークツリー削除の成否に影響しない */ });
       }
     } finally {
       loadingWorktrees.delete(worktree_id);

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,9 +45,7 @@ import { useAppAutoApproval } from "./composables/useAppAutoApproval";
 import { useAppHotkeys } from "./composables/useAppHotkeys";
 import { useSubWindowEvents } from "./composables/useSubWindowEvents";
 import { useShutdownGuard } from "./composables/useShutdownGuard";
-import { saveArchive, deleteArchive } from "./composables/useArchivePersistence";
 import type { ArchiveRow } from "./types/archive";
-import { cancelApproval } from "./utils/autoApproval";
 import { debug } from "@tauri-apps/plugin-log";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { useUpdater } from "./composables/useUpdater";
@@ -66,7 +64,7 @@ const { checkForUpdate, downloadAndInstall } = useUpdater();
 type ViewMode = "home" | "settings" | "terminal";
 
 const { settings, loadSettings, scheduleSave } = useSettings();
-const { worktrees, loadWorktreesFromSettings, addWorktreePlaceholder, invokeWorktreeAdd, commitWorktree, rollbackWorktree, removeWorktree, reorderWorktree, saveWorktreeOrder, restoreWorktreeOrder, addTerminal, removeTerminal, updateTerminalTitle, saveTerminalSession, loadTerminalSession } = useWorktrees();
+const { worktrees, loadWorktreesFromSettings, addWorktreePlaceholder, invokeWorktreeAdd, commitWorktree, rollbackWorktree, reorderWorktree, saveWorktreeOrder, restoreWorktreeOrder, addTerminal, removeTerminal, updateTerminalTitle, saveTerminalSession, loadTerminalSession } = useWorktrees();
 const { detachedWorktrees, isDetached, moveToSubWindow, moveToMainWindow, focusSubWindow, unregisterSubWindow, getPendingInitData, clearPendingInitData, getDetachedSessionId, registerTerminalSession, closeAllSubWindows } = useSubWindows();
 const { autoApprovalPromptMap, lastJudgedCommandMap, showAutoApprovalPromptDialog, autoApprovalPromptTargetId, restoreFromSettings: restoreAutoApprovalPrompts, onClickAutoApproval, onSaveAutoApprovalPrompt } = useAutoApprovalPrompt(settings, scheduleSave, isDetached);
 const { notifications, initNotificationListener, addNotification, clearNotification, purgeStaleNotifications, getNotifiedWorktreeIds, getTotalNotificationCount } = useNotifications();
@@ -290,6 +288,7 @@ const {
   onRemoveWorktree,
   onRemoveWorktreeConfirm,
   onArchiveWorktreeConfirm,
+  archiveWorktreeByMcp,
   cancelWorktreeRemove,
   dismissDialog: onRemoveWorktreeDismiss,
 } = useRemoveWorktreeDialog({
@@ -975,76 +974,11 @@ onMounted(async () => {
   // MCPからのワークツリークローズ（アーカイブ）
   await listen<{ worktree_id: string; worktree_name: string; merge_to: string; delete_branch: boolean; force_branch: boolean }>("mcp-close-worktree", async (event) => {
     const { worktree_id, merge_to, delete_branch, force_branch } = event.payload;
-    const worktree = worktrees.value.find((w) => w.id === worktree_id);
-    if (!worktree) return;
-
-    clearNotification(worktree_id);
-    loadingWorktrees.set(worktree_id, t("archivingText"));
-    try {
-      // アーカイブをDBに保存（git操作前に実行）
-      await saveArchive({
-        id: worktree.id,
-        name: worktree.name,
-        repository_id: worktree.repositoryId,
-        repository_name: worktree.repositoryName,
-        path: worktree.path,
-        branch_name: worktree.branchName,
-        archived_at: Date.now(),
-      });
-
-      // detachedの場合はメインウィンドウに戻してからターミナルを停止する
-      // （サブウィンドウのターミナルrefはメインウィンドウから参照できないため）
-      if (isDetached(worktree_id)) {
-        await moveToMainWindow(worktree_id);
-        subWindowEvents.subWindowFocusMap.delete(worktree_id);
-      }
-
-      // ターミナルを停止（git worktree remove前にファイルハンドルを解放するため）
-      const bundle = worktreeFrameBundles.get(worktree_id);
-      for (const terminal of [...worktree.terminals]) {
-        const term = bundle?.terminalRefs.get(terminal.id) ?? getTerminalRef(terminal.id);
-        if (term?.isRunning) await term.kill();
-        terminalWorktreeMap.delete(terminal.id);
-      }
-      worktreeFrameBundles.delete(worktree_id);
-
-      await removeWorktree(worktree_id, {
-        mergeTo: merge_to || undefined,
-        deleteBranch: delete_branch,
-        forceBranch: force_branch,
-      });
-
-      // git操作成功後にUIをクリーンアップ
-      await closeArtifactWindow(worktree_id);
-      await cancelApproval(worktree_id);
-      if (activeWorktreeId.value === worktree_id) goHome();
-      // MCPクライアントへアーカイブ完了を通知
-      await invoke("notify_worktree_archived", {
-        id: worktree.id,
-        name: worktree.name,
-        branchName: worktree.branchName,
-      }).catch(() => { /* 通知失敗はワークツリー削除の成否に影響しない */ });
-    } catch {
-      // 失敗時: ワークツリーパスの有無でケースを判定する
-      const pathStillExists = await invoke<boolean>("path_exists", { path: worktree.path }).catch(() => false);
-      if (pathStillExists) {
-        // git_worktree_remove が失敗（ワークツリーが残っている）→ アーカイブをロールバック
-        await deleteArchive(worktree_id);
-      } else {
-        // ワークツリーは削除済み（ブランチ削除のみ失敗）→ UIクリーンアップは実行する
-        await closeArtifactWindow(worktree_id);
-        await cancelApproval(worktree_id);
-        if (activeWorktreeId.value === worktree_id) goHome();
-        // MCPクライアントへアーカイブ完了を通知
-        await invoke("notify_worktree_archived", {
-          id: worktree.id,
-          name: worktree.name,
-          branchName: worktree.branchName,
-        }).catch(() => { /* 通知失敗はワークツリー削除の成否に影響しない */ });
-      }
-    } finally {
-      loadingWorktrees.delete(worktree_id);
-    }
+    await archiveWorktreeByMcp(worktree_id, {
+      mergeTo: merge_to,
+      deleteBranch: delete_branch,
+      forceBranch: force_branch,
+    });
   });
 
   // サブウィンドウ準備完了 → init データをイベントで送信（サブウィンドウ復元より前に登録必須）

--- a/src/composables/useRemoveWorktreeDialog.ts
+++ b/src/composables/useRemoveWorktreeDialog.ts
@@ -116,35 +116,26 @@ export function useRemoveWorktreeDialog(options: {
     removeDirtyFiles.value = [];
   }
 
-  /** 共通: ダイアログ後処理・ターミナル停止・アニメーション付きワークツリー削除
+  /** 共通コア: ターミナル停止・アニメーション付きワークツリー削除
+   *  ダイアログ state に依存しない純粋な削除処理。ダイアログ経由・MCP経由の両方から呼ばれる。
    *  beforeRemove: git 操作前に呼ぶ任意の非同期処理（アーカイブ保存など）
    *  onRemoveFailed: git 操作失敗時に beforeRemove の副作用をロールバックするコールバック
    *  afterRemove: git 操作成功後に呼ぶ任意の非同期処理（MCP通知など）
    */
-  async function _confirm(
+  async function _execute(
+    worktreeId: string,
     removeOptions: RemoveOptions,
     loadingText: string,
     beforeRemove?: (worktree: Worktree) => Promise<void>,
     onRemoveFailed?: (worktree: Worktree) => Promise<void>,
     afterRemove?: (worktree: Worktree) => Promise<void>,
   ): Promise<void> {
-    if (!removeTargetWorktree.value) return;
-    const { id: worktreeId } = removeTargetWorktree.value;
-
     const worktree = worktrees.value.find((w) => w.id === worktreeId);
-    if (!worktree) {
-      showRemoveDialog.value = false;
-      removeDirtyFiles.value = [];
-      return;
-    }
+    if (!worktree) return;
 
-    showRemoveDialog.value = false;
-    removeTargetWorktree.value = null;
-    removeBranches.value = [];
-    removeDirtyFiles.value = [];
     clearNotification(worktreeId);
 
-    // ダイアログを閉じた後、UI 破壊的操作の前に事前処理（アーカイブ保存など）を実行する。
+    // UI 破壊的操作の前に事前処理（アーカイブ保存など）を実行する。
     // ここで失敗した場合はワークツリーに何も手を加えずエラーを表示して終了する。
     if (beforeRemove) {
       try {
@@ -232,6 +223,31 @@ export function useRemoveWorktreeDialog(options: {
     }
   }
 
+  /** ダイアログ経由の確認後に呼ぶラッパー。ダイアログ state をクリアしてから _execute を呼ぶ */
+  async function _confirm(
+    removeOptions: RemoveOptions,
+    loadingText: string,
+    beforeRemove?: (worktree: Worktree) => Promise<void>,
+    onRemoveFailed?: (worktree: Worktree) => Promise<void>,
+    afterRemove?: (worktree: Worktree) => Promise<void>,
+  ): Promise<void> {
+    if (!removeTargetWorktree.value) return;
+    const { id: worktreeId } = removeTargetWorktree.value;
+
+    if (!worktrees.value.find((w) => w.id === worktreeId)) {
+      showRemoveDialog.value = false;
+      removeDirtyFiles.value = [];
+      return;
+    }
+
+    showRemoveDialog.value = false;
+    removeTargetWorktree.value = null;
+    removeBranches.value = [];
+    removeDirtyFiles.value = [];
+
+    await _execute(worktreeId, removeOptions, loadingText, beforeRemove, onRemoveFailed, afterRemove);
+  }
+
   async function onRemoveWorktreeConfirm(removeOptions: RemoveOptions): Promise<void> {
     await _confirm(removeOptions, t("deletingText"));
   }
@@ -279,6 +295,48 @@ export function useRemoveWorktreeDialog(options: {
     );
   }
 
+  /** MCP経由のワークツリーアーカイブ。ダイアログを経由せず直接 _execute を呼ぶ */
+  async function archiveWorktreeByMcp(
+    worktreeId: string,
+    removeOptions: RemoveOptions,
+  ): Promise<void> {
+    await _execute(
+      worktreeId,
+      removeOptions,
+      t("archivingText"),
+      async (worktree) => {
+        await saveArchive({
+          id: worktree.id,
+          name: worktree.name,
+          repository_id: worktree.repositoryId,
+          repository_name: worktree.repositoryName,
+          path: worktree.path,
+          branch_name: worktree.branchName,
+          archived_at: Date.now(),
+        });
+      },
+      async (worktree) => {
+        const pathStillExists = await invoke<boolean>("path_exists", { path: worktree.path }).catch(() => false);
+        if (pathStillExists) {
+          await deleteArchive(worktree.id);
+        } else {
+          await invoke("notify_worktree_archived", {
+            id: worktree.id,
+            name: worktree.name,
+            branchName: worktree.branchName,
+          }).catch(() => { /* 通知失敗は無視 */ });
+        }
+      },
+      async (worktree) => {
+        await invoke("notify_worktree_archived", {
+          id: worktree.id,
+          name: worktree.name,
+          branchName: worktree.branchName,
+        });
+      },
+    );
+  }
+
   return {
     showRemoveDialog,
     removeTargetWorktree,
@@ -288,6 +346,7 @@ export function useRemoveWorktreeDialog(options: {
     onRemoveWorktree,
     onRemoveWorktreeConfirm,
     onArchiveWorktreeConfirm,
+    archiveWorktreeByMcp,
     cancelWorktreeRemove,
     dismissDialog,
   };

--- a/src/composables/useRemoveWorktreeDialog.ts
+++ b/src/composables/useRemoveWorktreeDialog.ts
@@ -1,88 +1,9 @@
-import { ref, reactive, nextTick } from "vue";
-import type { Ref } from "vue";
+import { ref } from "vue";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
-import { message } from "@tauri-apps/plugin-dialog";
-import { useWorktrees } from "./useWorktrees";
-import { cancelApproval } from "../utils/autoApproval";
-import { saveArchive, deleteArchive } from "./useArchivePersistence";
-import type { Worktree } from "../types/worktree";
+import type { useWorktreeRemove, RemoveOptions } from "./useWorktreeRemove";
 
-interface TerminalRef {
-  isRunning: boolean;
-  kill(): Promise<void>;
-}
-
-interface HomeViewRef {
-  fadeOutCard(worktreeId: string): Promise<void>;
-  hideCard(worktreeId: string): Map<string, DOMRect>;
-  animateAfterRemove(positions: Map<string, DOMRect>): void;
-  unhideCard(worktreeId: string): void;
-}
-
-interface FrameBundle {
-  terminalRefs: { get(id: number): TerminalRef | undefined };
-}
-
-type RemoveOptions = { mergeTo: string; deleteBranch: boolean; forceBranch: boolean };
-
-export function useRemoveWorktreeDialog(options: {
-  loadingWorktrees: Map<string, string>;
-  clearNotification: (id: string) => void;
-  isDetached: (id: string) => boolean;
-  moveToMainWindow: (id: string) => Promise<void>;
-  subWindowFocusMap: { delete(key: string): void };
-  closeArtifactWindow: (id: string) => Promise<void>;
-  worktreeFrameBundles: { get(id: string): FrameBundle | undefined; delete(id: string): void };
-  getTerminalRef: (id: number) => TerminalRef | undefined;
-  terminalWorktreeMap: { delete(key: number): void };
-  activeWorktreeId: Ref<string | null>;
-  goHome: () => void;
-  homeViewRef: Ref<HomeViewRef | null>;
-  t: (key: string, params?: Record<string, unknown>) => string;
-}) {
-  const {
-    loadingWorktrees,
-    clearNotification,
-    isDetached,
-    moveToMainWindow,
-    subWindowFocusMap,
-    closeArtifactWindow,
-    worktreeFrameBundles,
-    getTerminalRef,
-    terminalWorktreeMap,
-    activeWorktreeId,
-    goHome,
-    homeViewRef,
-    t,
-  } = options;
-
-  const { worktrees, removeWorktree, listBranches } = useWorktrees();
-
-  // 永続リトライ中のワークツリーID（キャンセルボタン表示用）
-  const cancellableWorktrees = reactive(new Set<string>());
-
-  // バックエンドから永続リトライ開始イベントを受信したらキャンセル可能状態に移行
-  listen<{ worktreePath: string }>("worktree-remove-retrying", (event) => {
-    const worktree = worktrees.value.find(
-      (w) => w.path === event.payload.worktreePath
-    );
-    if (worktree) {
-      cancellableWorktrees.add(worktree.id);
-      loadingWorktrees.set(worktree.id, t("retryingDeleteText"));
-    }
-  });
-
-  /** 永続リトライ中の削除をキャンセルする */
-  async function cancelWorktreeRemove(worktreeId: string): Promise<void> {
-    const worktree = worktrees.value.find((w) => w.id === worktreeId);
-    if (!worktree) return;
-    try {
-      await invoke("cancel_worktree_remove", { worktreePath: worktree.path });
-    } catch {
-      // すでに完了している場合は無視
-    }
-  }
+export function useRemoveWorktreeDialog(core: ReturnType<typeof useWorktreeRemove>) {
+  const { worktrees, listBranches, clearNotification, cancellableWorktrees, cancelWorktreeRemove } = core;
 
   // ダイアログ state
   const showRemoveDialog = ref(false);
@@ -116,120 +37,10 @@ export function useRemoveWorktreeDialog(options: {
     removeDirtyFiles.value = [];
   }
 
-  /** 共通コア: ターミナル停止・アニメーション付きワークツリー削除
-   *  ダイアログ state に依存しない純粋な削除処理。ダイアログ経由・MCP経由の両方から呼ばれる。
-   *  beforeRemove: git 操作前に呼ぶ任意の非同期処理（アーカイブ保存など）
-   *  onRemoveFailed: git 操作失敗時に beforeRemove の副作用をロールバックするコールバック
-   *  afterRemove: git 操作成功後に呼ぶ任意の非同期処理（MCP通知など）
-   */
-  async function _execute(
-    worktreeId: string,
-    removeOptions: RemoveOptions,
-    loadingText: string,
-    beforeRemove?: (worktree: Worktree) => Promise<void>,
-    onRemoveFailed?: (worktree: Worktree) => Promise<void>,
-    afterRemove?: (worktree: Worktree) => Promise<void>,
-  ): Promise<void> {
-    const worktree = worktrees.value.find((w) => w.id === worktreeId);
-    if (!worktree) return;
-
-    clearNotification(worktreeId);
-
-    // UI 破壊的操作の前に事前処理（アーカイブ保存など）を実行する。
-    // ここで失敗した場合はワークツリーに何も手を加えずエラーを表示して終了する。
-    if (beforeRemove) {
-      try {
-        await beforeRemove(worktree);
-      } catch (e) {
-        await message(t("deleteFailed", { error: e }), { kind: "error" });
-        return;
-      }
-    }
-
-    loadingWorktrees.set(worktreeId, loadingText);
-    try {
-      if (isDetached(worktreeId)) {
-        await moveToMainWindow(worktreeId);
-        subWindowFocusMap.delete(worktreeId);
-      }
-
-      await closeArtifactWindow(worktreeId);
-      await cancelApproval(worktreeId);
-
-      // ターミナルプロセスをkillする（ディレクトリのファイルハンドル解放が目的）。
-      // ただし UI 状態のクリア（terminals.splice / frameBundles.delete）は削除成功後に行う。
-      // キャンセル時にワークツリーが UI に残った際、空ターミナルではなく停止済み状態で表示できるようにする。
-      const bundle = worktreeFrameBundles.get(worktreeId);
-      const terminalsSnapshot = [...worktree.terminals];
-      for (const terminal of terminalsSnapshot) {
-        const term = bundle?.terminalRefs.get(terminal.id) ?? getTerminalRef(terminal.id);
-        if (term?.isRunning) await term.kill();
-      }
-
-      if (activeWorktreeId.value === worktreeId) goHome();
-
-      let savedPositions: Map<string, DOMRect> | undefined;
-      try {
-        await removeWorktree(
-          worktreeId,
-          {
-            mergeTo: removeOptions.mergeTo || undefined,
-            deleteBranch: removeOptions.deleteBranch,
-            forceBranch: removeOptions.forceBranch,
-          },
-          async () => {
-            await homeViewRef.value?.fadeOutCard(worktreeId);
-            savedPositions = homeViewRef.value?.hideCard(worktreeId);
-          },
-        );
-        // 削除成功後に UI 状態をクリア
-        for (const terminal of terminalsSnapshot) {
-          terminalWorktreeMap.delete(terminal.id);
-        }
-        worktree.terminals.splice(0);
-        worktreeFrameBundles.delete(worktreeId);
-        // git 操作成功後の後処理（MCP通知など）
-        if (afterRemove) {
-          try { await afterRemove(worktree); } catch { /* 通知失敗はワークツリー削除の成否に影響しない */ }
-        }
-        await nextTick();
-        if (savedPositions) homeViewRef.value?.animateAfterRemove(savedPositions);
-      } catch (e) {
-        if (savedPositions) homeViewRef.value?.animateAfterRemove(savedPositions);
-        // git 操作失敗時: 事前処理の副作用をロールバック
-        if (onRemoveFailed) {
-          try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
-        }
-        // "cancelled" はユーザー操作によるキャンセルなのでエラーダイアログを出さない
-        if (String(e) !== "cancelled") {
-          await message(t("deleteFailed", { error: e }), { kind: "error" });
-        }
-      } finally {
-        homeViewRef.value?.unhideCard(worktreeId);
-        cancellableWorktrees.delete(worktreeId);
-      }
-    } catch (e) {
-      // UI 後処理ステップ（moveToMainWindow・closeArtifactWindow 等）が失敗した場合。
-      // beforeRemove が実行済みであれば副作用をロールバックする。
-      if (onRemoveFailed) {
-        try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
-      }
-      if (String(e) !== "cancelled") {
-        await message(t("deleteFailed", { error: e }), { kind: "error" });
-      }
-    } finally {
-      loadingWorktrees.delete(worktreeId);
-      cancellableWorktrees.delete(worktreeId);
-    }
-  }
-
-  /** ダイアログ経由の確認後に呼ぶラッパー。ダイアログ state をクリアしてから _execute を呼ぶ */
+  /** ダイアログ確認後の共通処理: state をクリアしてコア処理に委譲する */
   async function _confirm(
     removeOptions: RemoveOptions,
-    loadingText: string,
-    beforeRemove?: (worktree: Worktree) => Promise<void>,
-    onRemoveFailed?: (worktree: Worktree) => Promise<void>,
-    afterRemove?: (worktree: Worktree) => Promise<void>,
+    execute: (worktreeId: string, removeOptions: RemoveOptions) => Promise<void>,
   ): Promise<void> {
     if (!removeTargetWorktree.value) return;
     const { id: worktreeId } = removeTargetWorktree.value;
@@ -245,96 +56,15 @@ export function useRemoveWorktreeDialog(options: {
     removeBranches.value = [];
     removeDirtyFiles.value = [];
 
-    await _execute(worktreeId, removeOptions, loadingText, beforeRemove, onRemoveFailed, afterRemove);
+    await execute(worktreeId, removeOptions);
   }
 
   async function onRemoveWorktreeConfirm(removeOptions: RemoveOptions): Promise<void> {
-    await _confirm(removeOptions, t("deletingText"));
+    await _confirm(removeOptions, core.removeWorktreeNoArchive);
   }
 
   async function onArchiveWorktreeConfirm(removeOptions: RemoveOptions): Promise<void> {
-    await _confirm(
-      removeOptions,
-      t("archivingText"),
-      async (worktree) => {
-        await saveArchive({
-          id: worktree.id,
-          name: worktree.name,
-          repository_id: worktree.repositoryId,
-          repository_name: worktree.repositoryName,
-          path: worktree.path,
-          branch_name: worktree.branchName,
-          archived_at: Date.now(),
-        });
-      },
-      async (worktree) => {
-        // git 操作失敗時: ワークツリーパスがまだ存在する場合のみアーカイブをロールバック
-        // (git_worktree_remove 成功後に git_delete_branch が失敗した場合はワークツリーは
-        //  既に消えているためアーカイブを保持する)
-        const pathStillExists = await invoke<boolean>("path_exists", { path: worktree.path }).catch(() => false);
-        if (pathStillExists) {
-          await deleteArchive(worktree.id);
-        } else {
-          // ワークツリーは削除済み（ブランチ削除失敗などの部分的失敗）→ afterRemove は呼ばれないため
-          // ここでMCPクライアントへ通知する
-          await invoke("notify_worktree_archived", {
-            id: worktree.id,
-            name: worktree.name,
-            branchName: worktree.branchName,
-          }).catch(() => { /* 通知失敗は無視 */ });
-        }
-      },
-      async (worktree) => {
-        // git 操作成功後: MCPクライアントへアーカイブ完了を通知
-        await invoke("notify_worktree_archived", {
-          id: worktree.id,
-          name: worktree.name,
-          branchName: worktree.branchName,
-        });
-      },
-    );
-  }
-
-  /** MCP経由のワークツリーアーカイブ。ダイアログを経由せず直接 _execute を呼ぶ */
-  async function archiveWorktreeByMcp(
-    worktreeId: string,
-    removeOptions: RemoveOptions,
-  ): Promise<void> {
-    await _execute(
-      worktreeId,
-      removeOptions,
-      t("archivingText"),
-      async (worktree) => {
-        await saveArchive({
-          id: worktree.id,
-          name: worktree.name,
-          repository_id: worktree.repositoryId,
-          repository_name: worktree.repositoryName,
-          path: worktree.path,
-          branch_name: worktree.branchName,
-          archived_at: Date.now(),
-        });
-      },
-      async (worktree) => {
-        const pathStillExists = await invoke<boolean>("path_exists", { path: worktree.path }).catch(() => false);
-        if (pathStillExists) {
-          await deleteArchive(worktree.id);
-        } else {
-          await invoke("notify_worktree_archived", {
-            id: worktree.id,
-            name: worktree.name,
-            branchName: worktree.branchName,
-          }).catch(() => { /* 通知失敗は無視 */ });
-        }
-      },
-      async (worktree) => {
-        await invoke("notify_worktree_archived", {
-          id: worktree.id,
-          name: worktree.name,
-          branchName: worktree.branchName,
-        });
-      },
-    );
+    await _confirm(removeOptions, core.archiveWorktree);
   }
 
   return {
@@ -346,7 +76,6 @@ export function useRemoveWorktreeDialog(options: {
     onRemoveWorktree,
     onRemoveWorktreeConfirm,
     onArchiveWorktreeConfirm,
-    archiveWorktreeByMcp,
     cancelWorktreeRemove,
     dismissDialog,
   };

--- a/src/composables/useWorktreeRemove.ts
+++ b/src/composables/useWorktreeRemove.ts
@@ -1,0 +1,254 @@
+import { reactive, nextTick } from "vue";
+import type { Ref } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { message } from "@tauri-apps/plugin-dialog";
+import { useWorktrees } from "./useWorktrees";
+import { cancelApproval } from "../utils/autoApproval";
+import { saveArchive, deleteArchive } from "./useArchivePersistence";
+import type { Worktree } from "../types/worktree";
+
+interface TerminalRef {
+  isRunning: boolean;
+  kill(): Promise<void>;
+}
+
+interface HomeViewRef {
+  fadeOutCard(worktreeId: string): Promise<void>;
+  hideCard(worktreeId: string): Map<string, DOMRect>;
+  animateAfterRemove(positions: Map<string, DOMRect>): void;
+  unhideCard(worktreeId: string): void;
+}
+
+interface FrameBundle {
+  terminalRefs: { get(id: number): TerminalRef | undefined };
+}
+
+export type WorktreeRemoveOptions = {
+  loadingWorktrees: Map<string, string>;
+  clearNotification: (id: string) => void;
+  isDetached: (id: string) => boolean;
+  moveToMainWindow: (id: string) => Promise<void>;
+  subWindowFocusMap: { delete(key: string): void };
+  closeArtifactWindow: (id: string) => Promise<void>;
+  worktreeFrameBundles: { get(id: string): FrameBundle | undefined; delete(id: string): void };
+  getTerminalRef: (id: number) => TerminalRef | undefined;
+  terminalWorktreeMap: { delete(key: number): void };
+  activeWorktreeId: Ref<string | null>;
+  goHome: () => void;
+  homeViewRef: Ref<HomeViewRef | null>;
+  t: (key: string, params?: Record<string, unknown>) => string;
+};
+
+export type RemoveOptions = { mergeTo: string; deleteBranch: boolean; forceBranch: boolean };
+
+export function useWorktreeRemove(options: WorktreeRemoveOptions) {
+  const {
+    loadingWorktrees,
+    clearNotification,
+    isDetached,
+    moveToMainWindow,
+    subWindowFocusMap,
+    closeArtifactWindow,
+    worktreeFrameBundles,
+    getTerminalRef,
+    terminalWorktreeMap,
+    activeWorktreeId,
+    goHome,
+    homeViewRef,
+    t,
+  } = options;
+
+  const { worktrees, removeWorktree, listBranches } = useWorktrees();
+
+  // 永続リトライ中のワークツリーID（キャンセルボタン表示用）
+  const cancellableWorktrees = reactive(new Set<string>());
+
+  // バックエンドから永続リトライ開始イベントを受信したらキャンセル可能状態に移行
+  listen<{ worktreePath: string }>("worktree-remove-retrying", (event) => {
+    const worktree = worktrees.value.find(
+      (w) => w.path === event.payload.worktreePath
+    );
+    if (worktree) {
+      cancellableWorktrees.add(worktree.id);
+      loadingWorktrees.set(worktree.id, t("retryingDeleteText"));
+    }
+  });
+
+  /** 永続リトライ中の削除をキャンセルする */
+  async function cancelWorktreeRemove(worktreeId: string): Promise<void> {
+    const worktree = worktrees.value.find((w) => w.id === worktreeId);
+    if (!worktree) return;
+    try {
+      await invoke("cancel_worktree_remove", { worktreePath: worktree.path });
+    } catch {
+      // すでに完了している場合は無視
+    }
+  }
+
+  /** コア削除処理: ターミナル停止・アニメーション付きワークツリー削除
+   *  beforeRemove: git 操作前に呼ぶ任意の非同期処理（アーカイブ保存など）
+   *  onRemoveFailed: git 操作失敗時に beforeRemove の副作用をロールバックするコールバック
+   *  afterRemove: git 操作成功後に呼ぶ任意の非同期処理（MCP通知など）
+   */
+  async function _execute(
+    worktreeId: string,
+    removeOptions: RemoveOptions,
+    loadingText: string,
+    beforeRemove?: (worktree: Worktree) => Promise<void>,
+    onRemoveFailed?: (worktree: Worktree) => Promise<void>,
+    afterRemove?: (worktree: Worktree) => Promise<void>,
+  ): Promise<void> {
+    const worktree = worktrees.value.find((w) => w.id === worktreeId);
+    if (!worktree) return;
+
+    clearNotification(worktreeId);
+
+    // UI 破壊的操作の前に事前処理（アーカイブ保存など）を実行する。
+    // ここで失敗した場合はワークツリーに何も手を加えずエラーを表示して終了する。
+    if (beforeRemove) {
+      try {
+        await beforeRemove(worktree);
+      } catch (e) {
+        await message(t("deleteFailed", { error: e }), { kind: "error" });
+        return;
+      }
+    }
+
+    loadingWorktrees.set(worktreeId, loadingText);
+    try {
+      if (isDetached(worktreeId)) {
+        await moveToMainWindow(worktreeId);
+        subWindowFocusMap.delete(worktreeId);
+      }
+
+      await closeArtifactWindow(worktreeId);
+      await cancelApproval(worktreeId);
+
+      // ターミナルプロセスをkillする（ディレクトリのファイルハンドル解放が目的）。
+      // ただし UI 状態のクリア（terminals.splice / frameBundles.delete）は削除成功後に行う。
+      // キャンセル時にワークツリーが UI に残った際、空ターミナルではなく停止済み状態で表示できるようにする。
+      const bundle = worktreeFrameBundles.get(worktreeId);
+      const terminalsSnapshot = [...worktree.terminals];
+      for (const terminal of terminalsSnapshot) {
+        const term = bundle?.terminalRefs.get(terminal.id) ?? getTerminalRef(terminal.id);
+        if (term?.isRunning) await term.kill();
+      }
+
+      if (activeWorktreeId.value === worktreeId) goHome();
+
+      let savedPositions: Map<string, DOMRect> | undefined;
+      try {
+        await removeWorktree(
+          worktreeId,
+          {
+            mergeTo: removeOptions.mergeTo || undefined,
+            deleteBranch: removeOptions.deleteBranch,
+            forceBranch: removeOptions.forceBranch,
+          },
+          async () => {
+            await homeViewRef.value?.fadeOutCard(worktreeId);
+            savedPositions = homeViewRef.value?.hideCard(worktreeId);
+          },
+        );
+        // 削除成功後に UI 状態をクリア
+        for (const terminal of terminalsSnapshot) {
+          terminalWorktreeMap.delete(terminal.id);
+        }
+        worktree.terminals.splice(0);
+        worktreeFrameBundles.delete(worktreeId);
+        // git 操作成功後の後処理（MCP通知など）
+        if (afterRemove) {
+          try { await afterRemove(worktree); } catch { /* 通知失敗はワークツリー削除の成否に影響しない */ }
+        }
+        await nextTick();
+        if (savedPositions) homeViewRef.value?.animateAfterRemove(savedPositions);
+      } catch (e) {
+        if (savedPositions) homeViewRef.value?.animateAfterRemove(savedPositions);
+        // git 操作失敗時: 事前処理の副作用をロールバック
+        if (onRemoveFailed) {
+          try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
+        }
+        // "cancelled" はユーザー操作によるキャンセルなのでエラーダイアログを出さない
+        if (String(e) !== "cancelled") {
+          await message(t("deleteFailed", { error: e }), { kind: "error" });
+        }
+      } finally {
+        homeViewRef.value?.unhideCard(worktreeId);
+        cancellableWorktrees.delete(worktreeId);
+      }
+    } catch (e) {
+      // UI 後処理ステップ（moveToMainWindow・closeArtifactWindow 等）が失敗した場合。
+      // beforeRemove が実行済みであれば副作用をロールバックする。
+      if (onRemoveFailed) {
+        try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
+      }
+      if (String(e) !== "cancelled") {
+        await message(t("deleteFailed", { error: e }), { kind: "error" });
+      }
+    } finally {
+      loadingWorktrees.delete(worktreeId);
+      cancellableWorktrees.delete(worktreeId);
+    }
+  }
+
+  /** アーカイブDBに保存してワークツリーを削除する（ダイアログ経由・MCP経由の共通処理） */
+  async function archiveWorktree(worktreeId: string, removeOptions: RemoveOptions): Promise<void> {
+    await _execute(
+      worktreeId,
+      removeOptions,
+      t("archivingText"),
+      async (worktree) => {
+        await saveArchive({
+          id: worktree.id,
+          name: worktree.name,
+          repository_id: worktree.repositoryId,
+          repository_name: worktree.repositoryName,
+          path: worktree.path,
+          branch_name: worktree.branchName,
+          archived_at: Date.now(),
+        });
+      },
+      async (worktree) => {
+        // git 操作失敗時: ワークツリーパスがまだ存在する場合のみアーカイブをロールバック
+        // (git_worktree_remove 成功後に git_delete_branch が失敗した場合はワークツリーは
+        //  既に消えているためアーカイブを保持する)
+        const pathStillExists = await invoke<boolean>("path_exists", { path: worktree.path }).catch(() => false);
+        if (pathStillExists) {
+          await deleteArchive(worktree.id);
+        } else {
+          // ワークツリーは削除済み（ブランチ削除失敗などの部分的失敗）→ afterRemove は呼ばれないため
+          // ここでMCPクライアントへ通知する
+          await invoke("notify_worktree_archived", {
+            id: worktree.id,
+            name: worktree.name,
+            branchName: worktree.branchName,
+          }).catch(() => { /* 通知失敗は無視 */ });
+        }
+      },
+      async (worktree) => {
+        // git 操作成功後: MCPクライアントへアーカイブ完了を通知
+        await invoke("notify_worktree_archived", {
+          id: worktree.id,
+          name: worktree.name,
+          branchName: worktree.branchName,
+        });
+      },
+    );
+  }
+
+  /** アーカイブDBへの保存なしでワークツリーを削除する */
+  async function removeWorktreeNoArchive(worktreeId: string, removeOptions: RemoveOptions): Promise<void> {
+    await _execute(worktreeId, removeOptions, t("deletingText"));
+  }
+
+  return {
+    worktrees,
+    listBranches,
+    clearNotification,
+    cancellableWorktrees,
+    cancelWorktreeRemove,
+    archiveWorktree,
+    removeWorktreeNoArchive,
+  };
+}

--- a/src/composables/useWorktreeRemove.ts
+++ b/src/composables/useWorktreeRemove.ts
@@ -73,7 +73,7 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
       cancellableWorktrees.add(worktree.id);
       loadingWorktrees.set(worktree.id, t("retryingDeleteText"));
     }
-  });
+  }).catch(() => { /* リスナー登録失敗時は無視（通常発生しない） */ });
 
   /** 永続リトライ中の削除をキャンセルする */
   async function cancelWorktreeRemove(worktreeId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- MCP経由の `close_worktree` がUI経由（`useRemoveWorktreeDialog`）と異なる独自実装になっており、PR #34の永続リトライ+キャンセル機能・正しいUI状態クリアタイミング・MCP通知・ホームタブ遷移などが欠落していた問題を修正
- 削除コアロジックを `useWorktreeRemove.ts` に切り出し、ダイアログ経由・MCP経由の両方が共通の処理フローを使うよう統一

## Changes

- **`src/composables/useWorktreeRemove.ts`** (新規): ワークツリー削除のコアロジックを集約
  - `_execute`: ターミナルkill → サブウィンドウクローズ → ホームタブ遷移 → git削除 → UIクリア → アニメーション
  - `archiveWorktree`: アーカイブDB保存 + MCP通知込みの削除（ダイアログ・MCP共通）
  - `removeWorktreeNoArchive`: アーカイブなしの通常削除
  - `cancellableWorktrees` / `cancelWorktreeRemove`: 永続リトライ中のキャンセル管理
- **`src/composables/useRemoveWorktreeDialog.ts`**: ダイアログstate管理のみに専念。`useWorktreeRemove` のインスタンスを受け取り処理を委譲
- **`src/App.vue`**: `mcp-close-worktree` リスナーを `archiveWorktree` 呼び出しに簡素化。不要になったインライン実装・importを削除

## Behavior changes

MCP経由の `close_worktree` が以下を正しく実行するようになった:
- アーカイブ開始時にメインウィンドウでホームタブに遷移
- サブウィンドウで開いていた場合はウィンドウを閉じる
- 外部プロセスがファイルハンドルを掴んでいる場合の永続リトライ + キャンセルボタン表示
- 削除完了後に他MCPクライアントへ `worktree-archived` 通知を送信

## Test plan

- [ ] MCP経由で `oretachi_close_worktree` を実行 → ホームタブに遷移すること
- [ ] サブウィンドウで開いている状態でMCP経由クローズ → サブウィンドウが閉じること
- [ ] UIダイアログ経由の削除・アーカイブが既存通りに動作すること（リグレッションなし）
- [ ] 永続リトライ中のキャンセルがMCP経由でも動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)