### PR TITLE
feat: broadcast Claude Code lifecycle hooks through MCP notifications

### DIFF
--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -1260,7 +1260,8 @@ pub fn write_claude_hooks(
                             for h in hs.iter_mut() {
                                 if h.get("command")
                                     .and_then(|c| c.as_str())
-                                    .map_or(false, |c| c.contains("--notify") && c.contains("--kind hook"))
+                                    // oretachi が注入したフックの識別: --kind hook と --agent の組み合わせで特定
+                                    .map_or(false, |c| c.contains("--kind hook") && c.contains("--agent "))
                                 {
                                     h["command"] = serde_json::Value::String(command.clone());
                                     found = true;

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -1253,19 +1253,22 @@ pub fn write_claude_hooks(
             });
             if let Some(existing) = hooks_obj.get_mut(ev) {
                 if let Some(arr) = existing.as_array_mut() {
-                    // oretachi の --notify フックが既に含まれているかチェック
-                    let has_oretachi = arr.iter().any(|group| {
-                        group.get("hooks")
-                            .and_then(|h| h.as_array())
-                            .map_or(false, |hs| {
-                                hs.iter().any(|h| {
-                                    h.get("command")
-                                        .and_then(|c| c.as_str())
-                                        .map_or(false, |c| c.contains("--notify") && c.contains("--kind hook"))
-                                })
-                            })
-                    });
-                    if !has_oretachi {
+                    // oretachi の --notify フックが既に含まれていれば最新コマンドで更新
+                    let mut found = false;
+                    for group in arr.iter_mut() {
+                        if let Some(hs) = group.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+                            for h in hs.iter_mut() {
+                                if h.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .map_or(false, |c| c.contains("--notify") && c.contains("--kind hook"))
+                                {
+                                    h["command"] = serde_json::Value::String(command.clone());
+                                    found = true;
+                                }
+                            }
+                        }
+                    }
+                    if !found {
                         arr.push(oretachi_group);
                     }
                 }

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -1225,7 +1225,8 @@ pub fn write_claude_hooks(
         .and_then(|v| v.as_object().cloned())
         .unwrap_or_default();
 
-    // 有効なイベントを上書き
+    // ユーザー指定イベントを上書き
+    let user_events: std::collections::HashSet<&str> = hooks.iter().map(|h| h.event.as_str()).collect();
     for entry in &hooks {
         let command = format!(
             "\"{}\" --notify \"{}\" --kind {}",
@@ -1238,11 +1239,18 @@ pub fn write_claude_hooks(
         hooks_obj.insert(entry.event.clone(), hook_entry);
     }
 
-    // oretachi管理イベントのうち無効化されたものを既存hooksから削除
-    let enabled: std::collections::HashSet<&str> = hooks.iter().map(|h| h.event.as_str()).collect();
+    // ユーザーが指定していない MANAGED_EVENTS は kind "hook" で自動注入（モニタリング用）
     for &ev in MANAGED_EVENTS {
-        if !enabled.contains(ev) {
-            hooks_obj.remove(ev);
+        if !user_events.contains(ev) {
+            let command = format!(
+                "\"{}\" --notify \"{}\" --kind hook --agent cc",
+                exe_path, worktree_name
+            );
+            let hook_entry = serde_json::json!([{
+                "matcher": "",
+                "hooks": [{ "type": "command", "command": command }]
+            }]);
+            hooks_obj.insert(ev.to_string(), hook_entry);
         }
     }
 

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -1240,17 +1240,39 @@ pub fn write_claude_hooks(
     }
 
     // ユーザーが指定していない MANAGED_EVENTS は kind "hook" で自動注入（モニタリング用）
+    // 既存エントリがあれば oretachi のフックを追記（既に含まれていれば更新、ユーザー定義フックは保持）
     for &ev in MANAGED_EVENTS {
         if !user_events.contains(ev) {
             let command = format!(
                 "\"{}\" --notify \"{}\" --kind hook --agent cc",
                 exe_path, worktree_name
             );
-            let hook_entry = serde_json::json!([{
+            let oretachi_group = serde_json::json!({
                 "matcher": "",
                 "hooks": [{ "type": "command", "command": command }]
-            }]);
-            hooks_obj.insert(ev.to_string(), hook_entry);
+            });
+            if let Some(existing) = hooks_obj.get_mut(ev) {
+                if let Some(arr) = existing.as_array_mut() {
+                    // oretachi の --notify フックが既に含まれているかチェック
+                    let has_oretachi = arr.iter().any(|group| {
+                        group.get("hooks")
+                            .and_then(|h| h.as_array())
+                            .map_or(false, |hs| {
+                                hs.iter().any(|h| {
+                                    h.get("command")
+                                        .and_then(|c| c.as_str())
+                                        .map_or(false, |c| c.contains("--notify") && c.contains("--kind hook"))
+                                })
+                            })
+                    });
+                    if !has_oretachi {
+                        arr.push(oretachi_group);
+                    }
+                }
+                // else: 配列でない既存エントリは保持（上書きしない）
+            } else {
+                hooks_obj.insert(ev.to_string(), serde_json::json!([oretachi_group]));
+            }
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,7 +5,14 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     if let Some(name) = find_notify_arg(&args) {
         let kind = find_kind_arg(&args);
-        if let Err(e) = oretachi_lib::mcp_server::send_notification_standalone(&name, kind.as_deref()) {
+        let agent = find_agent_arg(&args);
+        let body = read_stdin_if_piped();
+        if let Err(e) = oretachi_lib::mcp_server::send_notification_standalone(
+            &name,
+            kind.as_deref(),
+            body.as_deref(),
+            agent.as_deref(),
+        ) {
             #[cfg(debug_assertions)]
             eprintln!("Notification failed: {}", e);
             std::process::exit(1);
@@ -34,6 +41,30 @@ fn find_notify_arg(args: &[String]) -> Option<String> {
 
 fn find_kind_arg(args: &[String]) -> Option<String> {
     find_arg(args, "--kind", "-k")
+}
+
+fn find_agent_arg(args: &[String]) -> Option<String> {
+    find_arg(args, "--agent", "-a")
+}
+
+/// stdin がパイプ（非 TTY）の場合のみ読み取り、タイムアウト付きで返す。
+/// Claude Code ライフサイクルフックのコンテキスト JSON を body として受け取るために使用。
+fn read_stdin_if_piped() -> Option<String> {
+    use std::io::IsTerminal;
+    if std::io::stdin().is_terminal() {
+        return None;
+    }
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = String::new();
+        let _ = std::io::stdin().take(65536).read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+    match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        Ok(s) if !s.is_empty() => Some(s),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -98,5 +129,29 @@ mod tests {
     fn test_find_kind_arg_none() {
         let args = vec!["bin".to_string(), "--notify".to_string(), "myname".to_string()];
         assert_eq!(find_kind_arg(&args), None);
+    }
+
+    #[test]
+    fn test_find_agent_arg_long_space() {
+        let args = vec!["bin".to_string(), "--agent".to_string(), "cc".to_string()];
+        assert_eq!(find_agent_arg(&args), Some("cc".to_string()));
+    }
+
+    #[test]
+    fn test_find_agent_arg_long_eq() {
+        let args = vec!["bin".to_string(), "--agent=codex".to_string()];
+        assert_eq!(find_agent_arg(&args), Some("codex".to_string()));
+    }
+
+    #[test]
+    fn test_find_agent_arg_short() {
+        let args = vec!["bin".to_string(), "-a".to_string(), "gemini".to_string()];
+        assert_eq!(find_agent_arg(&args), Some("gemini".to_string()));
+    }
+
+    #[test]
+    fn test_find_agent_arg_none() {
+        let args = vec!["bin".to_string(), "--notify".to_string(), "myname".to_string()];
+        assert_eq!(find_agent_arg(&args), None);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -58,7 +58,7 @@ fn read_stdin_if_piped() -> Option<String> {
     std::thread::spawn(move || {
         use std::io::Read;
         let mut buf = String::new();
-        let _ = std::io::stdin().take(65536).read_to_string(&mut buf);
+        let _ = std::io::stdin().read_to_string(&mut buf);
         let _ = tx.send(buf);
     });
     match rx.recv_timeout(std::time::Duration::from_secs(2)) {

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1473,14 +1473,26 @@ pub fn send_notification_standalone(worktree_name: &str, kind: Option<&str>, bod
     stream
         .set_write_timeout(Some(Duration::from_secs(5)))
         .map_err(|e| format!("Failed to set write timeout: {}", e))?;
+    // 短い読み取りタイムアウトで応答をチェック（非ブロッキング性を維持しつつ確実な配信失敗を検出）
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .map_err(|e| format!("Failed to set read timeout: {}", e))?;
     stream
         .write_all(request.as_bytes())
         .map_err(|e| format!("Failed to send notification: {}", e))?;
     stream
         .flush()
         .map_err(|e| format!("Failed to flush: {}", e))?;
-    // レスポンスは待たずに即リターン（fire-and-forget）
-    // PreToolUse 等の返り値待ちフックが Claude Code をブロックしないようにするため
+
+    // 応答の最初の行だけ読んでステータスを確認する（タイムアウトは無視してベストエフォートとする）
+    use std::io::{BufRead, BufReader};
+    let reader = BufReader::new(&stream);
+    if let Some(Ok(first_line)) = reader.lines().next() {
+        if first_line.starts_with("HTTP/") && !first_line.contains(" 200 ") {
+            return Err(format!("Server returned unexpected response: {}", first_line));
+        }
+    }
+    // タイムアウトや読み取りエラーはベストエフォート成功扱い（フックのブロック防止）
     Ok(())
 }
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -57,6 +57,8 @@ pub struct McpServerManager {
     archive_listener_id: Mutex<Option<tauri::EventId>>,
     /// worktree-added リスナーID（再起動時にアンリジスターするために保持）
     added_listener_id: Mutex<Option<tauri::EventId>>,
+    /// notify-worktree リスナーID（再起動時にアンリジスターするために保持）
+    notify_listener_id: Mutex<Option<tauri::EventId>>,
 }
 
 impl McpServerManager {
@@ -69,6 +71,7 @@ impl McpServerManager {
             generation: Arc::new(AtomicU64::new(0)),
             archive_listener_id: Mutex::new(None),
             added_listener_id: Mutex::new(None),
+            notify_listener_id: Mutex::new(None),
         }
     }
 
@@ -107,20 +110,26 @@ impl McpServerManager {
 pub struct NotifyPayload {
     pub worktree: String,
     pub kind: Option<String>,
+    pub body: Option<String>,
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct NotifyWorktreeParams {
     #[schemars(description = "通知するワークツリー名")]
     pub worktree_name: String,
-    #[schemars(description = "通知種別: \"approval\"(承認待ち) / \"completed\"(作業完了) / \"general\"(汎用)。省略時は \"general\"")]
+    #[schemars(description = "通知種別: \"approval\"(承認待ち) / \"completed\"(作業完了) / \"general\"(汎用) / \"hook\"(ライフサイクルフック)。省略時は \"general\"")]
     pub kind: Option<String>,
+    #[schemars(description = "通知本文（ライフサイクルフックのコンテキスト情報など）。省略可")]
+    pub body: Option<String>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NotifyWorktreeEvent {
     pub worktree_name: String,
     pub kind: String,
+    pub body: Option<String>,
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -666,11 +675,13 @@ impl NotifyService {
     #[tool(description = "ワークツリーに通知を送信する")]
     fn notify_worktree(
         &self,
-        Parameters(NotifyWorktreeParams { worktree_name, kind }): Parameters<NotifyWorktreeParams>,
+        Parameters(NotifyWorktreeParams { worktree_name, kind, body }): Parameters<NotifyWorktreeParams>,
     ) -> Result<CallToolResult, McpError> {
         let event = NotifyWorktreeEvent {
             worktree_name: worktree_name.clone(),
             kind: kind.unwrap_or_else(|| "general".to_string()),
+            body,
+            agent: None,
         };
         self.app_handle
             .emit("notify-worktree", &event)
@@ -955,6 +966,8 @@ async fn notify_handler(
     let event = NotifyWorktreeEvent {
         worktree_name: payload.worktree.clone(),
         kind: payload.kind.unwrap_or_else(|| "general".to_string()),
+        body: payload.body,
+        agent: payload.agent,
     };
     match app_handle.emit("notify-worktree", &event) {
         Ok(_) => {
@@ -1100,6 +1113,21 @@ async fn broadcast_worktree_added(peer_registry: &PeerMap, timeout_counts: &Peer
     broadcast_notification(peer_registry, timeout_counts, params).await;
 }
 
+async fn broadcast_notify_worktree(peer_registry: &PeerMap, timeout_counts: &PeerTimeoutCounts, event: &NotifyWorktreeEvent) {
+    let params = LoggingMessageNotificationParam {
+        level: LoggingLevel::Info,
+        logger: Some("oretachi".to_string()),
+        data: serde_json::json!({
+            "event": "notify_worktree",
+            "worktreeName": event.worktree_name,
+            "kind": event.kind,
+            "body": event.body,
+            "agent": event.agent,
+        }),
+    };
+    broadcast_notification(peer_registry, timeout_counts, params).await;
+}
+
 // ─── Port file management ─────────────────────────────────────────────────────
 
 fn port_file_path(app_handle: &AppHandle) -> Option<PathBuf> {
@@ -1220,6 +1248,11 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
             app_handle.unlisten(old_id);
         }
     }
+    if let Ok(mut guard) = manager.notify_listener_id.lock() {
+        if let Some(old_id) = guard.take() {
+            app_handle.unlisten(old_id);
+        }
+    }
 
     drop(manager);
 
@@ -1276,6 +1309,25 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
     let manager = app_handle.state::<McpServerManager>();
     if let Ok(mut guard) = manager.added_listener_id.lock() {
         *guard = Some(added_listener_id);
+    }
+    drop(manager);
+
+    // notify-worktree イベント受信時に全 MCP クライアントへブロードキャスト
+    let peer_map_for_notify_listener = peer_map.clone();
+    let timeout_counts_for_notify_listener = timeout_counts.clone();
+    let notify_listener_id = app_handle.listen("notify-worktree", move |event: tauri::Event| {
+        let registry = peer_map_for_notify_listener.clone();
+        let tc = timeout_counts_for_notify_listener.clone();
+        if let Ok(payload) = serde_json::from_str::<NotifyWorktreeEvent>(event.payload()) {
+            tauri::async_runtime::spawn(async move {
+                broadcast_notify_worktree(&registry, &tc, &payload).await;
+            });
+        }
+    });
+
+    let manager = app_handle.state::<McpServerManager>();
+    if let Ok(mut guard) = manager.notify_listener_id.lock() {
+        *guard = Some(notify_listener_id);
     }
     drop(manager);
 
@@ -1392,18 +1444,25 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
 
 // ─── CLI notification sender (standalone, no AppHandle needed) ───────────────
 
-pub fn send_notification_standalone(worktree_name: &str, kind: Option<&str>) -> Result<(), String> {
+pub fn send_notification_standalone(worktree_name: &str, kind: Option<&str>, body: Option<&str>, agent: Option<&str>) -> Result<(), String> {
     let (port, api_key) = read_server_info_standalone()?;
-    let body = serde_json::json!({
+    let mut payload = serde_json::json!({
         "worktree": worktree_name,
         "kind": kind.unwrap_or("general"),
-    }).to_string();
+    });
+    if let Some(b) = body {
+        payload["body"] = serde_json::Value::String(b.to_string());
+    }
+    if let Some(a) = agent {
+        payload["agent"] = serde_json::Value::String(a.to_string());
+    }
+    let payload_str = payload.to_string();
     let request = format!(
-        "POST /notify HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nContent-Type: application/json\r\nAuthorization: Bearer {api_key}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
+        "POST /notify HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nContent-Type: application/json\r\nAuthorization: Bearer {api_key}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload_str}",
+        payload_str.len()
     );
 
-    use std::io::{Read, Write};
+    use std::io::Write;
     use std::time::Duration;
 
     let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port)
@@ -1411,9 +1470,6 @@ pub fn send_notification_standalone(worktree_name: &str, kind: Option<&str>) -> 
         .map_err(|e| format!("Invalid address: {}", e))?;
     let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(3))
         .map_err(|e| format!("Cannot connect to oretachi MCP server: {}", e))?;
-    stream
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .map_err(|e| format!("Failed to set read timeout: {}", e))?;
     stream
         .set_write_timeout(Some(Duration::from_secs(5)))
         .map_err(|e| format!("Failed to set write timeout: {}", e))?;
@@ -1423,18 +1479,8 @@ pub fn send_notification_standalone(worktree_name: &str, kind: Option<&str>) -> 
     stream
         .flush()
         .map_err(|e| format!("Failed to flush: {}", e))?;
-
-    let mut response = Vec::new();
-    stream
-        .read_to_end(&mut response)
-        .map_err(|e| format!("Failed to read response: {}", e))?;
-
-    let response_str = String::from_utf8_lossy(&response);
-    // ステータス行 "HTTP/1.x 200 " を確認（単純な contains("200") は誤検知の恐れ）
-    let first_line = response_str.lines().next().unwrap_or("");
-    if !first_line.starts_with("HTTP/") || !first_line.contains(" 200 ") {
-        return Err(format!("Server returned unexpected response: {}", response_str));
-    }
+    // レスポンスは待たずに即リターン（fire-and-forget）
+    // PreToolUse 等の返り値待ちフックが Claude Code をブロックしないようにするため
     Ok(())
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -7,7 +7,7 @@ use tauri::{AppHandle, Manager};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotificationHookEntry {
     pub event: String, // "Stop", "Notification", "SubagentStop", "PreToolUse", "PostToolUse", "PermissionRequest"
-    pub kind: String,  // "completed", "approval", "general"
+    pub kind: String,  // "completed", "approval", "general", "hook"
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/composables/useAppAutoApproval.ts
+++ b/src/composables/useAppAutoApproval.ts
@@ -76,7 +76,7 @@ export function useAppAutoApproval(deps: UseAppAutoApprovalDeps) {
       );
 
       if (!wt) return;
-      if (kind === "completed") return;
+      if (kind === "completed" || kind === "hook") return;
       if (!autoApprovalMap.get(wt.id)) return;
 
       if (aiJudgingWorktrees.has(wt.id)) {

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -13,7 +13,9 @@ export type NotificationKind = "approval" | "completed" | "general";
 
 export interface NotifyWorktreeEvent {
   worktree_name: string;
-  kind: NotificationKind;
+  kind: NotificationKind | "hook";
+  body?: string;
+  agent?: string;
 }
 
 interface NotificationEntry {
@@ -82,6 +84,8 @@ export function useNotifications() {
 
     await listen<NotifyWorktreeEvent>("notify-worktree", async (event) => {
       const { worktree_name: worktreeName, kind } = event.payload;
+      // hook はモニタリング目的の MCP ブロードキャスト専用。UI 通知はスキップ
+      if (kind === "hook") return;
       const id = resolveWorktreeId(worktreeName);
       if (id) {
         if (shouldHold?.(id, kind)) return;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,6 +1,6 @@
 export interface NotificationHookEntry {
   event: 'Stop' | 'Notification' | 'SubagentStop' | 'PreToolUse' | 'PostToolUse' | 'PermissionRequest';
-  kind: 'completed' | 'approval' | 'general';
+  kind: 'completed' | 'approval' | 'general' | 'hook';
 }
 
 export interface Repository {


### PR DESCRIPTION
## Summary

- Claude Code の全ライフサイクルフック (Stop/Notification/SubagentStop/PreToolUse/PostToolUse/PermissionRequest) を `settings.local.json` に自動注入し、oretachi MCP サーバーへ通知する
- `notify_worktree` ツール・REST `/notify` エンドポイントに `body`/`agent` パラメータを追加
- Claude Code のフックコンテキスト JSON (stdin) を `body` として MCP クライアントへブロードキャスト
- PreToolUse 等のブロッキングフックが Claude Code を止めないよう fire-and-forget 化 (500ms ベストエフォート応答チェック)

## Changes

- **`src-tauri/src/git_worktree.rs`**: 全 MANAGED_EVENTS を常に注入。ユーザー未選択イベントは `kind=hook --agent cc` で追記注入。既存ユーザーフックは保持し、oretachi フックのみ更新 (`--kind hook` + `--agent ` パターンで識別)
- **`src-tauri/src/main.rs`**: `--agent` 引数追加。stdin がパイプ時のみ読み取り (TTY 判定 + 2s タイムアウト) して `body` として送信
- **`src-tauri/src/mcp_server.rs`**: `NotifyPayload`/`NotifyWorktreeParams`/`NotifyWorktreeEvent` に `body`/`agent` 追加。`notify-worktree` イベントを全 MCP クライアントへ `logging/message` でブロードキャスト。`McpServerManager` に `notify_listener_id` 追加
- **`src/composables/useNotifications.ts`**: `NotifyWorktreeEvent` 型拡張 (`body`/`agent`)。`kind === "hook"` は UI 通知・音をスキップ
- **`src/composables/useAppAutoApproval.ts`**: `kind === "hook"` で自動承認をスキップ
- **`src/types/settings.ts`**: `NotificationHookEntry.kind` に `'hook'` 追加

## Test plan

- [ ] `cargo check` / `pnpm run type-check` でビルドエラーなし
- [ ] `cargo test` で全テスト通過 (main.rs の `find_agent_arg` テスト含む)
- [ ] ワークツリー追加後に `.claude/settings.local.json` に全 6 イベントが注入されることを確認
- [ ] Claude Code がフックを実行した際、MCP クライアントに `logging/message` (event="notify_worktree") が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)