### PR TITLE
feat: AIエージェントのセッションIDを特定してタブツールチップに表示

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,7 +86,11 @@ fn pty_set_ai_agent(
 ) -> Result<(), String> {
     state.set_ai_agent(session_id, is_agent)?;
     let mut sessions = std::collections::HashMap::new();
-    sessions.insert(session_id, is_agent);
+    sessions.insert(session_id, pty_manager::AiAgentInfo {
+        is_agent,
+        agent_name: None,
+        session_id: None,
+    });
     let _ = app_handle.emit("pty-ai-agent-changed", AiAgentChangedPayload { sessions });
     Ok(())
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -38,9 +38,19 @@ pub struct PtyExitPayload {
 }
 
 #[derive(serde::Serialize, Clone)]
+pub struct AiAgentInfo {
+    #[serde(rename = "isAgent")]
+    pub is_agent: bool,
+    #[serde(rename = "agentName")]
+    pub agent_name: Option<String>,
+    #[serde(rename = "sessionId")]
+    pub session_id: Option<String>,
+}
+
+#[derive(serde::Serialize, Clone)]
 pub struct AiAgentChangedPayload {
-    /// sessionId → isAiAgent のマップ
-    pub sessions: HashMap<u32, bool>,
+    /// pty_session_id → AiAgentInfo のマップ
+    pub sessions: HashMap<u32, AiAgentInfo>,
 }
 
 /// 全プロセス一覧を (pid, parent_pid, name) のリストで返す。
@@ -176,28 +186,43 @@ fn scan_all_processes() -> Vec<(u32, u32, String)> {
     }
 }
 
-/// 指定PIDのサブツリーにAIエージェントプロセスが含まれるか判定（最大depth段）
-fn has_ai_agent_in_subtree(
+/// 指定PIDのサブツリーからAIエージェントプロセスを探す（最大depth段）
+/// 見つかった場合は (agent_name, agent_pid) を返す
+fn find_ai_agent_in_subtree(
     root_pid: u32,
     children_map: &HashMap<u32, Vec<(u32, String)>>,
     depth: u32,
-) -> bool {
+) -> Option<(String, u32)> {
     if depth == 0 {
-        return false;
+        return None;
     }
     if let Some(children) = children_map.get(&root_pid) {
         for (child_pid, child_name) in children {
             let name_lower = child_name.to_lowercase();
             let name_stem = name_lower.trim_end_matches(".exe");
             if AI_AGENT_NAMES.iter().any(|&a| name_stem == a) {
-                return true;
+                return Some((name_stem.to_string(), *child_pid));
             }
-            if has_ai_agent_in_subtree(*child_pid, children_map, depth - 1) {
-                return true;
+            if let Some(found) = find_ai_agent_in_subtree(*child_pid, children_map, depth - 1) {
+                return Some(found);
             }
         }
     }
-    false
+    None
+}
+
+/// Claude Code の PID から ~/.claude/sessions/<pid>.json を読んでセッション UUID を返す
+fn get_claude_session_id_by_pid(pid: u32) -> Option<String> {
+    let home = std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .ok()?;
+    let session_file = std::path::Path::new(&home)
+        .join(".claude")
+        .join("sessions")
+        .join(format!("{}.json", pid));
+    let content = std::fs::read_to_string(&session_file).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+    v.get("sessionId")?.as_str().map(|s| s.to_string())
 }
 
 impl PtyManager {
@@ -236,7 +261,8 @@ impl PtyManager {
         let polling_alive = self.polling_alive.clone();
 
         std::thread::spawn(move || {
-            let mut last_status: HashMap<u32, bool> = HashMap::new();
+            // (is_agent, session_id) のペアで差分検出
+            let mut last_status: HashMap<u32, (bool, Option<String>)> = HashMap::new();
             loop {
                 std::thread::sleep(std::time::Duration::from_secs(10));
 
@@ -265,33 +291,57 @@ impl PtyManager {
                     children_map.entry(*ppid).or_default().push((*pid, name.clone()));
                 }
 
-                let mut current_status: HashMap<u32, bool> = HashMap::new();
-                let mut new_statuses = Vec::new();
+                // pty_session_id → AiAgentInfo のマップを構築
+                let mut current_status: HashMap<u32, (bool, Option<String>)> = HashMap::new();
+                let mut new_infos: Vec<(u32, bool, AiAgentInfo)> = Vec::new();
 
                 for (session_id, child_pid) in session_pids {
-                    let status = if let Some(pid) = child_pid {
-                        has_ai_agent_in_subtree(pid, &children_map, 4)
+                    let (is_agent, info) = if let Some(pid) = child_pid {
+                        match find_ai_agent_in_subtree(pid, &children_map, 4) {
+                            Some((agent_name, agent_pid)) => {
+                                let claude_session_id = if agent_name == "claude" {
+                                    get_claude_session_id_by_pid(agent_pid)
+                                } else {
+                                    None
+                                };
+                                (true, AiAgentInfo {
+                                    is_agent: true,
+                                    agent_name: Some(agent_name),
+                                    session_id: claude_session_id,
+                                })
+                            }
+                            None => (false, AiAgentInfo { is_agent: false, agent_name: None, session_id: None }),
+                        }
                     } else {
-                        false
+                        (false, AiAgentInfo { is_agent: false, agent_name: None, session_id: None })
                     };
-                    current_status.insert(session_id, status);
-                    new_statuses.push((session_id, status));
+                    let session_id_val = info.session_id.clone();
+                    current_status.insert(session_id, (is_agent, session_id_val));
+                    new_infos.push((session_id, is_agent, info));
                 }
 
                 // 内部状態を更新
                 if let Ok(mut sessions) = sessions_arc.lock() {
-                    for (id, status) in &new_statuses {
+                    for (id, is_agent, _) in &new_infos {
                         if let Some(session) = sessions.get_mut(id) {
-                            session.is_ai_agent = *status;
+                            session.is_ai_agent = *is_agent;
                         }
                     }
                 }
 
-                // 前回との差分を検出
-                let changed: HashMap<u32, bool> = current_status
-                    .iter()
-                    .filter(|(&id, &status)| last_status.get(&id) != Some(&status))
-                    .map(|(&id, &status)| (id, status))
+                // 前回との差分を検出（is_agent または session_id が変わった場合）
+                let changed: HashMap<u32, AiAgentInfo> = new_infos
+                    .into_iter()
+                    .filter(|(id, _, info)| {
+                        let prev = last_status.get(id);
+                        match prev {
+                            None => true,
+                            Some((prev_is, prev_sid)) => {
+                                *prev_is != info.is_agent || *prev_sid != info.session_id
+                            }
+                        }
+                    })
+                    .map(|(id, _, info)| (id, info))
                     .collect();
 
                 if !changed.is_empty() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -119,6 +119,9 @@ const terminalExitCodes = reactive(new Map<number, number>());
 // terminalId → AIエージェント稼働中フラグ
 const terminalAgentStatus = reactive(new Map<number, boolean>());
 
+// terminalId → AIエージェントセッション情報（タブツールチップ用）
+const terminalAiSessions = reactive(new Map<number, import("./types/terminal").AiSessionInfo>());
+
 // terminalId → Webセッション情報（claude --remote で起動したターミナル）
 const terminalWebSessions = reactive(new Map<number, import("./types/terminal").WebSessionInfo>());
 
@@ -144,6 +147,7 @@ const {
   terminalExitCodes,
   terminalAgentStatus,
   terminalWebSessions,
+  terminalAiSessions,
   removeTerminal,
   clearNotification,
 });
@@ -990,11 +994,14 @@ onMounted(async () => {
     subWindowEvents.subWindowFocusMap.set(worktreeId, true);
     const initData = getPendingInitData(worktreeId);
     if (initData) {
-      // このワークツリーに属するターミナルのWebセッション情報を収集
+      // このワークツリーに属するターミナルのWebセッション情報とAIセッション情報を収集
       const webSessions: Record<number, import("./types/terminal").WebSessionInfo> = {};
+      const aiSessions: Record<number, import("./types/terminal").AiSessionInfo> = {};
       for (const t of initData.terminals) {
-        const info = terminalWebSessions.get(t.id);
-        if (info) webSessions[t.id] = info;
+        const webInfo = terminalWebSessions.get(t.id);
+        if (webInfo) webSessions[t.id] = webInfo;
+        const aiInfo = terminalAiSessions.get(t.id);
+        if (aiInfo) aiSessions[t.id] = aiInfo;
       }
       await emitTo(`sub-${worktreeId}`, "sub-init", {
         worktreeId,
@@ -1003,6 +1010,7 @@ onMounted(async () => {
         autoApprovalPrompt: initData.autoApprovalPrompt,
         layout: initData.layout,
         webSessions,
+        aiSessions,
       });
       clearPendingInitData(worktreeId);
     }
@@ -1096,9 +1104,9 @@ onMounted(async () => {
   // サブウィンドウイベントリスナーを初期化
   await subWindowEvents.init();
 
-  // AIエージェントインジケーター: pty-ai-agent-changed を受信して terminalAgentStatus を更新
-  await listen<{ sessions: Record<number, boolean> }>("pty-ai-agent-changed", (event) => {
-    // sessionId → terminalId の逆引きマップを構築
+  // AIエージェントインジケーター: pty-ai-agent-changed を受信して terminalAgentStatus / terminalAiSessions を更新
+  await listen<{ sessions: Record<number, { isAgent: boolean; agentName?: string; sessionId?: string }> }>("pty-ai-agent-changed", (event) => {
+    // pty sessionId → terminalId の逆引きマップを構築
     const sessionToTerminal = new Map<number, number>();
     for (const [, bundle] of worktreeFrameBundles) {
       for (const [tid, termRef] of bundle.terminalRefs) {
@@ -1106,14 +1114,24 @@ onMounted(async () => {
         if (sid != null) sessionToTerminal.set(sid, tid);
       }
     }
-    for (const [sessionIdStr, isAgent] of Object.entries(event.payload.sessions)) {
+    for (const [sessionIdStr, info] of Object.entries(event.payload.sessions)) {
       const sid = Number(sessionIdStr);
       const tid = sessionToTerminal.get(sid);
       if (tid != null) {
-        if (isAgent) {
+        if (info.isAgent) {
           terminalAgentStatus.set(tid, true);
+          if (info.sessionId && info.agentName) {
+            const aiInfo = { agentType: info.agentName, sessionId: info.sessionId };
+            terminalAiSessions.set(tid, aiInfo);
+            // サブウィンドウに移動済みの場合は同期イベントを送る
+            const worktreeId = terminalWorktreeMap.get(tid);
+            if (worktreeId && isDetached(worktreeId)) {
+              emitTo(`sub-${worktreeId}`, "sub-ai-session", { terminalId: tid, info: aiInfo });
+            }
+          }
         } else {
           terminalAgentStatus.delete(tid);
+          terminalAiSessions.delete(tid);
         }
       }
     }
@@ -1457,6 +1475,7 @@ onMounted(async () => {
               :terminal-exit-codes="terminalExitCodes"
               :terminal-agent-status="terminalAgentStatus"
               :terminal-web-sessions="terminalWebSessions"
+              :terminal-ai-sessions="terminalAiSessions"
               @switch-terminal="(leafId, tid) => onFrameSwitch(wt.id, leafId, tid)"
               @close-terminal="(leafId, tid) => onFrameClose(wt.id, leafId, tid)"
               @tab-drop="(sl, tid, tl, idx) => onFrameTabDrop(wt.id, sl, tid, tl, idx)"

--- a/src/SubWindowApp.vue
+++ b/src/SubWindowApp.vue
@@ -21,7 +21,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { debug } from "@tauri-apps/plugin-log";
 import IdeSelectDialog from "./components/IdeSelectDialog.vue";
 import AutoApprovalPromptDialog from "./components/AutoApprovalPromptDialog.vue";
-import type { SubTerminalEntry, WebSessionInfo } from "./types/terminal";
+import type { SubTerminalEntry, WebSessionInfo, AiSessionInfo } from "./types/terminal";
 import type { FrameNode } from "./types/frame";
 import { useI18n } from "vue-i18n";
 import { useWorktreeTaskMap } from "./composables/useWorktreeTaskMap";
@@ -49,6 +49,9 @@ const terminalAgentStatus = reactive(new Map<number, boolean>());
 
 // terminalId → Webセッション情報
 const terminalWebSessions = reactive(new Map<number, WebSessionInfo>());
+
+// terminalId → AIエージェントセッション情報（タブツールチップ用）
+const terminalAiSessions = reactive(new Map<number, AiSessionInfo>());
 
 // 自動承認フラグ
 const autoApproval = ref(false);
@@ -127,6 +130,7 @@ const {
     terminalExitCodes.delete(terminalId);
     terminalAgentStatus.delete(terminalId);
     terminalWebSessions.delete(terminalId);
+    terminalAiSessions.delete(terminalId);
     await emitTo("main", "sub-remove-terminal", { worktreeId, terminalId });
   },
 });
@@ -230,19 +234,23 @@ onMounted(async () => {
   }));
 
   // AIエージェントインジケーター: sessionId → terminalId に変換して terminalAgentStatus を更新
-  collect(await listen<{ sessions: Record<number, boolean> }>("pty-ai-agent-changed", (event) => {
+  collect(await listen<{ sessions: Record<number, { isAgent: boolean; agentName?: string; sessionId?: string }> }>("pty-ai-agent-changed", (event) => {
     const sessionToTerminal = new Map<number, number>();
     for (const [tid, entry] of terminalEntries) {
       if (entry.sessionId) sessionToTerminal.set(entry.sessionId, tid);
     }
-    for (const [sessionIdStr, isAgent] of Object.entries(event.payload.sessions)) {
+    for (const [sessionIdStr, info] of Object.entries(event.payload.sessions)) {
       const sid = Number(sessionIdStr);
       const tid = sessionToTerminal.get(sid);
       if (tid != null) {
-        if (isAgent) {
+        if (info.isAgent) {
           terminalAgentStatus.set(tid, true);
+          if (info.sessionId && info.agentName) {
+            terminalAiSessions.set(tid, { agentType: info.agentName, sessionId: info.sessionId });
+          }
         } else {
           terminalAgentStatus.delete(tid);
+          terminalAiSessions.delete(tid);
         }
       }
     }
@@ -251,6 +259,11 @@ onMounted(async () => {
   // メインウィンドウからのWebセッション情報を受信
   collect(await listen<{ terminalId: number; info: WebSessionInfo }>("sub-web-session", (event) => {
     terminalWebSessions.set(event.payload.terminalId, event.payload.info);
+  }));
+
+  // メインウィンドウからのAIセッション情報を受信
+  collect(await listen<{ terminalId: number; info: AiSessionInfo }>("sub-ai-session", (event) => {
+    terminalAiSessions.set(event.payload.terminalId, event.payload.info);
   }));
 
   const appWindow = getCurrentWindow();
@@ -263,6 +276,7 @@ onMounted(async () => {
     autoApprovalPrompt?: string;
     layout?: FrameNode;
     webSessions?: Record<number, WebSessionInfo>;
+    aiSessions?: Record<number, AiSessionInfo>;
   }>(
     "sub-init",
     async (event) => {
@@ -281,6 +295,12 @@ onMounted(async () => {
       if (event.payload.webSessions) {
         for (const [idStr, info] of Object.entries(event.payload.webSessions)) {
           terminalWebSessions.set(Number(idStr), info);
+        }
+      }
+
+      if (event.payload.aiSessions) {
+        for (const [idStr, info] of Object.entries(event.payload.aiSessions)) {
+          terminalAiSessions.set(Number(idStr), info);
         }
       }
 
@@ -550,6 +570,7 @@ async function onCancelAiJudging() {
           :terminal-exit-codes="terminalExitCodes"
           :terminal-agent-status="terminalAgentStatus"
           :terminal-web-sessions="terminalWebSessions"
+          :terminal-ai-sessions="terminalAiSessions"
           @switch-terminal="switchTerminal"
           @close-terminal="closeTerminal"
           @title-change="onTerminalTitleChange"

--- a/src/components/FrameContainer.vue
+++ b/src/components/FrameContainer.vue
@@ -4,7 +4,7 @@ import Splitter from "primevue/splitter";
 import SplitterPanel from "primevue/splitterpanel";
 import FramePane from "./FramePane.vue";
 import type { FrameNode, FrameLeaf } from "../types/frame";
-import type { SubTerminalEntry, WebSessionInfo } from "../types/terminal";
+import type { SubTerminalEntry, WebSessionInfo, AiSessionInfo } from "../types/terminal";
 
 const props = defineProps<{
   node: FrameNode;
@@ -12,6 +12,7 @@ const props = defineProps<{
   terminalExitCodes?: Map<number, number>;
   terminalAgentStatus?: Map<number, boolean>;
   terminalWebSessions?: Map<number, WebSessionInfo>;
+  terminalAiSessions?: Map<number, AiSessionInfo>;
 }>();
 
 const emit = defineEmits<{
@@ -50,6 +51,7 @@ function onResizeEnd(event: { sizes: number[] }) {
     :terminal-exit-codes="terminalExitCodes"
     :terminal-agent-status="terminalAgentStatus"
     :terminal-web-sessions="terminalWebSessions"
+    :terminal-ai-sessions="terminalAiSessions"
     @switch-terminal="(leafId, terminalId) => emit('switchTerminal', leafId, terminalId)"
     @close-terminal="(leafId, terminalId) => emit('closeTerminal', leafId, terminalId)"
     @title-change="(terminalId, title) => emit('titleChange', terminalId, title)"
@@ -83,6 +85,7 @@ function onResizeEnd(event: { sizes: number[] }) {
         :terminal-exit-codes="terminalExitCodes"
         :terminal-agent-status="terminalAgentStatus"
         :terminal-web-sessions="terminalWebSessions"
+        :terminal-ai-sessions="terminalAiSessions"
         @switch-terminal="(leafId, terminalId) => emit('switchTerminal', leafId, terminalId)"
         @close-terminal="(leafId, terminalId) => emit('closeTerminal', leafId, terminalId)"
         @title-change="(terminalId, title) => emit('titleChange', terminalId, title)"

--- a/src/components/FramePane.vue
+++ b/src/components/FramePane.vue
@@ -10,7 +10,7 @@ import { ref, computed } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { FrameLeaf } from "../types/frame";
-import type { SubTerminalEntry, WebSessionInfo } from "../types/terminal";
+import type { SubTerminalEntry, WebSessionInfo, AiSessionInfo } from "../types/terminal";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
@@ -30,6 +30,7 @@ const props = defineProps<{
   terminalExitCodes?: Map<number, number>;
   terminalAgentStatus?: Map<number, boolean>;
   terminalWebSessions?: Map<number, WebSessionInfo>;
+  terminalAiSessions?: Map<number, AiSessionInfo>;
 }>();
 
 const emit = defineEmits<{
@@ -42,6 +43,14 @@ const emit = defineEmits<{
   tabReorder: [leafId: string, terminalId: number, insertIndex: number];
   requestAddTerminal: [leafId: string];
 }>();
+
+// タブボタンのツールチップ文字列を生成する
+function tabTooltip(tid: number): string {
+  const title = props.terminalEntries.get(tid)?.title ?? `Terminal ${tid}`;
+  const session = props.terminalAiSessions?.get(tid);
+  if (session) return `${title}\nSession: ${session.sessionId}`;
+  return title;
+}
 
 // アクティブターミナルのWebセッション情報
 const activeWebSession = computed(() => {
@@ -247,6 +256,7 @@ function overlayStyle(zone: DropZone): Record<string, string> {
           :key="tid"
           class="tab-button"
           :class="tid === leaf.activeTerminalId ? 'tab-active' : 'tab-inactive'"
+          :title="tabTooltip(tid)"
           draggable="true"
           @dragstart="onTabDragStart($event, tid)"
           @dragend="onTabDragEnd"

--- a/src/composables/useWorktreeFrameBundles.ts
+++ b/src/composables/useWorktreeFrameBundles.ts
@@ -1,7 +1,7 @@
 import { ref, reactive, shallowReactive, nextTick } from "vue";
 import type { Ref } from "vue";
 import { useWorktreeFrame } from "./useWorktreeFrame";
-import type { SubTerminalEntry, WebSessionInfo } from "../types/terminal";
+import type { SubTerminalEntry, WebSessionInfo, AiSessionInfo } from "../types/terminal";
 import type { Worktree } from "../types/worktree";
 import type { FrameNode } from "../types/frame";
 import type TerminalView from "../components/TerminalView.vue";
@@ -23,6 +23,7 @@ export function useWorktreeFrameBundles(options: {
   terminalExitCodes: Map<number, number>;
   terminalAgentStatus: Map<number, boolean>;
   terminalWebSessions: Map<number, WebSessionInfo>;
+  terminalAiSessions: Map<number, AiSessionInfo>;
   removeTerminal: (worktreeId: string, terminalId: number) => void;
   clearNotification: (worktreeId: string) => void;
 }) {
@@ -33,6 +34,7 @@ export function useWorktreeFrameBundles(options: {
     terminalExitCodes,
     terminalAgentStatus,
     terminalWebSessions,
+    terminalAiSessions,
     removeTerminal,
     clearNotification,
   } = options;
@@ -53,6 +55,7 @@ export function useWorktreeFrameBundles(options: {
         terminalExitCodes.delete(terminalId);
         terminalAgentStatus.delete(terminalId);
         terminalWebSessions.delete(terminalId);
+        terminalAiSessions.delete(terminalId);
         removeTerminal(worktreeId, terminalId);
       },
     });

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -1,3 +1,9 @@
+/** AIエージェントのセッション情報（ターミナルタブのツールチップ表示用） */
+export interface AiSessionInfo {
+  agentType: string;   // "claude" | "gemini" | "codex" | "cline"
+  sessionId: string;   // UUID e.g. "5e0560f8-8a52-4070-828a-a3ce48cf216c"
+}
+
 /** Webセッション（claude --remote）の情報 */
 export interface WebSessionInfo {
   url: string;         // https://claude.ai/code/session_...?m=0


### PR DESCRIPTION
## Summary

- Rust側のプロセススキャンを拡張し、AIエージェントのPIDを検出して `~/.claude/sessions/<pid>.json` からセッションIDを読み取る
- `AiAgentInfo` 構造体に `agent_name` / `session_id` フィールドを追加し、既存の `is_ai_agent: bool` の通知に統合
- フロントエンドで `terminalAiSessions: Map<number, AiSessionInfo>` を管理し、ターミナルタブのホバー時にセッションIDをツールチップ表示
- 同一ワークツリーに複数のAIエージェントが起動している場合もPID単位で確実に区別可能

## Test plan

- [ ] `cargo check` 通過
- [ ] `pnpm run type-check` 通過
- [ ] `pnpm run tauri dev` 起動 → Claude Code 起動 → 10秒以内にタブホバーで `タイトル\nSession: UUID` 表示
- [ ] 同一ワークツリーで2ターミナルにそれぞれClaude Codeを起動 → 異なるセッションIDが表示される
- [ ] エージェント終了後、ツールチップからセッション情報が消える
- [ ] サブウィンドウに移動してもセッションIDが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)