### PR TITLE
feat: bundle Claude skills into oretachi plugin

### DIFF
--- a/src-tauri/skills/domain-model-diagram/SKILL.md
+++ b/src-tauri/skills/domain-model-diagram/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: domain-model-diagram
+description: インタラクティブな React ドメインモデル図アーティファクトを作成する。グリッド/フォーカス2モードビュー、パン/ズーム、カテゴリ色分け対応。
+allowed-tools: mcp__plugin_oretachi_oretachi__artifact, mcp__plugin_oretachi_oretachi__artifact_module, mcp__plugin_oretachi_oretachi__search_artifact, Read, Bash(git branch:*)
+---
+
+# domain-model-diagram スキル
+
+インタラクティブな React ドメインモデル図アーティファクトをテンプレートから作成する。
+
+**機能:**
+- グリッドビュー（全エンティティ俯瞰 + パン/ズーム）
+- フォーカスビュー（エンティティクリックでラジアル配置 + リレーションラベル表示）
+- CSS トランジション付きのスムーズな切り替え
+- カテゴリ別色分け凡例
+
+## 引数
+
+```
+$ARGUMENTS: <artifact-id> [--repo <repo>] [--branch <branch>]
+```
+
+- `artifact-id`（必須）: 作成するアーティファクトID（例: `my-service-diagram`）
+- `--repo`（省略時: `oretachi`）: リポジトリ名
+- `--branch`（省略時: `git branch --show-current`）: ブランチ名
+
+## ワークフロー
+
+### Step 1: パラメータ確定
+
+引数を解析する。`--branch` が省略された場合は `git branch --show-current` で現在ブランチを取得。
+
+### Step 2: テンプレートを読み込む
+
+このスキルディレクトリ（`SKILL.md` と同じ場所）の `templates/` フォルダにある以下のファイルを Read で読み込む:
+
+| ファイル | アーティファクトモジュール | カスタマイズ要否 |
+|---|---|---|
+| `templates/entry-point.jsx` | エントリポイント（content）| `// CUSTOMIZE:` コメント箇所のみ変更 |
+| `templates/components--EntityBox.jsx` | `components/EntityBox` | `CATEGORY_COLORS`, `LAYER_LABELS` を変更 |
+| `templates/components--RelationshipLine.jsx` | `components/RelationshipLine` | そのまま利用 |
+| `templates/data--entities.example.jsx` | ※スキーマ参照用 | 新規生成 |
+| `templates/data--relationships.example.jsx` | ※スキーマ参照用 | 新規生成 |
+
+### Step 3: ドメイン分析
+
+対象コードベースを調査 or ユーザーヒアリングで以下を特定する:
+- エンティティ一覧（名前・フィールド）
+- エンティティ間のリレーション（方向・カーディナリティ・ラベル）
+- カテゴリ/レイヤー（3〜6 分類を推奨）
+
+### Step 4: カテゴリ定義
+
+カテゴリごとに Catppuccin Mocha パレットから背景色を選ぶ。
+`templates/components--EntityBox.jsx` の `CATEGORY_COLORS` / `LAYER_LABELS` 形式に合わせて定義する。
+
+**Catppuccin Mocha パレット（推奨色）:**
+| 色名 | hex | 推奨用途 |
+|---|---|---|
+| red | `#f38ba8` | ドメイン層・コア |
+| peach | `#fab387` | ユースケース層 |
+| blue | `#89b4fa` | インフラ層・外部依存 |
+| green | `#a6e3a1` | プレゼンテーション層・UI |
+| yellow | `#f9e2af` | 設定・設定値 |
+| mauve | `#cba6f7` | 共通・ユーティリティ |
+| teal | `#94e2d5` | イベント・メッセージ |
+| sky | `#89dceb` | クライアント・外部API |
+
+テキスト色は常に `#1e1e2e`（暗背景上でのコントラスト確保）。
+
+### Step 5: レイアウト計算
+
+グリッド座標を割り当てる。
+
+**ガイドライン:**
+- 列の開始 x: 40, 320, 600, 880, 1160, 1440, ...（列幅 280px）
+- 行の高さ見積もり: `26 + fieldCount * 19 + 50` px（次のエンティティのy座標算出に使用）
+- カテゴリ同士を空間的にまとめる（関連するカテゴリは隣接列に配置）
+- 接続数の多いエンティティはキャンバス中央付近に配置（フォーカスビューの可読性向上）
+- `CANVAS_W` = 全エンティティの最大 x + BOX_WIDTH + 40（マージン）
+- `CANVAS_H` = 全エンティティの最大 y + 最大高さ + 40（マージン）
+
+### Step 6: アーティファクト作成
+
+以下の順序で MCP ツールを呼び出す:
+
+**1. エントリポイント作成**
+```
+artifact(command: "create", id: "<artifact-id>", type: "application/vnd.ant.react",
+  title: "<ダイアグラムタイトル>",
+  content: <entry-point.jsx の内容。CANVAS_W/H・タイトル・zoom を調整>)
+```
+
+**2. EntityBox モジュール作成**
+```
+artifact_module(command: "create", module_name: "components/EntityBox",
+  content: <components--EntityBox.jsx の内容。CATEGORY_COLORS/LAYER_LABELS をドメインに合わせて変更>)
+```
+
+**3. RelationshipLine モジュール作成**
+```
+artifact_module(command: "create", module_name: "components/RelationshipLine",
+  content: <components--RelationshipLine.jsx をそのまま>)
+```
+
+**4. entities モジュール作成**
+```
+artifact_module(command: "create", module_name: "data/entities",
+  content: <Step 3〜5 で定義したエンティティ配列>)
+```
+
+**5. relationships モジュール作成**
+```
+artifact_module(command: "create", module_name: "data/relationships",
+  content: <Step 3 で定義したリレーション配列>)
+```
+
+### Step 7: 検証
+
+```
+artifact(command: "outline")
+```
+
+で構造確認。エントリポイント + 4 モジュール（`components/EntityBox`, `components/RelationshipLine`, `data/entities`, `data/relationships`）が揃っていれば完了。
+
+## テンプレートファイルの位置
+
+このスキルファイル（`SKILL.md`）と同じディレクトリの `templates/` フォルダを Read で参照:
+- `templates/entry-point.jsx`
+- `templates/components--EntityBox.jsx`
+- `templates/components--RelationshipLine.jsx`
+- `templates/data--entities.example.jsx`（スキーマ確認用）
+- `templates/data--relationships.example.jsx`（スキーマ確認用）

--- a/src-tauri/skills/domain-model-diagram/templates/components--EntityBox.jsx
+++ b/src-tauri/skills/domain-model-diagram/templates/components--EntityBox.jsx
@@ -1,0 +1,89 @@
+
+// CUSTOMIZE: カテゴリ名とカラーをドメインに合わせて定義
+// キー名はエンティティの category フィールドに対応する
+// bg: Catppuccin Mocha パレットから選択（red:#f38ba8 peach:#fab387 blue:#89b4fa green:#a6e3a1
+//     yellow:#f9e2af mauve:#cba6f7 teal:#94e2d5 sky:#89dceb）
+// text: 常に #1e1e2e（暗背景上でのコントラスト確保）
+const CATEGORY_COLORS = {
+  domain:         { bg: '#f38ba8', text: '#1e1e2e' }, // red   — ドメイン層
+  usecase:        { bg: '#fab387', text: '#1e1e2e' }, // peach — ユースケース層
+  infrastructure: { bg: '#89b4fa', text: '#1e1e2e' }, // blue  — インフラ層
+  presentation:   { bg: '#a6e3a1', text: '#1e1e2e' }, // green — プレゼンテーション層
+};
+
+// CUSTOMIZE: 凡例に表示する人間向けラベル（日本語可）
+// キーは CATEGORY_COLORS のキーと一致させる
+const LAYER_LABELS = {
+  domain:         'Domain ドメイン層',
+  usecase:        'Use Case ユースケース層',
+  infrastructure: 'Infrastructure インフラ層',
+  presentation:   'Presentation プレゼンテーション層',
+};
+
+function EntityBox({ entity, selected, highlighted, dimmed, onClick, x, y }) {
+  const color = CATEGORY_COLORS[entity.category] || { bg: '#cdd6f4', text: '#1e1e2e' };
+  const active = selected || highlighted;
+  const posX = x !== undefined ? x : entity.x;
+  const posY = y !== undefined ? y : entity.y;
+
+  return (
+    <div
+      onClick={() => onClick(entity.id)}
+      style={{
+        position: 'absolute',
+        left: posX,
+        top: posY,
+        width: 220,
+        background: '#1e1e2e',
+        border: `2px solid ${active ? color.bg : '#313244'}`,
+        borderRadius: 7,
+        overflow: 'hidden',
+        cursor: 'pointer',
+        boxShadow: selected
+          ? `0 0 16px ${color.bg}88`
+          : highlighted
+          ? `0 0 8px ${color.bg}55`
+          : '0 2px 6px rgba(0,0,0,0.5)',
+        transition: 'left 0.4s ease, top 0.4s ease, opacity 0.35s ease, border-color 0.12s, box-shadow 0.12s',
+        zIndex: selected ? 20 : highlighted ? 10 : 1,
+        userSelect: 'none',
+        opacity: dimmed ? 0.3 : 1,
+      }}
+    >
+      <div style={{
+        background: color.bg,
+        color: color.text,
+        padding: '5px 10px',
+        fontSize: 11,
+        fontWeight: 700,
+        fontFamily: 'system-ui, sans-serif',
+        letterSpacing: '0.01em',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}>
+        {entity.name}
+      </div>
+      <div style={{ padding: '3px 0 4px' }}>
+        {entity.fields.map((field, i) => (
+          <div key={i} style={{
+            padding: '2px 9px',
+            fontSize: 10,
+            fontFamily: 'monospace',
+            color: '#a6adc8',
+            borderTop: i > 0 ? '1px solid #2a2a3e' : undefined,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}>
+            {field}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+exports.default = EntityBox;
+exports.CATEGORY_COLORS = CATEGORY_COLORS;
+exports.LAYER_LABELS = LAYER_LABELS;

--- a/src-tauri/skills/domain-model-diagram/templates/components--RelationshipLine.jsx
+++ b/src-tauri/skills/domain-model-diagram/templates/components--RelationshipLine.jsx
@@ -1,0 +1,109 @@
+
+// このファイルはそのまま利用（カスタマイズ不要）
+// BOX_WIDTH は EntityBox の幅と一致させること（デフォルト 220）
+
+const BOX_WIDTH = 220;
+
+function getBoxHeight(fields) {
+  return 26 + fields.length * 19 + 6;
+}
+
+// posOverrides: { [entityId]: { x, y } } — フォーカスビューでの動的座標
+// focusedId: ツリーモード時の中心エンティティID。指定時は縦方向エッジに固定
+function getEdgePoints(fromE, toE, posOverrides, focusedId) {
+  const fo = posOverrides && posOverrides[fromE.id];
+  const to_ = posOverrides && posOverrides[toE.id];
+  const fX = fo ? fo.x : fromE.x;
+  const fY = fo ? fo.y : fromE.y;
+  const tX = to_ ? to_.x : toE.x;
+  const tY = to_ ? to_.y : toE.y;
+
+  const fH = getBoxHeight(fromE.fields);
+  const tH = getBoxHeight(toE.fields);
+  const fCx = fX + BOX_WIDTH / 2;
+  const tCx = tX + BOX_WIDTH / 2;
+
+  let fx, fy, tx, ty;
+
+  if (focusedId) {
+    // ツリーモード: 中心エンティティは常に上段、接続先は下段
+    // 中心→子: 中心下辺→子上辺、子→中心: 子上辺→中心下辺
+    if (fromE.id === focusedId) {
+      fx = fCx; fy = fY + fH + 2;
+      tx = tCx; ty = tY - 2;
+    } else {
+      fx = fCx; fy = fY - 2;
+      tx = tCx; ty = tY + tH + 2;
+    }
+  } else {
+    const fCy = fY + fH / 2;
+    const tCy = tY + tH / 2;
+    const dx = tCx - fCx;
+    const dy = tCy - fCy;
+    if (Math.abs(dx) >= Math.abs(dy)) {
+      fx = dx >= 0 ? fX + BOX_WIDTH + 2 : fX - 2;
+      fy = fCy;
+      tx = dx >= 0 ? tX - 2 : tX + BOX_WIDTH + 2;
+      ty = tCy;
+    } else {
+      fx = fCx;
+      fy = dy >= 0 ? fY + fH + 2 : fY - 2;
+      tx = tCx;
+      ty = dy >= 0 ? tY - 2 : tY + tH + 2;
+    }
+  }
+
+  return { fx, fy, tx, ty };
+}
+
+// renderMode: "line" | "label"
+// showLabel: trueのとき常時ラベル表示 (focusモード用)
+// posOverrides: フォーカスビューでの動的座標マップ
+// focusedId: ツリーモード時の中心エンティティID
+function RelationshipLine({ idx, rel, fromEntity, toEntity, highlighted, renderMode, showLabel, posOverrides, focusedId }) {
+  if (!fromEntity || !toEntity) return null;
+  const { fx, fy, tx, ty } = getEdgePoints(fromEntity, toEntity, posOverrides, focusedId);
+  const mx = (fx + tx) / 2;
+  const my = (fy + ty) / 2;
+
+  if (renderMode === 'label') {
+    if (!highlighted && !showLabel) return null;
+    const text = rel.label + ' (' + rel.cardinality + ')';
+    const tw = text.length * 5.8 + 16;
+    return (
+      <g>
+        <rect x={mx - tw / 2} y={my - 17} width={tw} height={20} rx={4}
+          fill="#1e1e2e" stroke="#cba6f7" strokeWidth={1} />
+        <text x={mx} y={my - 4} textAnchor="middle" fill="#cdd6f4"
+          fontSize={10} fontFamily="system-ui,sans-serif" fontWeight={600}>
+          {text}
+        </text>
+      </g>
+    );
+  }
+
+  // renderMode === 'line'
+  const markerId = 'arr-' + idx;
+  const stroke = (highlighted || showLabel) ? '#cba6f7' : '#45475a';
+  const strokeW = (highlighted || showLabel) ? 2.5 : 1;
+  const isDashed = rel.label === 'extends';
+
+  return (
+    <g>
+      <defs>
+        <marker id={markerId} markerWidth="16" markerHeight="16" refX="12" refY="8" orient="auto">
+          <path d="M0,2 L12,8 L0,14 Z" fill={stroke} />
+        </marker>
+      </defs>
+      <line x1={fx} y1={fy} x2={tx} y2={ty}
+        stroke={stroke} strokeWidth={strokeW}
+        strokeDasharray={isDashed ? '6,4' : undefined}
+        markerEnd={'url(#' + markerId + ')'} />
+    </g>
+  );
+}
+
+exports.default = RelationshipLine;
+exports.BOX_WIDTH = BOX_WIDTH;
+exports.getBoxHeight = getBoxHeight;
+exports.getEdgePoints = getEdgePoints;

--- a/src-tauri/skills/domain-model-diagram/templates/data--entities.example.jsx
+++ b/src-tauri/skills/domain-model-diagram/templates/data--entities.example.jsx
@@ -1,0 +1,36 @@
+
+// ── data/entities テンプレート例 ──────────────────────────────────
+// このファイルはスキーマ確認用のサンプル。実際の data/entities モジュールは
+// ドメイン分析に基づいて新規生成する。
+//
+// フィールド仕様:
+//   id       (string) : エンティティの一意な識別子。リレーション定義でも使う。
+//   name     (string) : 表示名。括弧付きの補足可（例: "EventBus (singleton)"）
+//   category (string) : CATEGORY_COLORS のキーに一致する文字列
+//   x, y     (number) : グリッド配置の座標（px）
+//   fields   (string[]): フィールド/プロパティ一覧。1エントリ = 1行表示
+//
+// 座標ガイドライン:
+//   列幅: 280px（BOX_WIDTH 220 + 間隔 60）
+//   列の開始 x: 40, 320, 600, 880, 1160, ...
+//   行の高さ見積もり: 26 + fieldCount * 19 + 50 px
+//   ※ カテゴリを空間的にまとめると見やすい
+
+const ENTITIES = [
+  // ── ドメイン層 ────────────────────────────────────────────────
+  { id: 'User', name: 'User', category: 'domain', x: 320, y: 40,
+    fields: ['id: string', 'name: string', 'email: string', 'createdAt: Date'] },
+
+  { id: 'Order', name: 'Order', category: 'domain', x: 600, y: 40,
+    fields: ['id: string', 'userId: string', 'status: OrderStatus', 'items: OrderItem[]', 'total: number'] },
+
+  // ── ユースケース層 ───────────────────────────────────────────
+  { id: 'OrderService', name: 'OrderService', category: 'usecase', x: 40, y: 40,
+    fields: ['placeOrder(userId, items): Order', 'cancelOrder(orderId): void', 'getOrderHistory(userId): Order[]'] },
+
+  // ── インフラ層 ────────────────────────────────────────────────
+  { id: 'OrderRepository', name: 'OrderRepository', category: 'infrastructure', x: 880, y: 40,
+    fields: ['save(order: Order): void', 'findById(id): Order | null', 'findByUserId(userId): Order[]'] },
+];
+
+exports.default = ENTITIES;

--- a/src-tauri/skills/domain-model-diagram/templates/data--relationships.example.jsx
+++ b/src-tauri/skills/domain-model-diagram/templates/data--relationships.example.jsx
@@ -1,0 +1,31 @@
+
+// ── data/relationships テンプレート例 ─────────────────────────────
+// このファイルはスキーマ確認用のサンプル。実際の data/relationships モジュールは
+// ドメイン分析に基づいて新規生成する。
+//
+// フィールド仕様:
+//   from        (string) : 関係元エンティティの id
+//   to          (string) : 関係先エンティティの id
+//   label       (string) : 関係の動詞（例: "contains", "uses", "manages", "extends"）
+//                          "extends" のみ破線表示になる
+//   cardinality (string) : "1:1" | "1:N" | "N:1" | "N:M"
+//
+// 方向の意味: from → to の向きで矢印が描画される
+// グリッドビューでは線のみ（ラベルなし）
+// フォーカスビューでは "label (cardinality)" 形式でラベルが表示される
+
+const RELATIONSHIPS = [
+  // OrderService → Order: 生成・管理
+  { from: 'OrderService', to: 'Order',           label: 'creates',    cardinality: '1:N' },
+
+  // OrderService → OrderRepository: データアクセス
+  { from: 'OrderService', to: 'OrderRepository', label: 'uses',       cardinality: '1:1' },
+
+  // OrderRepository → Order: 永続化
+  { from: 'OrderRepository', to: 'Order',        label: 'persists',   cardinality: '1:N' },
+
+  // Order → User: 所有
+  { from: 'Order', to: 'User',                   label: 'belongs to', cardinality: 'N:1' },
+];
+
+exports.default = RELATIONSHIPS;

--- a/src-tauri/skills/domain-model-diagram/templates/entry-point.jsx
+++ b/src-tauri/skills/domain-model-diagram/templates/entry-point.jsx
@@ -1,0 +1,357 @@
+
+const { useState, useRef, useEffect, useCallback, useMemo } = React;
+const ENTITIES = require('./data/entities').default;
+const RELATIONSHIPS = require('./data/relationships').default;
+const EntityBox = require('./components/EntityBox').default;
+const { CATEGORY_COLORS, LAYER_LABELS } = require('./components/EntityBox');
+const RelationshipLine = require('./components/RelationshipLine').default;
+const { getBoxHeight, BOX_WIDTH } = require('./components/RelationshipLine');
+
+// CUSTOMIZE: キャンバスサイズをエンティティ数・配置に合わせて調整
+// CANVAS_W = 最大エンティティ x + BOX_WIDTH + 40, CANVAS_H = 最大エンティティ y + 最大高さ + 40
+const CANVAS_W = 1480;
+const CANVAS_H = 1340;
+
+// フォーカスビューのキャンバス水平中心
+const FC_X = CANVAS_W / 2;
+
+// エンティティIDからインデックスへのマップをグローバルで生成
+const ENTITY_MAP_STATIC = {};
+ENTITIES.forEach(e => { ENTITY_MAP_STATIC[e.id] = e; });
+
+// エンティティに接続されている他エンティティIDリストを返す
+function getConnectedIds(entityId) {
+  const s = new Set();
+  RELATIONSHIPS.forEach(r => {
+    if (r.from === entityId) s.add(r.to);
+    if (r.to === entityId) s.add(r.from);
+  });
+  return Array.from(s);
+}
+
+// フォーカスビュー用ツリー座標計算
+// 中心エンティティ → 上段中央、接続エンティティ → 下段に横一列
+function computeFocusPositions(centerId, connectedIds) {
+  const n = connectedIds.length;
+  const positions = {};
+  const centerEntity = ENTITY_MAP_STATIC[centerId];
+  const centerH = getBoxHeight(centerEntity.fields);
+  const TREE_TOP = 60;
+  const CHILD_Y = TREE_TOP + centerH + 100;
+  const GAP = 40;
+  const totalWidth = n * BOX_WIDTH + (n - 1) * GAP;
+  const startX = FC_X - totalWidth / 2;
+
+  positions[centerId] = {
+    x: FC_X - BOX_WIDTH / 2,
+    y: TREE_TOP,
+  };
+
+  connectedIds.forEach((id, i) => {
+    const entity = ENTITY_MAP_STATIC[id];
+    if (!entity) return;
+    positions[id] = {
+      x: startX + i * (BOX_WIDTH + GAP),
+      y: CHILD_Y,
+    };
+  });
+
+  return positions;
+}
+
+function App() {
+  // layoutMode: "grid" | "focus"
+  const [layoutMode, setLayoutMode] = useState('grid');
+  const [focusedId, setFocusedId] = useState(null);
+  const [pan, setPan] = useState({ x: 20, y: 20 });
+  // CUSTOMIZE: 初期ズームをエンティティ数・キャンバスサイズに合わせて調整（小さいほど広い範囲が見える）
+  const [zoom, setZoom] = useState(0.62);
+  const [dragging, setDragging] = useState(false);
+  const lastPos = useRef(null);
+  const dragMoved = useRef(false); // ドラッグ中に移動が発生したか追跡
+  const containerRef = useRef(null);
+
+  // フォーカスビューの接続エンティティと座標
+  const focusConnected = useMemo(() => {
+    if (!focusedId) return [];
+    return getConnectedIds(focusedId);
+  }, [focusedId]);
+
+  const posOverrides = useMemo(() => {
+    if (layoutMode !== 'focus' || !focusedId) return null;
+    return computeFocusPositions(focusedId, focusConnected);
+  }, [layoutMode, focusedId, focusConnected]);
+
+  // フォーカスビューで表示するエンティティ（中心 + 接続のみ）
+  const visibleEntityIds = useMemo(() => {
+    if (layoutMode !== 'focus' || !focusedId) return null; // null = 全て表示
+    const s = new Set([focusedId, ...focusConnected]);
+    return s;
+  }, [layoutMode, focusedId, focusConnected]);
+
+  // フォーカスビューで表示するリレーション
+  const visibleRelIndices = useMemo(() => {
+    if (layoutMode !== 'focus' || !focusedId) return null; // null = 全て表示
+    const s = new Set();
+    RELATIONSHIPS.forEach((r, i) => {
+      if (r.from === focusedId || r.to === focusedId) s.add(i);
+    });
+    return s;
+  }, [layoutMode, focusedId]);
+
+  // マウスイベント
+  // data-ui 要素（UI コントロール）上のドラッグは無視、それ以外はどこからでもパン可能
+  const handleMouseDown = useCallback(e => {
+    if (e.target.closest && e.target.closest('[data-ui]')) return;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    dragMoved.current = false;
+  }, []);
+
+  // 3px 以上移動した時点でドラッグ開始とみなし、dragging フラグをセット
+  const handleMouseMove = useCallback(e => {
+    if (!lastPos.current) return;
+    const dx = e.clientX - lastPos.current.x;
+    const dy = e.clientY - lastPos.current.y;
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
+      dragMoved.current = true;
+      setDragging(true);
+    }
+    setPan(p => ({ x: p.x + dx, y: p.y + dy }));
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const handleMouseUp = useCallback(() => {
+    setDragging(false);
+    lastPos.current = null;
+  }, []);
+
+  const handleWheel = useCallback(e => {
+    e.preventDefault();
+    const factor = e.deltaY > 0 ? 0.9 : 1.1;
+    setZoom(z => Math.min(2.5, Math.max(0.15, z * factor)));
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => el.removeEventListener('wheel', handleWheel);
+  }, [handleWheel]);
+
+  // フォーカスビューに切り替えてビューポートをツリー中央に合わせる
+  const enterFocus = useCallback((id) => {
+    setFocusedId(id);
+    setLayoutMode('focus');
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      const newZoom = 0.72;
+      const centerEntity = ENTITY_MAP_STATIC[id];
+      const centerH = getBoxHeight(centerEntity.fields);
+      const TREE_TOP = 60;
+      const CHILD_Y = TREE_TOP + centerH + 100;
+      const treeMidY = (TREE_TOP + CHILD_Y + 89) / 2; // 上段中央〜下段中央の中点
+      setZoom(newZoom);
+      setPan({
+        x: rect.width / 2 - FC_X * newZoom,
+        y: rect.height / 2 - treeMidY * newZoom,
+      });
+    }
+  }, []);
+
+  // グリッドビューに戻る
+  const backToGrid = useCallback(() => {
+    setLayoutMode('grid');
+    setFocusedId(null);
+    setPan({ x: 20, y: 20 });
+    setZoom(0.62); // CUSTOMIZE: 初期ズームに合わせる
+  }, []);
+
+  // ドラッグ中（移動あり）ならクリックを無視してフォーカス誤作動を防ぐ
+  const handleEntityClick = useCallback(id => {
+    if (dragMoved.current) return;
+    if (layoutMode === 'focus' && id === focusedId) {
+      // フォーカス中のエンティティを再クリック → グリッドビューに戻る
+      backToGrid();
+    } else {
+      enterFocus(id);
+    }
+  }, [layoutMode, focusedId, enterFocus, backToGrid]);
+
+  const handleBgClick = useCallback(e => {
+    // 背景クリックでは何もしない（ドラッグ後の意図しない戻りを防ぐ）
+  }, []);
+
+  const svgStyle = {
+    position: 'absolute', left: 0, top: 0,
+    width: CANVAS_W, height: CANVAS_H,
+    pointerEvents: 'none', overflow: 'visible',
+  };
+  const svgViewBox = '0 0 ' + CANVAS_W + ' ' + CANVAS_H;
+  const categories = Object.keys(CATEGORY_COLORS);
+
+  const isFocus = layoutMode === 'focus';
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: '100vw', height: '100vh', overflow: 'hidden',
+        background: '#181825',
+        cursor: dragging ? 'grabbing' : 'grab',
+        position: 'relative', userSelect: 'none',
+      }}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      onClick={handleBgClick}
+    >
+      {/* ドラッグ中は透明オーバーレイを重ねてエンティティへのホバーを防ぐ */}
+      {dragging && (
+        <div style={{ position: 'absolute', inset: 0, zIndex: 50, cursor: 'grabbing' }} />
+      )}
+      <div style={{
+        position: 'absolute',
+        transform: 'translate(' + pan.x + 'px,' + pan.y + 'px) scale(' + zoom + ')',
+        transformOrigin: '0 0',
+        width: CANVAS_W, height: CANVAS_H,
+      }}>
+        {/* Layer 1: 接続線 */}
+        <svg style={{ ...svgStyle, zIndex: 0 }} viewBox={svgViewBox}>
+          {RELATIONSHIPS.map((rel, i) => {
+            if (visibleRelIndices && !visibleRelIndices.has(i)) return null;
+            return (
+              <RelationshipLine key={i} idx={i} rel={rel} renderMode="line"
+                fromEntity={ENTITY_MAP_STATIC[rel.from]}
+                toEntity={ENTITY_MAP_STATIC[rel.to]}
+                highlighted={false}
+                showLabel={false}
+                posOverrides={posOverrides}
+                focusedId={isFocus ? focusedId : null}
+              />
+            );
+          })}
+        </svg>
+
+        {/* Layer 2: エンティティボックス */}
+        {ENTITIES.map(entity => {
+          const isVisible = !visibleEntityIds || visibleEntityIds.has(entity.id);
+          const pos = posOverrides && posOverrides[entity.id];
+          const isCenter = isFocus && entity.id === focusedId;
+          const isConnected = isFocus && focusConnected.includes(entity.id);
+          // フォーカスエンティティはラッパーレベルで高いz-indexを持ち、
+          // DOM順に関わらず dimmed エンティティの前面に描画される
+          const wrapperZ = isCenter ? 30 : isConnected ? 20 : 1;
+          return (
+            <div key={entity.id} data-entity="1" style={{ position: 'relative', zIndex: wrapperZ }}>
+              <EntityBox
+                entity={entity}
+                selected={isCenter}
+                highlighted={isConnected}
+                dimmed={isFocus && !isVisible}
+                onClick={handleEntityClick}
+                x={pos ? pos.x : undefined}
+                y={pos ? pos.y : undefined}
+              />
+            </div>
+          );
+        })}
+
+        {/* Layer 3: ラベル（フォーカスビューでは常時表示、グリッドビューでは非表示） */}
+        <svg style={{ ...svgStyle, zIndex: 3 }} viewBox={svgViewBox}>
+          {RELATIONSHIPS.map((rel, i) => {
+            if (visibleRelIndices && !visibleRelIndices.has(i)) return null;
+            return (
+              <RelationshipLine key={'lbl' + i} idx={i} rel={rel} renderMode="label"
+                fromEntity={ENTITY_MAP_STATIC[rel.from]}
+                toEntity={ENTITY_MAP_STATIC[rel.to]}
+                highlighted={false}
+                showLabel={isFocus}
+                posOverrides={posOverrides}
+                focusedId={isFocus ? focusedId : null}
+              />
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* タイトル */}
+      <div data-ui="1" style={{
+        position: 'absolute', top: 14, left: 14,
+        background: 'rgba(24,24,37,0.97)', border: '1px solid #313244',
+        borderRadius: 8, padding: '10px 16px', zIndex: 10,
+      }}>
+        {/* CUSTOMIZE: タイトルをダイアグラムの対象に合わせて変更 */}
+        <div style={{ fontSize: 15, fontWeight: 700, color: '#cdd6f4', fontFamily: 'system-ui,sans-serif' }}>
+          Domain Model Diagram
+        </div>
+        <div style={{ fontSize: 11, color: '#6c7086', fontFamily: 'system-ui,sans-serif', marginTop: 2 }}>
+          {ENTITIES.length} entities · {RELATIONSHIPS.length} relationships
+        </div>
+      </div>
+
+      {/* フォーカスビュー: 戻るボタン + エンティティ名 */}
+      {isFocus && (
+        <div data-ui="1" style={{
+          position: 'absolute', top: 14, right: 14,
+          display: 'flex', flexDirection: 'column', gap: 6, zIndex: 10,
+        }}>
+          <button
+            onClick={backToGrid}
+            style={{
+              background: '#313244', border: '1px solid #45475a',
+              borderRadius: 6, padding: '6px 14px',
+              color: '#cdd6f4', fontSize: 12, fontFamily: 'system-ui,sans-serif',
+              cursor: 'pointer', fontWeight: 600,
+            }}
+          >
+            ← Back to overview
+          </button>
+          <div style={{
+            background: 'rgba(24,24,37,0.95)', border: '1px solid #45475a',
+            borderRadius: 6, padding: '6px 12px',
+            fontSize: 11, color: '#6c7086', fontFamily: 'system-ui,sans-serif',
+            lineHeight: 1.7,
+          }}>
+            <div style={{ color: '#cba6f7', fontWeight: 700, fontSize: 12 }}>{focusedId}</div>
+            <div>{focusConnected.length} connections</div>
+            <div style={{ marginTop: 2, color: '#585b70' }}>Click center: back to grid</div>
+            <div style={{ color: '#585b70' }}>Click other: re-focus</div>
+          </div>
+        </div>
+      )}
+
+      {/* グリッドビュー: 操作説明 */}
+      {!isFocus && (
+        <div data-ui="1" style={{
+          position: 'absolute', top: 14, right: 14,
+          background: 'rgba(24,24,37,0.93)', border: '1px solid #313244',
+          borderRadius: 6, padding: '7px 13px',
+          fontSize: 11, color: '#6c7086', fontFamily: 'system-ui,sans-serif',
+          lineHeight: '1.75', zIndex: 10,
+        }}>
+          <div>Scroll: zoom | Drag: pan</div>
+          <div>Click entity: focus view + labels</div>
+        </div>
+      )}
+
+      {/* カテゴリ凡例 */}
+      <div data-ui="1" style={{
+        position: 'absolute', bottom: 14, left: 14,
+        background: 'rgba(24,24,37,0.97)', border: '1px solid #313244',
+        borderRadius: 8, padding: '9px 14px',
+        display: 'flex', flexWrap: 'wrap', gap: '5px 14px', maxWidth: 640,
+        pointerEvents: 'none', zIndex: 10,
+      }}>
+        {categories.map(cat => (
+          <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <div style={{ width: 10, height: 10, borderRadius: 2, background: CATEGORY_COLORS[cat].bg, flexShrink: 0 }} />
+            <span style={{ fontSize: 11, color: '#cdd6f4', fontFamily: 'system-ui,sans-serif' }}>{LAYER_LABELS[cat] || cat}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+exports.default = App;

--- a/src-tauri/skills/wireframe/SKILL.md
+++ b/src-tauri/skills/wireframe/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: wireframe
+description: インタラクティブな React ワイヤーフレームアーティファクトを作成する。エンティティバインディング表示（W コンポーネント）、画面遷移図（OverviewScreen）、デスクトップ全画面レイアウト対応。
+allowed-tools: mcp__plugin_oretachi_oretachi__artifact, mcp__plugin_oretachi_oretachi__artifact_module, mcp__plugin_oretachi_oretachi__search_artifact, Read, Bash(git branch:*)
+---
+
+# wireframe スキル
+
+インタラクティブな React ワイヤーフレームアーティファクトをテンプレートから作成する。
+
+**機能:**
+- タブ切り替えによる複数画面プレビュー（デスクトップ全画面レイアウト）
+- W コンポーネントによるエンティティバインディング表示（ホバー or 「パラメータ表示」ボタンで常時表示）
+- 画面遷移 SVG 図（クリックで対応タブにジャンプ）
+- Catppuccin Mocha ダークテーマのタブバー
+
+## 引数
+
+```
+$ARGUMENTS: <artifact-id> [--repo <repo>] [--branch <branch>]
+```
+
+- `artifact-id`（必須）: 作成するアーティファクトID（例: `my-app-wireframe`）
+- `--repo`（省略時: `oretachi`）: リポジトリ名
+- `--branch`（省略時: `git branch --show-current`）: ブランチ名
+
+## ワークフロー
+
+### Step 1: パラメータ確定
+
+引数を解析する。`--branch` が省略された場合は `git branch --show-current` で現在ブランチを取得。
+
+### Step 2: テンプレートを読み込む
+
+このスキルディレクトリの `templates/` フォルダにある以下のファイルを Read で読み込む:
+
+| ファイル | アーティファクトモジュール | カスタマイズ要否 |
+|---|---|---|
+| `templates/entry-point.jsx` | エントリポイント（content）| `// CUSTOMIZE:` コメント箇所のみ変更 |
+| `templates/components--W.jsx` | `components/W` | `EC` エンティティカラーマップのみ変更 |
+| `templates/components--layout.jsx` | `components/layout` | そのまま利用 |
+| `templates/components--primitives.jsx` | `components/primitives` | そのまま利用 |
+| `templates/screens--OverviewScreen.example.jsx` | ※スキーマ参照用 | 新規生成 |
+| `templates/screens--screen.example.jsx` | ※スキーマ参照用 | 新規生成 |
+
+### Step 3: 画面・ドメイン分析
+
+ユーザー要件（補足ヒアリング or コードベース調査）から以下を特定する:
+
+**画面一覧:**
+各画面について定義する:
+- `key`: タブキー（kebab-case、例: `task-list`）
+- `label`: タブ表示名（例: `Task List`）
+- `type`: `list` | `detail` | `form` | `auth` | `overview`（常に1つ含む）
+- 表示フィールドとエンティティバインディング（例: `Task.title`, `Task.status`）
+- アクションボタンとサービスメソッドバインディング（例: `TaskService.createTask(title, dueDate)`）
+- ナビゲーション先（どのタブキーに遷移するか）
+
+**エンティティ一覧:**
+- エンティティ名（例: `User`, `Task`）と所属カテゴリ
+- 主要フィールド（W コンポーネントの `f` prop で参照するもの）
+- サービスクラス（例: `TaskService`, `UserService`）も同様に定義
+
+**画面遷移グラフ:**
+- `{ from, to, label, isBack }` のリスト
+- `isBack: true` は戻り方向（破線表示）
+
+### Step 4: エンティティカラーマップ定義
+
+`components/W` の `EC` オブジェクトを定義する。エンティティ名 → Catppuccin Mocha 色の対応を作成。
+
+**Catppuccin Mocha パレット（推奨色）:**
+| 色名 | hex | 推奨用途 |
+|---|---|---|
+| red | `#f38ba8` | ドメインコアエンティティ |
+| peach | `#fab387` | サービス・ユースケース層 |
+| blue | `#89b4fa` | インフラ・アダプター層 |
+| green | `#a6e3a1` | プレゼンテーション・UI |
+| yellow | `#f9e2af` | 値オブジェクト・列挙型 |
+| mauve | `#cba6f7` | 共通・ユーティリティ |
+| teal | `#94e2d5` | イベント・メッセージ |
+| sky | `#89dceb` | 外部クライアント・API |
+
+### Step 5: 画面モジュール設計
+
+Step 3 の分析に基づき各画面の実装内容を設計する。
+`templates/screens--screen.example.jsx` のスキーマを参照して各画面のコードを生成。
+
+**画面タイプ別ガイドライン:**
+
+- **list**: Frame + 右端に新規作成ボタン + Card 配列。各カードにタイトル・バッジ・メタ情報を Row で横並び
+- **detail**: Frame + 右端に編集ボタン + 複数 Card。最後の Card にアクションボタン Row
+- **form**: Frame + maxWidth 640 のフォームコンテナ + WInput/WTextarea/WSelect + 送信/キャンセルボタン Row
+- **auth**: Frame + maxWidth 480 の中央配置コンテナ + メールアドレス/パスワード入力 + 送信ボタン
+- **overview**: `templates/screens--OverviewScreen.example.jsx` のスキーマを参照して SVG 遷移図を新規生成
+
+### Step 6: アーティファクト作成
+
+以下の順序で MCP ツールを呼び出す:
+
+**1. エントリポイント作成**
+```
+artifact(command: "create", id: "<artifact-id>", type: "application/vnd.ant.react",
+  title: "<アプリ名> — ワイヤーフレーム",
+  content: <entry-point.jsx の内容。CUSTOMIZE: Screen imports / TABS array / Screen render switch を変更>)
+```
+
+**2. `components/W` モジュール作成**
+```
+artifact_module(command: "create", module_name: "components/W",
+  content: <components--W.jsx の内容。EC エンティティカラーマップをStep 4の定義に変更>)
+```
+
+**3. `components/layout` モジュール作成**
+```
+artifact_module(command: "create", module_name: "components/layout",
+  content: <components--layout.jsx をそのまま>)
+```
+
+**4. `components/primitives` モジュール作成**
+```
+artifact_module(command: "create", module_name: "components/primitives",
+  content: <components--primitives.jsx をそのまま>)
+```
+
+**5. `screens/OverviewScreen` モジュール作成**
+```
+artifact_module(command: "create", module_name: "screens/OverviewScreen",
+  content: <Step 3の画面リスト・遷移グラフから新規生成>)
+```
+
+**6. 各画面モジュール作成**（画面数分だけ繰り返す）
+```
+artifact_module(command: "create", module_name: "screens/<ScreenName>",
+  content: <Step 5 の設計に基づいて新規生成>)
+```
+
+複数の画面が定義されている場合、同一の export ファイルにまとめることができる（例: 認証系は `screens/AuthScreens` に `LoginScreen` / `RegisterScreen` を名前付き export）。
+
+### Step 7: 検証
+
+```
+artifact(command: "outline")
+```
+
+で構造確認。エントリポイント + 4 つの固定モジュール（`components/W`, `components/layout`, `components/primitives`, `screens/OverviewScreen`）+ 各画面モジュールが揃っていれば完了。
+
+## テンプレートファイルの位置
+
+このスキルファイル（`SKILL.md`）と同じディレクトリの `templates/` フォルダを Read で参照:
+- `templates/entry-point.jsx`
+- `templates/components--W.jsx`
+- `templates/components--layout.jsx`
+- `templates/components--primitives.jsx`
+- `templates/screens--OverviewScreen.example.jsx`（OverviewScreen 生成時のスキーマ参照用）
+- `templates/screens--screen.example.jsx`（各画面生成時のスキーマ参照用）

--- a/src-tauri/skills/wireframe/templates/components--W.jsx
+++ b/src-tauri/skills/wireframe/templates/components--W.jsx
@@ -1,0 +1,67 @@
+
+const { useState, useRef, useEffect, useCallback } = React;
+
+// CUSTOMIZE: エンティティ名 → Catppuccin Mocha 色のマップ
+// キーはエンティティ名（W コンポーネントの `e` prop に渡す文字列と一致させること）
+// 色は以下のパレットから選ぶ:
+//   red    #f38ba8 — ドメインコアエンティティ
+//   peach  #fab387 — サービス・ユースケース層
+//   blue   #89b4fa — インフラ・アダプター層
+//   green  #a6e3a1 — プレゼンテーション・UI
+//   yellow #f9e2af — 値オブジェクト・列挙型
+//   mauve  #cba6f7 — 共通・ユーティリティ
+//   teal   #94e2d5 — イベント・メッセージ
+//   sky    #89dceb — 外部クライアント・API
+const EC = {
+  // ── 例（実際のドメインに合わせて書き換える） ──────────────────
+  // User: '#f38ba8', Task: '#f38ba8',           // red   — ドメイン
+  // UserService: '#fab387', TaskService: '#fab387', // peach — サービス
+  // CalendarAdapter: '#89b4fa',                  // blue  — アダプター
+  // Email: '#f9e2af', TaskStatus: '#f9e2af',     // yellow — 値オブジェクト
+};
+
+// W: ワイヤーフレームアイテム（エンティティバインディングツールチップ付き）
+// position: fixed でツールチップを描画するため overflow: auto による切り抜け問題なし
+function W({ e, f, sa, style, children }) {
+  const [hov, setHov] = useState(false);
+  const [pos, setPos] = useState(null);
+  const ref = useRef(null);
+  const color = EC[e] || '#cdd6f4';
+
+  const measure = useCallback(() => {
+    if (ref.current && e) {
+      const r = ref.current.getBoundingClientRect();
+      setPos({ x: r.left, y: r.top });
+    }
+  }, [e]);
+
+  // showAll 切り替え時 & スクロール時に再計測
+  useEffect(() => {
+    if (!sa || !e) { if (!hov) setPos(null); return; }
+    measure();
+    const onScroll = () => measure();
+    window.addEventListener('scroll', onScroll, true);
+    return () => window.removeEventListener('scroll', onScroll, true);
+  }, [sa, measure]);
+
+  return (
+    <div ref={ref} style={style}
+      onMouseEnter={() => { measure(); setHov(true); }}
+      onMouseLeave={() => { setHov(false); if (!sa) setPos(null); }}>
+      {children}
+      {(hov || sa) && e && pos && (
+        <div style={{
+          position: 'fixed', left: pos.x, top: pos.y - 26,
+          background: '#1e1e2e', color, border: `1px solid ${color}55`,
+          borderRadius: 4, padding: '2px 8px', fontSize: 10,
+          fontFamily: 'monospace', whiteSpace: 'nowrap',
+          zIndex: 9999, pointerEvents: 'none',
+          boxShadow: '0 2px 8px rgba(0,0,0,0.6)',
+        }}>{e}.{f}</div>
+      )}
+    </div>
+  );
+}
+
+exports.default = W;
+exports.EC = EC;

--- a/src-tauri/skills/wireframe/templates/components--layout.jsx
+++ b/src-tauri/skills/wireframe/templates/components--layout.jsx
@@ -1,0 +1,63 @@
+
+// このファイルはそのまま利用（カスタマイズ不要）
+
+function Card({ children }) {
+  return (
+    <div style={{ border: '1px solid #e0e0e0', borderRadius: 8, padding: '16px 20px', background: 'white', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {children}
+    </div>
+  );
+}
+
+function Divider() {
+  return <div style={{ borderTop: '1px solid #ebebeb', margin: '4px 0' }} />;
+}
+
+function Row({ children, gap = 12 }) {
+  return <div style={{ display: 'flex', gap, alignItems: 'center', flexWrap: 'wrap' }}>{children}</div>;
+}
+
+function Spacer({ h = 8 }) {
+  return <div style={{ height: h }} />;
+}
+
+// Frame: 画面全体のラッパー。ヘッダーバー + コンテンツエリア
+// Props:
+//   title     (string)    ヘッダーに表示するタイトル
+//   back      (bool)      true のとき ← 戻るリンクを表示
+//   backLabel (string)    戻るリンクのラベル（デフォルト: '戻る'）
+//   onBack    (function)  戻るリンクのクリックハンドラ（通常 () => go('...')）
+//   rightEl   (ReactNode) ヘッダー右端に配置する要素（例: 編集ボタン）
+//   children  (ReactNode) コンテンツエリアの中身
+function Frame({ title, back, backLabel = '戻る', onBack, rightEl, children }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100%', background: '#fafafa' }}>
+      <div style={{
+        background: '#f0f0f0', borderBottom: '1px solid #d8d8d8',
+        padding: '16px 28px', display: 'flex', alignItems: 'center',
+        justifyContent: 'space-between', flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+          {back && (
+            <span onClick={onBack} style={{ fontSize: 13, color: '#555', cursor: 'pointer', fontFamily: 'system-ui' }}>
+              ← {backLabel}
+            </span>
+          )}
+          {title && (
+            <span style={{ fontSize: 16, fontWeight: 700, color: '#222', fontFamily: 'system-ui' }}>{title}</span>
+          )}
+        </div>
+        {rightEl}
+      </div>
+      <div style={{ flex: 1, padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+exports.Card = Card;
+exports.Divider = Divider;
+exports.Row = Row;
+exports.Spacer = Spacer;
+exports.Frame = Frame;

--- a/src-tauri/skills/wireframe/templates/components--primitives.jsx
+++ b/src-tauri/skills/wireframe/templates/components--primitives.jsx
@@ -1,0 +1,98 @@
+
+// このファイルはそのまま利用（カスタマイズ不要）
+// 各コンポーネントは W でラップされ、エンティティバインディングツールチップが付く
+// 共通 Props: e (エンティティ名), f (フィールド/メソッド名), sa (showAll フラグ)
+
+const W = require('./W').default;
+
+// WInput: テキスト入力フィールドのプレースホルダー
+// Props: label (string), placeholder (string), e, f, sa
+function WInput({ label, placeholder = '────────────────', e, f, sa }) {
+  return (
+    <W e={e} f={f} sa={sa}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        {label && <span style={{ fontSize: 13, color: '#666', fontFamily: 'system-ui', fontWeight: 500 }}>{label}</span>}
+        <div style={{ border: '1px solid #ccc', borderRadius: 6, padding: '10px 14px', background: 'white', fontSize: 14, color: '#bbb', fontFamily: 'system-ui' }}>
+          {placeholder}
+        </div>
+      </div>
+    </W>
+  );
+}
+
+// WTextarea: 複数行テキスト入力フィールドのプレースホルダー
+// Props: label (string), e, f, sa
+function WTextarea({ label, e, f, sa }) {
+  return (
+    <W e={e} f={f} sa={sa}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        {label && <span style={{ fontSize: 13, color: '#666', fontFamily: 'system-ui', fontWeight: 500 }}>{label}</span>}
+        <div style={{ border: '1px solid #ccc', borderRadius: 6, padding: '10px 14px', background: 'white', fontSize: 14, color: '#bbb', fontFamily: 'system-ui', height: 100, lineHeight: 1.7 }}>
+          ────────────────<br/>──────────<br/>────────────────────
+        </div>
+      </div>
+    </W>
+  );
+}
+
+// WBtn: ボタン
+// Props: label (string), primary (bool), small (bool), e, f, sa, onClick
+function WBtn({ label, primary, small, e, f, sa, onClick }) {
+  return (
+    <W e={e} f={f} sa={sa}>
+      <div onClick={onClick} style={{
+        border: primary ? 'none' : '1px solid #ccc', borderRadius: 6,
+        padding: small ? '8px 14px' : '10px 20px',
+        background: primary ? '#444' : '#f0f0f0',
+        color: primary ? 'white' : '#555',
+        fontSize: small ? 13 : 14, fontWeight: 600, fontFamily: 'system-ui',
+        textAlign: 'center', cursor: 'pointer',
+      }}>{label}</div>
+    </W>
+  );
+}
+
+// WSelect: ドロップダウン選択フィールドのプレースホルダー
+// Props: label (string), e, f, sa
+function WSelect({ label, e, f, sa }) {
+  return (
+    <W e={e} f={f} sa={sa}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        {label && <span style={{ fontSize: 13, color: '#666', fontFamily: 'system-ui', fontWeight: 500 }}>{label}</span>}
+        <div style={{ border: '1px solid #ccc', borderRadius: 6, padding: '10px 14px', background: 'white', fontSize: 14, color: '#999', fontFamily: 'system-ui', display: 'flex', justifyContent: 'space-between' }}>
+          <span>選択してください</span><span>▼</span>
+        </div>
+      </div>
+    </W>
+  );
+}
+
+// WBadge: インラインバッジ（ステータス表示など）
+// Props: label (string), color (hex string, デフォルト '#888'), e, f, sa
+function WBadge({ label, color = '#888', e, f, sa }) {
+  return (
+    <W e={e} f={f} sa={sa} style={{ display: 'inline-block' }}>
+      <span style={{ background: `${color}22`, color, border: `1px solid ${color}55`, borderRadius: 4, padding: '3px 8px', fontSize: 11, fontFamily: 'monospace', fontWeight: 700 }}>{label}</span>
+    </W>
+  );
+}
+
+// WText: ラベル + 値のペア表示（詳細画面のメタ情報など）
+// Props: label (string), value (string), e, f, sa
+function WText({ label, value, e, f, sa }) {
+  return (
+    <W e={e} f={f} sa={sa}>
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center', fontFamily: 'system-ui', fontSize: 14 }}>
+        {label && <span style={{ color: '#999', fontSize: 13, minWidth: 72, flexShrink: 0 }}>{label}</span>}
+        <span style={{ color: '#333' }}>{value}</span>
+      </div>
+    </W>
+  );
+}
+
+exports.WInput = WInput;
+exports.WTextarea = WTextarea;
+exports.WBtn = WBtn;
+exports.WSelect = WSelect;
+exports.WBadge = WBadge;
+exports.WText = WText;

--- a/src-tauri/skills/wireframe/templates/entry-point.jsx
+++ b/src-tauri/skills/wireframe/templates/entry-point.jsx
@@ -1,0 +1,83 @@
+
+const { useState } = React;
+
+// CUSTOMIZE: 画面モジュールの require を追加・変更する
+// 単一 default export の場合: const XxxScreen = require('./screens/XxxScreen').default;
+// 複数画面をまとめた場合:    const { LoginScreen, RegisterScreen } = require('./screens/AuthScreens');
+const OverviewScreen = require('./screens/OverviewScreen').default;
+// const ExampleScreen = require('./screens/ExampleScreen').default;
+
+// CUSTOMIZE: タブ一覧を定義する
+// key: 画面モジュールに対応する一意なキー（kebab-case）
+// label: タブに表示する文字列
+// 先頭は必ず { key: 'overview', label: 'Overview' } を置く（画面遷移図）
+const TABS = [
+  { key: 'overview', label: 'Overview' },
+  // { key: 'login',      label: 'Login' },
+  // { key: 'task-list',  label: 'Task List' },
+];
+
+function App() {
+  const [tab, setTab] = useState('overview');
+  const [showAll, setShowAll] = useState(false);
+
+  return (
+    <div style={{
+      height: '100vh',
+      background: '#11111b',
+      fontFamily: 'system-ui, sans-serif',
+      display: 'flex',
+      flexDirection: 'column',
+      boxSizing: 'border-box',
+      overflow: 'hidden',
+    }}>
+      {/* タブバー — フル幅 */}
+      <div style={{
+        background: '#1e1e2e',
+        borderBottom: '1px solid #313244',
+        padding: '0 24px',
+        display: 'flex',
+        alignItems: 'stretch',
+        flexShrink: 0,
+        gap: 2,
+      }}>
+        {TABS.map(t => (
+          <button key={t.key} onClick={() => setTab(t.key)} style={{
+            padding: '12px 20px',
+            fontSize: 13, fontWeight: 600,
+            border: 'none',
+            borderBottom: tab === t.key ? '2px solid #cba6f7' : '2px solid transparent',
+            background: 'transparent',
+            color: tab === t.key ? '#cba6f7' : '#6c7086',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+          }}>{t.label}</button>
+        ))}
+        <div style={{ flex: 1 }} />
+        <button onClick={() => setShowAll(s => !s)} style={{
+          padding: '8px 16px', margin: '6px 0',
+          borderRadius: 6, fontSize: 12, fontWeight: 600,
+          border: '1px solid ' + (showAll ? '#f9e2af' : '#45475a'),
+          background: showAll ? '#f9e2af' : 'transparent',
+          color: showAll ? '#1e1e2e' : '#f9e2af',
+          cursor: 'pointer',
+          alignSelf: 'center',
+        }}>パラメータ表示</button>
+      </div>
+
+      {/* スクリーン — 残り高さを全て埋める */}
+      <div style={{ flex: 1, overflow: 'auto', background: '#fafafa' }}>
+        {/* CUSTOMIZE: 各タブキーに対応する画面コンポーネントを条件分岐で描画する
+            - OverviewScreen は go のみ（sa 不要）
+            - 各画面は sa={showAll} go={setTab} を渡す
+            - 複数バリアントがある画面（作成/編集）は画面固有の props も渡す
+        */}
+        {tab === 'overview'  && <OverviewScreen go={setTab} />}
+        {/* {tab === 'login'     && <LoginScreen sa={showAll} go={setTab} />} */}
+        {/* {tab === 'task-list' && <ExampleScreen sa={showAll} go={setTab} />} */}
+      </div>
+    </div>
+  );
+}
+
+exports.default = App;

--- a/src-tauri/skills/wireframe/templates/screens--OverviewScreen.example.jsx
+++ b/src-tauri/skills/wireframe/templates/screens--OverviewScreen.example.jsx
@@ -1,0 +1,108 @@
+
+// ── screens/OverviewScreen テンプレート例 ────────────────────────────
+// このファイルはスキーマ確認用のサンプル。実際の OverviewScreen は
+// ドメイン分析で特定した画面リスト・遷移グラフに基づいて新規生成する。
+//
+// ── SMETA 配列フィールド仕様 ─────────────────────────────────────────
+//   id    (string) : タブキー。go(s.id) で対応タブに遷移
+//   label (string) : スクリーンボックスに表示するラベル（日本語可）
+//   x, y  (number) : SVG 内の左上座標（px）
+//   w, h  (number) : ボックスの幅・高さ（デフォルト: w=128, h=46 推奨）
+//
+// ── SVG 座標ガイドライン ─────────────────────────────────────────────
+//   SVG サイズ: width="820" height="370"（画面数・遷移数に応じて調整）
+//   スクリーンボックス列ピッチ: 約 200px（x + w + gap）
+//   スクリーンボックス行ピッチ: 約 113px（y + h + gap）
+//   配置方針: 左→右に時系列フロー、認証系は左端、メイン画面は中央以降
+//
+// ── 遷移線スタイル ────────────────────────────────────────────────────
+//   前進遷移（solid）: stroke="#666" strokeWidth={1.5} markerEnd="url(#fw)"
+//   戻り遷移（dashed）: stroke="#bbb" strokeWidth={1.5} strokeDasharray="5,3" markerEnd="url(#bk)"
+//   直線遷移: <line x1 y1 x2 y2 ...>
+//   曲線遷移: <path d="M ... Q ... ..." ...> （戻り線など交差を避ける場合）
+//   ラベル: <text x={mid} y={mid-8} fontSize={9} fill="#888" fontFamily="system-ui">ラベル</text>
+//
+// ── エクスポートパターン ──────────────────────────────────────────────
+//   exports.default = OverviewScreen;
+
+const SMETA = [
+  // ── 認証フロー（左端） ──────────────────────────────────────────
+  { id: 'login',       label: 'ログイン',   x: 50,  y: 155, w: 128, h: 46 },
+  { id: 'register',    label: '新規登録',   x: 50,  y: 268, w: 128, h: 46 },
+
+  // ── メインフロー（中央以降） ────────────────────────────────────
+  { id: 'task-list',   label: 'タスク一覧', x: 252, y: 155, w: 128, h: 46 },
+  { id: 'task-detail', label: 'タスク詳細', x: 452, y: 75,  w: 128, h: 46 },
+  { id: 'task-edit',   label: 'タスク編集', x: 650, y: 75,  w: 128, h: 46 },
+  { id: 'task-create', label: 'タスク作成', x: 452, y: 258, w: 128, h: 46 },
+];
+
+function OverviewScreen({ go }) {
+  return (
+    <div style={{ padding: '28px 32px', background: '#f8f8f8', minHeight: '100%' }}>
+      <div style={{ fontFamily: 'system-ui', fontSize: 16, fontWeight: 700, color: '#333', marginBottom: 4 }}>画面遷移図</div>
+      <div style={{ fontFamily: 'system-ui', fontSize: 12, color: '#aaa', marginBottom: 24 }}>スクリーンをクリックしてプレビューへ</div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <svg width="820" height="370" style={{ background: 'white', border: '1px solid #e0e0e0', borderRadius: 8, display: 'block', maxWidth: '100%' }}>
+          <defs>
+            {/* 前進遷移用マーカー */}
+            <marker id="fw" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+              <path d="M0,1 L6,4 L0,7 Z" fill="#666" />
+            </marker>
+            {/* 戻り遷移用マーカー */}
+            <marker id="bk" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+              <path d="M0,1 L6,4 L0,7 Z" fill="#bbb" />
+            </marker>
+          </defs>
+
+          {/* ── 前進遷移（実線） ── */}
+          {/* 接続座標: ボックスの右辺中央 = (x+w, y+h/2)、左辺中央 = (x, y+h/2)、下辺中央 = (x+w/2, y+h) */}
+          <line x1={178} y1={178} x2={250} y2={178} stroke="#666" strokeWidth={1.5} markerEnd="url(#fw)" />
+          <text x={214} y={172} textAnchor="middle" fontSize={9} fill="#888" fontFamily="system-ui">ログイン成功</text>
+
+          <line x1={114} y1={201} x2={114} y2={266} stroke="#666" strokeWidth={1.5} markerEnd="url(#fw)" />
+          <text x={126} y={236} fontSize={9} fill="#888" fontFamily="system-ui">新規登録へ</text>
+
+          <line x1={178} y1={291} x2={250} y2={187} stroke="#666" strokeWidth={1.5} markerEnd="url(#fw)" />
+          <text x={226} y={248} fontSize={9} fill="#888" fontFamily="system-ui">登録成功</text>
+
+          <line x1={380} y1={166} x2={450} y2={100} stroke="#666" strokeWidth={1.5} markerEnd="url(#fw)" />
+          <text x={424} y={127} fontSize={9} fill="#888" fontFamily="system-ui">タスク選択</text>
+
+          <line x1={380} y1={190} x2={450} y2={270} stroke="#666" strokeWidth={1.5} markerEnd="url(#fw)" />
+          <text x={426} y={240} fontSize={9} fill="#888" fontFamily="system-ui">新規作成</text>
+
+          <line x1={580} y1={98} x2={648} y2={98} stroke="#666" strokeWidth={1.5} markerEnd="url(#fw)" />
+          <text x={614} y={92} textAnchor="middle" fontSize={9} fill="#888" fontFamily="system-ui">編集</text>
+
+          {/* ── 戻り遷移（破線）: 曲線で交差を回避 ── */}
+          <path d="M 454,77 Q 380,18 324,153" stroke="#bbb" strokeWidth={1.5} strokeDasharray="5,3" fill="none" markerEnd="url(#bk)" />
+          <text x={380} y={33} textAnchor="middle" fontSize={9} fill="#bbb" fontFamily="system-ui">戻る</text>
+
+          <path d="M 652,73 Q 616,36 582,73" stroke="#bbb" strokeWidth={1.5} strokeDasharray="5,3" fill="none" markerEnd="url(#bk)" />
+          <text x={617} y={40} textAnchor="middle" fontSize={9} fill="#bbb" fontFamily="system-ui">保存/キャンセル</text>
+
+          <path d="M 454,300 Q 375,338 324,203" stroke="#bbb" strokeWidth={1.5} strokeDasharray="5,3" fill="none" markerEnd="url(#bk)" />
+          <text x={374} y={340} textAnchor="middle" fontSize={9} fill="#bbb" fontFamily="system-ui">作成/キャンセル</text>
+
+          {/* ── スクリーンボックス（クリックで遷移） ── */}
+          {SMETA.map(s => (
+            <g key={s.id} onClick={() => go(s.id)} style={{ cursor: 'pointer' }}>
+              <rect x={s.x} y={s.y} width={s.w} height={s.h} rx={6}
+                fill="white" stroke="#555" strokeWidth={1.8} />
+              <text x={s.x + s.w / 2} y={s.y + s.h / 2 + 5}
+                textAnchor="middle" fontSize={12} fontFamily="system-ui" fontWeight={600} fill="#222">
+                {s.label}
+              </text>
+            </g>
+          ))}
+        </svg>
+      </div>
+      <div style={{ marginTop: 16, fontSize: 11, color: '#bbb', fontFamily: 'system-ui' }}>
+        実線: 画面遷移（前進） / 破線: 戻る操作
+      </div>
+    </div>
+  );
+}
+
+exports.default = OverviewScreen;

--- a/src-tauri/skills/wireframe/templates/screens--screen.example.jsx
+++ b/src-tauri/skills/wireframe/templates/screens--screen.example.jsx
@@ -1,0 +1,209 @@
+
+// ── screens/<ScreenName> テンプレート例 ──────────────────────────────
+// このファイルはスキーマ確認用のサンプル。実際の画面モジュールは
+// ドメイン分析に基づいて新規生成する。
+//
+// ── インポートパターン ─────────────────────────────────────────────────
+//   const W = require('../components/W').default;
+//   const { WInput, WTextarea, WBtn, WSelect, WBadge, WText } = require('../components/primitives');
+//   const { Frame, Card, Row, Divider, Spacer } = require('../components/layout');
+//
+// ── Props パターン ────────────────────────────────────────────────────
+//   sa  (bool)     : showAll フラグ。W / プリミティブコンポーネント全てに渡す
+//   go  (function) : go('tab-key') でタブ切り替え（画面遷移）
+//   + 画面固有の props（例: isCreate, userId など）
+//
+// ── エクスポートパターン ──────────────────────────────────────────────
+//   単一画面: exports.default = XxxScreen;
+//   複数画面: exports.XxxScreen = XxxScreen; exports.YyyScreen = YyyScreen;
+//
+// ── エンティティバインディング ────────────────────────────────────────
+//   W / プリミティブコンポーネントの e, f props にエンティティ情報を渡す:
+//     e: エンティティ名（例: "Task", "User", "TaskService"）
+//     f: フィールド名またはメソッドシグネチャ（例: "title", "createTask(title, dueDate)"）
+//   バインディングなしの要素は e, f を省略してよい（ツールチップなし）
+
+const W = require('../components/W').default;
+const { WInput, WTextarea, WBtn, WSelect, WBadge, WText } = require('../components/primitives');
+const { Frame, Card, Row, Divider, Spacer } = require('../components/layout');
+
+// ══════════════════════════════════════════════════════════════════════
+// パターン 1: list 型画面
+// 用途: エンティティ一覧表示。行クリックで詳細、ヘッダーに新規作成ボタン
+// ══════════════════════════════════════════════════════════════════════
+
+// サンプルデータ（2〜3件あればワイヤーフレームとして十分）
+const ITEMS = [
+  { title: 'サンプルアイテム 1', status: 'TODO',      sc: '#f9e2af', meta: '2026/5/10' },
+  { title: 'サンプルアイテム 2', status: 'COMPLETED', sc: '#a6e3a1', meta: '2026/4/30' },
+];
+
+function ListScreen({ sa, go }) {
+  return (
+    <Frame
+      title="一覧"
+      // rightEl: ヘッダー右端に配置する要素（ログインユーザー情報など）
+      rightEl={
+        <W e="User" f="name" sa={sa} style={{ fontSize: 13, color: '#444', fontFamily: 'system-ui' }}>
+          山田 太郎
+        </W>
+      }
+    >
+      {/* 新規作成ボタン: 右揃え */}
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <WBtn label="＋ 新規作成" primary e="ItemService" f="create()" sa={sa} onClick={() => go('item-create')} />
+      </div>
+
+      {/* 一覧: 各行を Card でラップ */}
+      {ITEMS.map((item, i) => (
+        <Card key={i}>
+          {/* タイトル: クリックで詳細へ */}
+          <W e="Item" f="title" sa={sa}>
+            <span onClick={() => go('item-detail')} style={{ fontSize: 14, fontWeight: 600, color: '#222', fontFamily: 'system-ui', cursor: 'pointer', textDecoration: 'underline' }}>
+              {item.title}
+            </span>
+          </W>
+          {/* メタ情報: Row で横並び */}
+          <Row gap={12}>
+            <WBadge label={item.status} color={item.sc} e="Item" f="status" sa={sa} />
+            <W e="Item" f="dueDate" sa={sa}>
+              <span style={{ fontSize: 12, color: '#888', fontFamily: 'system-ui' }}>期日: {item.meta}</span>
+            </W>
+          </Row>
+        </Card>
+      ))}
+    </Frame>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// パターン 2: detail 型画面
+// 用途: エンティティの詳細表示。ヘッダー右に編集ボタン、下部にアクション群
+// ══════════════════════════════════════════════════════════════════════
+
+function DetailScreen({ sa, go }) {
+  return (
+    <Frame
+      title="詳細"
+      back backLabel="一覧へ" onBack={() => go('item-list')}
+      rightEl={
+        <WBtn label="編集" small e="ItemService" f="update(id, ...)" sa={sa} onClick={() => go('item-edit')} />
+      }
+    >
+      {/* メインコンテンツ Card */}
+      <Card>
+        <W e="Item" f="title" sa={sa}>
+          <span style={{ fontSize: 16, fontWeight: 700, color: '#111', fontFamily: 'system-ui' }}>サンプルアイテム 1</span>
+        </W>
+        <W e="Item" f="description" sa={sa}>
+          <span style={{ fontSize: 13, color: '#666', fontFamily: 'system-ui', lineHeight: 1.7 }}>
+            詳細な説明文がここに入ります。
+          </span>
+        </W>
+      </Card>
+
+      {/* メタ情報 Card: WText でラベル＋値の行を並べる */}
+      <Card>
+        <WText label="状態" value="TODO" e="Item" f="status" sa={sa} />
+        <Divider />
+        <WText label="期日" value="2026/5/10" e="Item" f="dueDate" sa={sa} />
+        <Divider />
+        <WText label="担当者" value="山田 太郎" e="Item" f="assigneeId → User.name" sa={sa} />
+      </Card>
+
+      {/* アクションボタン Row */}
+      <Row gap={12}>
+        <WBtn label="完了にする" primary e="ItemService" f="complete(id)" sa={sa} />
+        <WBtn label="キャンセル" e="ItemService" f="cancel(id)" sa={sa} onClick={() => go('item-list')} />
+      </Row>
+    </Frame>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// パターン 3: form 型画面（作成 / 編集の共用）
+// 用途: エンティティの作成・編集フォーム。isCreate prop で分岐
+// ══════════════════════════════════════════════════════════════════════
+
+function FormScreen({ sa, go, isCreate }) {
+  return (
+    <Frame
+      title={isCreate ? '新規作成' : '編集'}
+      back backLabel="キャンセル"
+      onBack={() => go(isCreate ? 'item-list' : 'item-detail')}
+    >
+      {/* フォームコンテナ: maxWidth で横幅を制限して中央配置 */}
+      <div style={{ maxWidth: 640, width: '100%', display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <WInput label="タイトル *" placeholder="タイトルを入力" e="Item" f="title" sa={sa} />
+        <WTextarea label="説明" e="Item" f="description" sa={sa} />
+        <WInput label="期日" placeholder="2026/05/10" e="Item" f="dueDate" sa={sa} />
+        <WSelect label="担当者" e="Item" f="assigneeId" sa={sa} />
+
+        {/* 作成時のみ表示するフィールド */}
+        {isCreate && (
+          <W e="ExternalService" f="registerEvent(item)" sa={sa}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', border: '1px solid #ddd', borderRadius: 6, background: 'white', cursor: 'pointer' }}>
+              <span style={{ fontSize: 14, color: '#888', fontFamily: 'system-ui' }}>☐</span>
+              <span style={{ fontSize: 13, color: '#666', fontFamily: 'system-ui' }}>外部サービスに登録する</span>
+            </div>
+          </W>
+        )}
+
+        {/* 送信 / キャンセルボタン */}
+        <Row gap={12}>
+          <WBtn
+            label={isCreate ? '作成する' : '保存する'}
+            primary
+            e="ItemService"
+            f={isCreate ? 'create(title, ...)' : 'update(id, ...)'}
+            sa={sa}
+            onClick={() => go(isCreate ? 'item-list' : 'item-detail')}
+          />
+          <WBtn
+            label="キャンセル"
+            e="ItemService" f="(cancel)"
+            sa={sa}
+            onClick={() => go(isCreate ? 'item-list' : 'item-detail')}
+          />
+        </Row>
+      </div>
+    </Frame>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// パターン 4: auth 型画面
+// 用途: ログイン / 新規登録フォーム。maxWidth 480 で中央配置
+// ══════════════════════════════════════════════════════════════════════
+
+function AuthScreen({ sa, go }) {
+  return (
+    <Frame title="アプリ名">
+      {/* 中央配置フォームコンテナ */}
+      <div style={{ maxWidth: 480, width: '100%', margin: '0 auto', padding: '32px 0', display: 'flex', flexDirection: 'column', gap: 18 }}>
+        {/* アプリロゴ代替 */}
+        <div style={{ textAlign: 'center', fontFamily: 'system-ui', fontSize: 28, fontWeight: 800, color: '#333', marginBottom: 8 }}>□</div>
+
+        <WInput label="メールアドレス" placeholder="user@example.com" e="Email" f="value" sa={sa} />
+        <WInput label="パスワード" placeholder="••••••••" />
+        <WBtn label="ログイン" primary e="AuthService" f="authenticate(email, password)" sa={sa} onClick={() => go('main')} />
+
+        {/* 画面切り替えリンク */}
+        <div style={{ textAlign: 'center' }}>
+          <span onClick={() => go('register')} style={{ fontSize: 13, color: '#777', fontFamily: 'system-ui', textDecoration: 'underline', cursor: 'pointer' }}>
+            新規登録はこちら
+          </span>
+        </div>
+      </div>
+    </Frame>
+  );
+}
+
+// エクスポート（単一画面の場合）
+exports.default = ListScreen;
+
+// エクスポート（複数画面をまとめる場合）
+// exports.ListScreen = ListScreen;
+// exports.DetailScreen = DetailScreen;
+// exports.FormScreen = FormScreen;
+// exports.AuthScreen = AuthScreen;

--- a/src-tauri/src/claude_plugin.rs
+++ b/src-tauri/src/claude_plugin.rs
@@ -87,6 +87,24 @@ pub fn generate_plugin_files(app_handle: &AppHandle) -> Result<(), String> {
     )
     .map_err(|e| format!("Failed to write hooks.json: {}", e))?;
 
+    // skills/
+    write_skill_files(&plugin_dir)?;
+
+    Ok(())
+}
+
+fn write_skill_files(plugin_dir: &std::path::Path) -> Result<(), String> {
+    let skills_dir = plugin_dir.join("skills");
+    for (rel_path, content) in crate::claude_plugin_skills::SKILL_FILES {
+        let dest = skills_dir.join(rel_path);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                format!("Failed to create skill dir {}: {}", parent.display(), e)
+            })?;
+        }
+        std::fs::write(&dest, content)
+            .map_err(|e| format!("Failed to write skill file {}: {}", dest.display(), e))?;
+    }
     Ok(())
 }
 
@@ -136,6 +154,7 @@ fn build_plugin_json(exe_path: &str) -> serde_json::Value {
         "name": PLUGIN_NAME,
         "description": "oretachi worktree notification hooks & MCP server",
         "mcpServers": "./.mcp.json",
+        "skills": "./skills/",
         "env": {
             "ORETACHI_APP_PATH": exe_path
         },

--- a/src-tauri/src/claude_plugin_skills.rs
+++ b/src-tauri/src/claude_plugin_skills.rs
@@ -1,0 +1,62 @@
+/// Claude Code プラグインに同梱するスキルファイルの埋め込みデータ。
+/// 各エントリは (プラグイン skills/ ディレクトリからの相対パス, ファイル内容) のペア。
+pub const SKILL_FILES: &[(&str, &str)] = &[
+    // --- domain-model-diagram ---
+    (
+        "domain-model-diagram/SKILL.md",
+        include_str!("../skills/domain-model-diagram/SKILL.md"),
+    ),
+    (
+        "domain-model-diagram/templates/entry-point.jsx",
+        include_str!("../skills/domain-model-diagram/templates/entry-point.jsx"),
+    ),
+    (
+        "domain-model-diagram/templates/components--EntityBox.jsx",
+        include_str!("../skills/domain-model-diagram/templates/components--EntityBox.jsx"),
+    ),
+    (
+        "domain-model-diagram/templates/components--RelationshipLine.jsx",
+        include_str!(
+            "../skills/domain-model-diagram/templates/components--RelationshipLine.jsx"
+        ),
+    ),
+    (
+        "domain-model-diagram/templates/data--entities.example.jsx",
+        include_str!("../skills/domain-model-diagram/templates/data--entities.example.jsx"),
+    ),
+    (
+        "domain-model-diagram/templates/data--relationships.example.jsx",
+        include_str!(
+            "../skills/domain-model-diagram/templates/data--relationships.example.jsx"
+        ),
+    ),
+    // --- wireframe ---
+    (
+        "wireframe/SKILL.md",
+        include_str!("../skills/wireframe/SKILL.md"),
+    ),
+    (
+        "wireframe/templates/entry-point.jsx",
+        include_str!("../skills/wireframe/templates/entry-point.jsx"),
+    ),
+    (
+        "wireframe/templates/components--W.jsx",
+        include_str!("../skills/wireframe/templates/components--W.jsx"),
+    ),
+    (
+        "wireframe/templates/components--layout.jsx",
+        include_str!("../skills/wireframe/templates/components--layout.jsx"),
+    ),
+    (
+        "wireframe/templates/components--primitives.jsx",
+        include_str!("../skills/wireframe/templates/components--primitives.jsx"),
+    ),
+    (
+        "wireframe/templates/screens--OverviewScreen.example.jsx",
+        include_str!("../skills/wireframe/templates/screens--OverviewScreen.example.jsx"),
+    ),
+    (
+        "wireframe/templates/screens--screen.example.jsx",
+        include_str!("../skills/wireframe/templates/screens--screen.example.jsx"),
+    ),
+];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod ai_judge;
 mod ai_provider;
 mod archive_db;
 mod claude_plugin;
+mod claude_plugin_skills;
 mod fs_watcher;
 mod git_worktree;
 mod ide_launcher;


### PR DESCRIPTION
## Summary

- `src-tauri/skills/` にスキルのソースファイル（domain-model-diagram・wireframe）を配置し、`include_str!` でRustバイナリにコンパイル時埋め込み
- `claude_plugin_skills.rs` を新規追加（13ファイル分の `&[(&str, &str)]` 定数配列）
- `generate_plugin_files()` でプラグインディレクトリへのスキルファイル書き出しを追加
- `plugin.json` に `"skills": "./skills/"` を追加

これにより、oretachiプラグインをインストールするだけで `domain-model-diagram` / `wireframe` スキルが自動展開されるようになる。

## Test plan

- [ ] `cd src-tauri && cargo check` でコンパイルエラーなし
- [ ] アプリ起動後に `%APPDATA%/com.ia.oretachi/claude-plugins/oretachi/skills/` 配下にスキルファイルが展開されることを確認
- [ ] Claude Code でプラグイン有効時に `/domain-model-diagram` / `/wireframe` スキルが利用可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)