### PR TITLE
feat: Claude Code plugin system for worktree notification hooks

### DIFF
--- a/src-tauri/src/claude_plugin.rs
+++ b/src-tauri/src/claude_plugin.rs
@@ -1,0 +1,301 @@
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+use crate::settings::NotificationHookEntry;
+
+const PLUGIN_NAME: &str = "oretachi";
+const PLUGIN_ID: &str = "oretachi@oretachi";
+const MARKETPLACE_DIR: &str = "claude-plugins";
+
+/// Claude Code プラグイン: 管理対象イベントとそのuserConfigキー
+const EVENT_CONFIG_KEYS: &[(&str, &str)] = &[
+    ("Stop", "stop_kind"),
+    ("Notification", "notification_kind"),
+    ("SubagentStop", "subagent_stop_kind"),
+    ("PreToolUse", "pre_tool_use_kind"),
+    ("PostToolUse", "post_tool_use_kind"),
+    ("PermissionRequest", "permission_request_kind"),
+];
+
+/// マーケットプレイスディレクトリ（extraKnownMarketplacesで指定するパス）を返す
+/// Windows: %APPDATA%/com.ia.oretachi/claude-plugins
+pub fn marketplace_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    app_handle
+        .path()
+        .app_data_dir()
+        .map(|d| d.join(MARKETPLACE_DIR))
+        .map_err(|e| format!("Failed to get app_data_dir: {}", e))
+}
+
+/// プラグイン本体ディレクトリを返す
+/// marketplace_dir/oretachi/
+fn plugin_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    marketplace_dir(app_handle).map(|d| d.join(PLUGIN_NAME))
+}
+
+/// 起動時にプラグインファイル群を生成・更新する
+/// - ディレクトリ構造の作成
+/// - plugin.json: env.ORETACHI_APP_PATH を現在のexeパスで更新
+/// - hooks/hooks.json: 全イベントのフック定義
+/// - .mcp.json はポート確定後に update_mcp_config で書き込むため、ここでは生成しない
+pub fn generate_plugin_files(app_handle: &AppHandle) -> Result<(), String> {
+    let plugin_dir = plugin_dir(app_handle)?;
+    let claude_plugin_dir = plugin_dir.join(".claude-plugin");
+    let hooks_dir = plugin_dir.join("hooks");
+
+    std::fs::create_dir_all(&claude_plugin_dir)
+        .map_err(|e| format!("Failed to create .claude-plugin dir: {}", e))?;
+    std::fs::create_dir_all(&hooks_dir)
+        .map_err(|e| format!("Failed to create hooks dir: {}", e))?;
+
+    let exe_path = std::env::current_exe()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|_| "oretachi".to_string());
+
+    // plugin.json
+    let plugin_json = build_plugin_json(&exe_path);
+    let plugin_json_path = claude_plugin_dir.join("plugin.json");
+    std::fs::write(
+        &plugin_json_path,
+        serde_json::to_string_pretty(&plugin_json)
+            .map_err(|e| format!("Failed to serialize plugin.json: {}", e))?,
+    )
+    .map_err(|e| format!("Failed to write plugin.json: {}", e))?;
+
+    // hooks/hooks.json
+    let hooks_json = build_hooks_json();
+    let hooks_json_path = hooks_dir.join("hooks.json");
+    std::fs::write(
+        &hooks_json_path,
+        serde_json::to_string_pretty(&hooks_json)
+            .map_err(|e| format!("Failed to serialize hooks.json: {}", e))?,
+    )
+    .map_err(|e| format!("Failed to write hooks.json: {}", e))?;
+
+    Ok(())
+}
+
+/// .mcp.json のみ更新する（MCP サーバー起動後にポート確定値で呼ばれる）
+pub fn update_mcp_config(app_handle: &AppHandle, port: u16, api_key: &str) -> Result<(), String> {
+    let plugin_dir = plugin_dir(app_handle)?;
+    // プラグインディレクトリが存在しない場合は初回生成前なのでスキップ
+    if !plugin_dir.exists() {
+        return Ok(());
+    }
+    update_mcp_json(&plugin_dir, port, api_key)
+}
+
+fn update_mcp_json(plugin_dir: &std::path::Path, port: u16, api_key: &str) -> Result<(), String> {
+    let mcp_json = build_mcp_json(port, api_key);
+    let mcp_json_path = plugin_dir.join(".mcp.json");
+    std::fs::write(
+        &mcp_json_path,
+        serde_json::to_string_pretty(&mcp_json)
+            .map_err(|e| format!("Failed to serialize .mcp.json: {}", e))?,
+    )
+    .map_err(|e| format!("Failed to write .mcp.json: {}", e))
+}
+
+fn build_plugin_json(exe_path: &str) -> serde_json::Value {
+    let mut user_config = serde_json::Map::new();
+    user_config.insert(
+        "worktree_name".to_string(),
+        serde_json::json!({ "description": "Worktree name for notifications" }),
+    );
+    for (_, key) in EVENT_CONFIG_KEYS {
+        user_config.insert(
+            key.to_string(),
+            serde_json::json!({ "description": format!("Notification kind for {} event", key) }),
+        );
+    }
+
+    serde_json::json!({
+        "name": PLUGIN_NAME,
+        "description": "oretachi worktree notification hooks & MCP server",
+        "hooks": "./hooks/hooks.json",
+        "mcpServers": "./.mcp.json",
+        "env": {
+            "ORETACHI_APP_PATH": exe_path
+        },
+        "userConfig": user_config
+    })
+}
+
+fn build_hooks_json() -> serde_json::Value {
+    // ${ORETACHI_APP_PATH} は plugin.json の env フィールドで定義された環境変数。
+    // ${user_config.XXX} は Claude Code プラグイン仕様のユーザー設定値展開構文。
+    // 各ワークツリーの pluginConfigs.oretachi@oretachi.options から値が注入される。
+    let mut hooks = serde_json::Map::new();
+    for (event, key) in EVENT_CONFIG_KEYS {
+        let command = format!(
+            "\"${{ORETACHI_APP_PATH}}\" --notify \"${{user_config.worktree_name}}\" --kind ${{user_config.{}}} --agent cc",
+            key
+        );
+        hooks.insert(
+            event.to_string(),
+            serde_json::json!([{
+                "matcher": "",
+                "hooks": [{ "type": "command", "command": command }]
+            }]),
+        );
+    }
+    serde_json::json!({ "hooks": hooks })
+}
+
+fn build_mcp_json(port: u16, api_key: &str) -> serde_json::Value {
+    serde_json::json!({
+        "mcpServers": {
+            PLUGIN_NAME: {
+                "type": "streamableHttp",
+                "url": format!("http://127.0.0.1:{}/mcp", port),
+                "headers": {
+                    "x-api-key": api_key
+                }
+            }
+        }
+    })
+}
+
+/// ワークツリーの .claude/settings.local.json にプラグイン設定を書き込む
+/// - extraKnownMarketplaces: プラグインのマーケットプレイスディレクトリ
+/// - enabledPlugins: oretachi プラグインを有効化
+/// - pluginConfigs: ワークツリー名と各イベントの通知 kind
+/// - 旧形式の hooks キー内 oretachi フックを削除（マイグレーション）
+pub fn write_plugin_config(
+    worktree_path: &str,
+    worktree_name: &str,
+    hooks: Vec<NotificationHookEntry>,
+    marketplace_dir_path: &str,
+) -> Result<(), String> {
+    use std::path::Path;
+
+    let claude_dir = Path::new(worktree_path).join(".claude");
+    std::fs::create_dir_all(&claude_dir)
+        .map_err(|e| format!("Failed to create .claude dir: {}", e))?;
+
+    let settings_path = claude_dir.join("settings.local.json");
+    let mut json: serde_json::Value = if settings_path.exists() {
+        let content = std::fs::read_to_string(&settings_path)
+            .map_err(|e| format!("Failed to read settings.local.json: {}", e))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse settings.local.json: {}", e))?
+    } else {
+        serde_json::json!({})
+    };
+
+    let root = json
+        .as_object_mut()
+        .ok_or_else(|| "settings.local.json is not a JSON object".to_string())?;
+
+    // extraKnownMarketplaces に oretachi マーケットプレイスを追加
+    {
+        let marketplaces = root
+            .entry("extraKnownMarketplaces")
+            .or_insert_with(|| serde_json::json!({}));
+        if let Some(obj) = marketplaces.as_object_mut() {
+            obj.insert(
+                PLUGIN_NAME.to_string(),
+                serde_json::json!({
+                    "source": {
+                        "source": "directory",
+                        "path": marketplace_dir_path
+                    }
+                }),
+            );
+        }
+    }
+
+    // enabledPlugins に oretachi を追加
+    {
+        let enabled = root
+            .entry("enabledPlugins")
+            .or_insert_with(|| serde_json::json!({}));
+        if let Some(obj) = enabled.as_object_mut() {
+            obj.insert(PLUGIN_ID.to_string(), serde_json::Value::Bool(true));
+        }
+    }
+
+    // pluginConfigs に oretachi の設定を追加
+    {
+        let user_events: std::collections::HashMap<&str, &str> = hooks
+            .iter()
+            .map(|h| (h.event.as_str(), h.kind.as_str()))
+            .collect();
+
+        let mut options = serde_json::Map::new();
+        options.insert(
+            "worktree_name".to_string(),
+            serde_json::Value::String(worktree_name.to_string()),
+        );
+        for (event, key) in EVENT_CONFIG_KEYS {
+            let kind = user_events.get(event).copied().unwrap_or("hook");
+            options.insert(
+                key.to_string(),
+                serde_json::Value::String(kind.to_string()),
+            );
+        }
+
+        let plugin_configs = root
+            .entry("pluginConfigs")
+            .or_insert_with(|| serde_json::json!({}));
+        if let Some(obj) = plugin_configs.as_object_mut() {
+            obj.insert(
+                PLUGIN_ID.to_string(),
+                serde_json::json!({ "options": options }),
+            );
+        }
+    }
+
+    // マイグレーション: 旧形式の hooks キー内 oretachi フックを削除
+    migrate_remove_oretachi_hooks(&mut json);
+
+    let content = serde_json::to_string_pretty(&json)
+        .map_err(|e| format!("Failed to serialize settings.local.json: {}", e))?;
+    std::fs::write(&settings_path, content)
+        .map_err(|e| format!("Failed to write settings.local.json: {}", e))?;
+
+    Ok(())
+}
+
+/// 旧形式の hooks オブジェクト内から oretachi が注入したフックを削除する。
+/// oretachi フックの識別: --notify と --agent cc の両方を含むコマンド。
+/// 各イベント配列から oretachi フックを除き、空になったイベントキーは削除する。
+fn migrate_remove_oretachi_hooks(json: &mut serde_json::Value) {
+    let Some(hooks_val) = json.get_mut("hooks") else {
+        return;
+    };
+    let Some(hooks_obj) = hooks_val.as_object_mut() else {
+        return;
+    };
+
+    let events_to_check: Vec<String> = hooks_obj.keys().cloned().collect();
+    for event in events_to_check {
+        let Some(groups) = hooks_obj.get_mut(&event).and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+        // oretachi フックを含むグループを除去（--notify と --agent cc の組み合わせで識別）
+        groups.retain(|group| {
+            let has_oretachi = group
+                .get("hooks")
+                .and_then(|hs| hs.as_array())
+                .map_or(false, |hs| {
+                    hs.iter().any(|h| {
+                        h.get("command")
+                            .and_then(|c| c.as_str())
+                            .map_or(false, |c| c.contains("--notify") && c.contains("--agent cc"))
+                    })
+                });
+            !has_oretachi
+        });
+    }
+
+    // 空配列になったイベントキーを削除
+    hooks_obj.retain(|_, v| v.as_array().map_or(true, |arr| !arr.is_empty()));
+
+    // hooks オブジェクト自体が空になったら削除
+    if hooks_obj.is_empty() {
+        if let Some(obj) = json.as_object_mut() {
+            obj.remove("hooks");
+        }
+    }
+}

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -1,5 +1,4 @@
 use crate::process_utils::{kill_external_processes_in_dir, make_command};
-use crate::settings::NotificationHookEntry;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use serde::Serialize;
@@ -1184,110 +1183,6 @@ pub fn worktree_remove_persistent(
             std::thread::sleep(std::time::Duration::from_millis(200));
         }
     }
-}
-
-/// ワークツリーの `.claude/settings.local.json` に Claude Code 通知フックを書き込む
-pub fn write_claude_hooks(
-    worktree_path: &str,
-    worktree_name: &str,
-    hooks: Vec<NotificationHookEntry>,
-) -> Result<(), String> {
-    use std::path::Path;
-
-    let claude_dir = Path::new(worktree_path).join(".claude");
-    std::fs::create_dir_all(&claude_dir)
-        .map_err(|e| format!("Failed to create .claude dir: {}", e))?;
-
-    let settings_path = claude_dir.join("settings.local.json");
-
-    // 既存ファイルを読み込む（存在しなければ空オブジェクト）
-    let mut json: serde_json::Value = if settings_path.exists() {
-        let content = std::fs::read_to_string(&settings_path)
-            .map_err(|e| format!("Failed to read settings.local.json: {}", e))?;
-        serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse settings.local.json: {}", e))?
-    } else {
-        serde_json::json!({})
-    };
-
-    // oretachi.exe のパスを取得してforward slashに統一
-    let exe_path = std::env::current_exe()
-        .map(|p| p.to_string_lossy().replace('\\', "/"))
-        .unwrap_or_else(|_| "oretachi".to_string());
-
-    // oretachiが管理するイベント一覧（このリスト外は保持）
-    const MANAGED_EVENTS: &[&str] =
-        &["Stop", "Notification", "SubagentStop", "PreToolUse", "PostToolUse", "PermissionRequest"];
-
-    // 既存のhooksオブジェクトを取得し、oretachiが管理するeventキーのみ上書き（他は保持）
-    let mut hooks_obj = json
-        .get("hooks")
-        .and_then(|v| v.as_object().cloned())
-        .unwrap_or_default();
-
-    // ユーザー指定イベントを上書き
-    let user_events: std::collections::HashSet<&str> = hooks.iter().map(|h| h.event.as_str()).collect();
-    for entry in &hooks {
-        let command = format!(
-            "\"{}\" --notify \"{}\" --kind {}",
-            exe_path, worktree_name, entry.kind
-        );
-        let hook_entry = serde_json::json!([{
-            "matcher": "",
-            "hooks": [{ "type": "command", "command": command }]
-        }]);
-        hooks_obj.insert(entry.event.clone(), hook_entry);
-    }
-
-    // ユーザーが指定していない MANAGED_EVENTS は kind "hook" で自動注入（モニタリング用）
-    // 既存エントリがあれば oretachi のフックを追記（既に含まれていれば更新、ユーザー定義フックは保持）
-    for &ev in MANAGED_EVENTS {
-        if !user_events.contains(ev) {
-            let command = format!(
-                "\"{}\" --notify \"{}\" --kind hook --agent cc",
-                exe_path, worktree_name
-            );
-            let oretachi_group = serde_json::json!({
-                "matcher": "",
-                "hooks": [{ "type": "command", "command": command }]
-            });
-            if let Some(existing) = hooks_obj.get_mut(ev) {
-                if let Some(arr) = existing.as_array_mut() {
-                    // oretachi の --notify フックが既に含まれていれば最新コマンドで更新
-                    let mut found = false;
-                    for group in arr.iter_mut() {
-                        if let Some(hs) = group.get_mut("hooks").and_then(|h| h.as_array_mut()) {
-                            for h in hs.iter_mut() {
-                                if h.get("command")
-                                    .and_then(|c| c.as_str())
-                                    // oretachi が注入したフックの識別: --kind hook と --agent の組み合わせで特定
-                                    .map_or(false, |c| c.contains("--kind hook") && c.contains("--agent "))
-                                {
-                                    h["command"] = serde_json::Value::String(command.clone());
-                                    found = true;
-                                }
-                            }
-                        }
-                    }
-                    if !found {
-                        arr.push(oretachi_group);
-                    }
-                }
-                // else: 配列でない既存エントリは保持（上書きしない）
-            } else {
-                hooks_obj.insert(ev.to_string(), serde_json::json!([oretachi_group]));
-            }
-        }
-    }
-
-    json["hooks"] = serde_json::Value::Object(hooks_obj);
-
-    let content = serde_json::to_string_pretty(&json)
-        .map_err(|e| format!("Failed to serialize settings.local.json: {}", e))?;
-    std::fs::write(&settings_path, content)
-        .map_err(|e| format!("Failed to write settings.local.json: {}", e))?;
-
-    Ok(())
 }
 
 /// パスを Claude Code のプロジェクトディレクトリ名に変換する

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod ai_commit_message;
 mod ai_judge;
 mod ai_provider;
 mod archive_db;
+mod claude_plugin;
 mod fs_watcher;
 mod git_worktree;
 mod ide_launcher;
@@ -247,12 +248,19 @@ async fn copy_gitignore_targets(
 }
 
 #[tauri::command]
-async fn write_claude_hooks(
+async fn write_claude_plugin_config(
+    app_handle: tauri::AppHandle,
     worktree_path: String,
     worktree_name: String,
     hooks: Vec<crate::settings::NotificationHookEntry>,
 ) -> Result<(), String> {
-    run_git(move || git_worktree::write_claude_hooks(&worktree_path, &worktree_name, hooks)).await
+    let marketplace_dir = claude_plugin::marketplace_dir(&app_handle)?
+        .to_string_lossy()
+        .replace('\\', "/");
+    run_git(move || {
+        claude_plugin::write_plugin_config(&worktree_path, &worktree_name, hooks, &marketplace_dir)
+    })
+    .await
 }
 
 #[tauri::command]
@@ -774,7 +782,7 @@ pub fn run() {
             detect_package_manager,
             read_gitignore,
             copy_gitignore_targets,
-            write_claude_hooks,
+            write_claude_plugin_config,
             copy_claude_session_data,
             copy_working_changes,
             git_merge_branch,
@@ -911,6 +919,11 @@ pub fn run() {
             }
             let settings_manager = app.state::<SettingsManager>();
             settings_manager.init(app.handle());
+
+            // Claude Code プラグインファイルを生成・更新
+            if let Err(e) = claude_plugin::generate_plugin_files(app.handle()) {
+                log::warn!("[ClaudePlugin] Failed to generate plugin files: {}", e);
+            }
 
             // AIエージェントインジケーター用ポーリング起動
             let pty_manager = app.state::<PtyManager>();

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1154,19 +1154,25 @@ fn write_server_info_file(app_handle: &AppHandle, port: u16, api_key: &str) {
         .unwrap_or(true);
 
     // mcp-server.json を書き込む（ポート確定値 or キー更新のため常に更新）
+    // ポート上書き禁止かつ既存ファイルがある場合: ポートは既存値を使い、APIキーのみ更新
+    let effective_port = if !overwrite_port {
+        server_info_file_path(app_handle)
+            .and_then(|p| {
+                if p.exists() {
+                    fs::read_to_string(&p)
+                        .ok()
+                        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+                        .and_then(|v| v["port"].as_u64())
+                        .map(|n| n as u16)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(port)
+    } else {
+        port
+    };
     if let Some(path) = server_info_file_path(app_handle) {
-        // ポート上書き禁止かつ既存ファイルがある場合: ポートは既存値を使い、APIキーのみ更新
-        let effective_port = if !overwrite_port && path.exists() {
-            // 既存ファイルからポートを読み取る
-            fs::read_to_string(&path)
-                .ok()
-                .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
-                .and_then(|v| v["port"].as_u64())
-                .map(|p| p as u16)
-                .unwrap_or(port)
-        } else {
-            port
-        };
         if let Some(parent) = path.parent() {
             let _ = fs::create_dir_all(parent);
         }
@@ -1174,11 +1180,11 @@ fn write_server_info_file(app_handle: &AppHandle, port: u16, api_key: &str) {
         if let Err(e) = fs::write(&path, serde_json::to_string_pretty(&info).unwrap_or_default()) {
             log::warn!("Failed to write server info file: {}", e);
         }
+    }
 
-        // プラグインの .mcp.json も同じ値で更新
-        if let Err(e) = crate::claude_plugin::update_mcp_config(app_handle, effective_port, api_key) {
-            log::warn!("[ClaudePlugin] Failed to update .mcp.json: {}", e);
-        }
+    // プラグインの .mcp.json も同じ値で更新（app_data_dir 取得失敗時は plugin_dir.exists() で早期 return）
+    if let Err(e) = crate::claude_plugin::update_mcp_config(app_handle, effective_port, api_key) {
+        log::warn!("[ClaudePlugin] Failed to update .mcp.json: {}", e);
     }
 
     // 後方互換: 旧 mcp-port テキストファイルも書き込む

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1174,6 +1174,11 @@ fn write_server_info_file(app_handle: &AppHandle, port: u16, api_key: &str) {
         if let Err(e) = fs::write(&path, serde_json::to_string_pretty(&info).unwrap_or_default()) {
             log::warn!("Failed to write server info file: {}", e);
         }
+
+        // プラグインの .mcp.json も同じ値で更新
+        if let Err(e) = crate::claude_plugin::update_mcp_config(app_handle, effective_port, api_key) {
+            log::warn!("[ClaudePlugin] Failed to update .mcp.json: {}", e);
+        }
     }
 
     // 後方互換: 旧 mcp-port テキストファイルも書き込む

--- a/src/App.vue
+++ b/src/App.vue
@@ -571,10 +571,10 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
       }
     }
 
-    // Claude Code通知フックが設定されていれば settings.local.json を生成
+    // Claude Code プラグイン設定を settings.local.json に書き込む
     if (repo?.notificationHooks?.length) {
       try {
-        await invoke("write_claude_hooks", {
+        await invoke("write_claude_plugin_config", {
           worktreePath: entry.path,
           worktreeName: entry.name,
           hooks: repo.notificationHooks,

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -262,10 +262,10 @@ export function useTaskExecution(deps: {
         }
       }
 
-      // Claude Code通知フックが設定されていれば settings.local.json を生成
+      // Claude Code プラグイン設定を settings.local.json に書き込む
       if (repo.notificationHooks?.length) {
         try {
-          await invoke("write_claude_hooks", {
+          await invoke("write_claude_plugin_config", {
             worktreePath: entry.path,
             worktreeName: entry.name,
             hooks: repo.notificationHooks,


### PR DESCRIPTION
## Summary

- ワークツリー追加時の通知フック注入を、`settings.local.json` への直接書き込みからClaude Codeプラグインシステム経由に移行
- 新規 `claude_plugin.rs` にプラグイン生成ロジックを集約。アプリ起動時に `%APPDATA%/com.ia.oretachi/claude-plugins/oretachi/` へ `plugin.json` / `hooks.json` を生成し、MCP サーバー起動後に `.mcp.json` を更新
- ワークツリーの `.claude/settings.local.json` には `extraKnownMarketplaces` / `enabledPlugins` / `pluginConfigs` のみ書き込む。フック定義はプラグイン側で一元管理し、`${user_config.XXX}` でワークツリーごとの設定を注入
- 旧形式の `hooks` エントリが残っている場合はマイグレーションで自動削除

## Changes

- `src-tauri/src/claude_plugin.rs` — 新規追加
- `src-tauri/src/git_worktree.rs` — `write_claude_hooks()` を削除
- `src-tauri/src/lib.rs` — `write_claude_plugin_config` コマンドに置き換え、起動時にプラグイン生成を追加
- `src-tauri/src/mcp_server.rs` — MCP サーバー情報書き込み時に `.mcp.json` も更新
- `src/App.vue` / `src/composables/useTaskExecution.ts` — 新コマンドを使用

## Test plan

- [ ] `cargo check` / `pnpm run type-check` がエラーなしで通ること
- [ ] oretachi 起動後、`%APPDATA%/com.ia.oretachi/claude-plugins/oretachi/` 以下にプラグインファイルが生成されていること
- [ ] `plugin.json` の `env.ORETACHI_APP_PATH` が正しい exe パスであること
- [ ] `.mcp.json` のポートと apiKey が `mcp-server.json` と一致していること
- [ ] ワークツリー追加後、`.claude/settings.local.json` に `extraKnownMarketplaces` / `enabledPlugins` / `pluginConfigs` が書き込まれること
- [ ] `pluginConfigs` の kind 値がリポジトリの通知フック設定と一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)