### PR TITLE
fix: prevent WebView freeze by filtering hook notifications from webview

### DIFF
--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -59,6 +59,8 @@ pub struct McpServerManager {
     added_listener_id: Mutex<Option<tauri::EventId>>,
     /// notify-worktree リスナーID（再起動時にアンリジスターするために保持）
     notify_listener_id: Mutex<Option<tauri::EventId>>,
+    /// notify-worktree-mcp リスナーID（hook専用内部イベント、再起動時にアンリジスターするために保持）
+    hook_notify_listener_id: Mutex<Option<tauri::EventId>>,
 }
 
 impl McpServerManager {
@@ -72,6 +74,7 @@ impl McpServerManager {
             archive_listener_id: Mutex::new(None),
             added_listener_id: Mutex::new(None),
             notify_listener_id: Mutex::new(None),
+            hook_notify_listener_id: Mutex::new(None),
         }
     }
 
@@ -683,8 +686,11 @@ impl NotifyService {
             body,
             agent: None,
         };
+        // hook イベントはフロントエンドの両リスナーでフィルタされるため WebView には送らない。
+        // 内部専用イベント名でブロードキャストリスナーのみに届ける。
+        let event_name = if event.kind == "hook" { "notify-worktree-mcp" } else { "notify-worktree" };
         self.app_handle
-            .emit("notify-worktree", &event)
+            .emit(event_name, &event)
             .map_err(|e: tauri::Error| McpError::internal_error(e.to_string(), None))?;
         log::info!("[mcp] notify_worktree: {} kind={}", worktree_name, event.kind);
         Ok(CallToolResult::success(vec![Content::text("ok")]))
@@ -969,13 +975,15 @@ async fn notify_handler(
         body: payload.body,
         agent: payload.agent,
     };
-    match app_handle.emit("notify-worktree", &event) {
+    // hook イベントはフロントエンドの両リスナーでフィルタされるため WebView には送らない。
+    let event_name = if event.kind == "hook" { "notify-worktree-mcp" } else { "notify-worktree" };
+    match app_handle.emit(event_name, &event) {
         Ok(_) => {
             log::info!("[notify] worktree={} kind={}", payload.worktree, event.kind);
             StatusCode::OK
         }
         Err(e) => {
-            log::error!("Failed to emit notify-worktree: {}", e);
+            log::error!("Failed to emit {}: {}", event_name, e);
             StatusCode::INTERNAL_SERVER_ERROR
         }
     }
@@ -1264,6 +1272,11 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
             app_handle.unlisten(old_id);
         }
     }
+    if let Ok(mut guard) = manager.hook_notify_listener_id.lock() {
+        if let Some(old_id) = guard.take() {
+            app_handle.unlisten(old_id);
+        }
+    }
 
     drop(manager);
 
@@ -1339,6 +1352,25 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
     let manager = app_handle.state::<McpServerManager>();
     if let Ok(mut guard) = manager.notify_listener_id.lock() {
         *guard = Some(notify_listener_id);
+    }
+    drop(manager);
+
+    // hook 専用の内部イベント（WebView をスキップして MCP ピアにのみブロードキャスト）
+    let peer_map_for_hook_listener = peer_map.clone();
+    let timeout_counts_for_hook_listener = timeout_counts.clone();
+    let hook_notify_listener_id = app_handle.listen("notify-worktree-mcp", move |event: tauri::Event| {
+        let registry = peer_map_for_hook_listener.clone();
+        let tc = timeout_counts_for_hook_listener.clone();
+        if let Ok(payload) = serde_json::from_str::<NotifyWorktreeEvent>(event.payload()) {
+            tauri::async_runtime::spawn(async move {
+                broadcast_notify_worktree(&registry, &tc, &payload).await;
+            });
+        }
+    });
+
+    let manager = app_handle.state::<McpServerManager>();
+    if let Ok(mut guard) = manager.hook_notify_listener_id.lock() {
+        *guard = Some(hook_notify_listener_id);
     }
     drop(manager);
 

--- a/src/composables/useAppAutoApproval.ts
+++ b/src/composables/useAppAutoApproval.ts
@@ -69,30 +69,32 @@ export function useAppAutoApproval(deps: UseAppAutoApprovalDeps) {
     // notify-worktree → 自動承認チェック
     await listen<{ worktree_name: string; kind: string }>("notify-worktree", async (event) => {
       const { worktree_name: worktreeName, kind } = event.payload;
-      const wt = deps.worktrees.value.find((w) => w.name === worktreeName);
 
-      await debug(
-        `[AutoApproval] notify-worktree received worktreeName=${worktreeName} resolved=${wt?.id ?? "null"} autoApproval=${wt ? autoApprovalMap.get(wt.id) : "undefined"}`
-      );
-
-      if (!wt) return;
+      // hook/completed はこのリスナーでは不要。フィルタをすべての async 処理の前に置く
       if (kind === "completed" || kind === "hook") return;
+
+      const wt = deps.worktrees.value.find((w) => w.name === worktreeName);
+      if (!wt) return;
       if (!autoApprovalMap.get(wt.id)) return;
 
+      debug(
+        `[AutoApproval] notify-worktree received worktreeName=${worktreeName} resolved=${wt.id} autoApproval=true`
+      );
+
       if (aiJudgingWorktrees.has(wt.id)) {
-        await debug(`[AutoApproval] already in progress for ${wt.id}, skipping`);
+        debug(`[AutoApproval] already in progress for ${wt.id}, skipping`);
         return;
       }
 
       if (deps.isDetached(wt.id)) {
-        await debug(`[AutoApproval] delegating to sub-window ${wt.id}`);
+        debug(`[AutoApproval] delegating to sub-window ${wt.id}`);
         await emitTo(`sub-${wt.id}`, "sub-try-auto-approve", {
           additionalPrompt: deps.autoApprovalPromptMap.get(wt.id) ?? "",
         });
         return;
       }
 
-      await debug(`[AutoApproval] local terminals check, count=${wt.terminals.length}`);
+      debug(`[AutoApproval] local terminals check, count=${wt.terminals.length}`);
       aiJudgingWorktrees.add(wt.id);
       let loopResult: { approved: boolean; lastCommand: string | undefined };
       try {


### PR DESCRIPTION
## Summary

- `kind=hook` の notify-worktree イベントを WebView に送信しないよう変更（Rust 側で内部イベント `notify-worktree-mcp` にルーティング）
- `useAppAutoApproval.ts` のホットパスで `await debug()` IPC 往復をブロッキングしていた問題を修正

## 背景・原因

2026-04-13 に 2 回のフリーズ→クラッシュが発生。ログ分析の結果、**`notify-worktree` イベントの大量送信による WebView2 イベントループの飽和**が原因と特定。

- 1 セッションで **807 件の hook 通知** が発生（6 ワークツリー同時稼働）
- 各 hook 通知につき `useAppAutoApproval.ts` が `await debug()`（Rust への IPC 往復）を実行してからフィルタ → microtask キューが飽和
- WebView が応答停止し、10〜15 分後に Rust バックエンドごとクラッシュ（`on_before_exit` 未発火）

## 変更内容

### `src-tauri/src/mcp_server.rs`
- `kind == "hook"` のイベントは `"notify-worktree-mcp"` 内部専用イベントで emit
- `"notify-worktree-mcp"` を受信する Rust リスナーを追加し、MCP ピアへのブロードキャストは従来通り実施
- `McpServerManager` に `hook_notify_listener_id` フィールドを追加し、再起動時に正しく unlisten

### `src/composables/useAppAutoApproval.ts`
- `kind === "hook" / "completed"` フィルタを `await debug()` より前に移動
- `debug()` を fire-and-forget 化してホットパスの IPC ブロッキングを排除

## 効果

| 指標 | 修正前 | 修正後 |
|---|---|---|
| WebView が受信する hook 通知 | 807 件/セッション | **0 件** |
| hook 通知あたりの IPC 往復 | 2 回 | 0 回 |

MCP クライアント（claude-code 等）への hook 通知ブロードキャストは変わらず届きます。

## Test plan

- [ ] `cargo check` 通過
- [ ] `pnpm run type-check` 通過
- [ ] `kind=approval` / `completed` / `general` の通知がフロントエンドに届くこと
- [ ] `kind=hook` の通知が MCP クライアントに届くこと（WebView ログに出力されないこと）
- [ ] 複数ワークツリー同時稼働時にフリーズが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)