### PR TITLE
feat: webview ハング診断機能を追加

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ use fs_watcher::FsWatcherManager;
 use process_utils::WorktreeRemoveManager;
 use pty_manager::{AiAgentChangedPayload, PtyManager};
 use settings::{AppSettings, SettingsManager};
-use tauri::{Emitter, Manager, State};
+use tauri::{Emitter, Listener, Manager, State};
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 
 /// パスコンポーネントに `..`、絶対パス区切り文字、NULバイトが含まれていないか検証する
@@ -979,6 +979,92 @@ pub fn run() {
             // AIエージェントインジケーター用ポーリング起動
             let pty_manager = app.state::<PtyManager>();
             pty_manager.start_polling(app.handle().clone());
+
+            // Webview ハング診断: heartbeat ループ（30秒間隔で ping → pong のラウンドトリップ計測）
+            {
+                use std::sync::Arc;
+                use std::sync::atomic::{AtomicU64, Ordering};
+                use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+                let last_pong_ms = Arc::new(AtomicU64::new(0));
+                let last_pong_for_listener = last_pong_ms.clone();
+                let heartbeat_handle = app.handle().clone();
+
+                // pong リスナー登録
+                heartbeat_handle.listen("__webview-heartbeat-pong", move |event: tauri::Event| {
+                    #[derive(serde::Deserialize)]
+                    struct PongPayload {
+                        ts: u64,
+                        mem: Option<u64>,
+                        terminals: Option<TerminalStats>,
+                    }
+                    #[derive(serde::Deserialize)]
+                    struct TerminalStats {
+                        active: u32,
+                        #[serde(rename = "totalMounts")]
+                        total_mounts: u32,
+                        #[serde(rename = "totalUnmounts")]
+                        total_unmounts: u32,
+                    }
+                    let now_ms = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64;
+                    last_pong_for_listener.store(now_ms, Ordering::Relaxed);
+                    if let Ok(payload) = serde_json::from_str::<PongPayload>(event.payload()) {
+                        let rtt = now_ms.saturating_sub(payload.ts);
+                        let mem_mb = payload.mem.unwrap_or(0) / 1024 / 1024;
+                        if let Some(t) = &payload.terminals {
+                            log::debug!(
+                                "[heartbeat] pong rtt={}ms mem={}MB terminals(active={} mounts={} unmounts={})",
+                                rtt, mem_mb, t.active, t.total_mounts, t.total_unmounts
+                            );
+                        } else {
+                            log::debug!("[heartbeat] pong rtt={}ms mem={}MB", rtt, mem_mb);
+                        }
+                        if rtt > 5000 {
+                            log::warn!("[heartbeat] webview response slow: rtt={}ms", rtt);
+                        }
+                    }
+                });
+
+                // ping ループ
+                let ping_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let mut ping_pending_since: Option<u64> = None;
+                    loop {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        let now_ms = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as u64;
+                        // pong が届いていれば pending をクリア（エラー判定より先に行う）
+                        let last_pong = last_pong_ms.load(Ordering::Relaxed);
+                        if last_pong > 0 && now_ms.saturating_sub(last_pong) < 35_000 {
+                            ping_pending_since = None;
+                        }
+                        // クリアされずに残っている場合のみ本当の未応答と判定
+                        if let Some(pending_since) = ping_pending_since {
+                            let unresponsive_secs = now_ms.saturating_sub(pending_since) / 1000;
+                            log::error!(
+                                "[heartbeat] webview unresponsive, no pong for {}s",
+                                unresponsive_secs
+                            );
+                        }
+                        match ping_handle.emit("__webview-heartbeat-ping", serde_json::json!({ "ts": now_ms })) {
+                            Ok(_) => {
+                                if ping_pending_since.is_none() {
+                                    ping_pending_since = Some(now_ms);
+                                }
+                            }
+                            Err(e) => {
+                                log::error!("[heartbeat] ping emit failed: {}", e);
+                                ping_pending_since = None;
+                            }
+                        }
+                    }
+                });
+            }
 
             // 通常モード: MCP サーバー起動 + ウィンドウ表示
             if mcp_enabled {

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -983,7 +983,25 @@ async fn notify_handler(
             StatusCode::OK
         }
         Err(e) => {
-            log::error!("Failed to emit {}: {}", event_name, e);
+            // webview の状態情報を詳細ログに記録してハング診断に役立てる
+            let window_info: Vec<String> = app_handle
+                .webview_windows()
+                .iter()
+                .map(|(label, w)| {
+                    format!(
+                        "{}(visible={:?} focused={:?})",
+                        label,
+                        w.is_visible().unwrap_or(false),
+                        w.is_focused().unwrap_or(false)
+                    )
+                })
+                .collect();
+            log::error!(
+                "[emit-failed] event={} error={} windows=[{}]",
+                event_name,
+                e,
+                window_info.join(", ")
+            );
             StatusCode::INTERNAL_SERVER_ERROR
         }
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, nextTick, onMounted, computed, watch } from "vue";
 import { renderToDataUrl } from "./composables/useTerminalThumbnail";
 import { isDirty, clearDirty } from "./composables/usePtyDispatcher";
-import { listen, emitTo } from "@tauri-apps/api/event";
+import { listen, emitTo, emit } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import TerminalView from "./components/TerminalView.vue";
 import FrameContainer from "./components/FrameContainer.vue";
@@ -48,6 +48,8 @@ import { useSubWindowEvents } from "./composables/useSubWindowEvents";
 import { useShutdownGuard } from "./composables/useShutdownGuard";
 import type { ArchiveRow } from "./types/archive";
 import { debug } from "@tauri-apps/plugin-log";
+import { startEventLoopMonitor } from "./utils/eventLoopMonitor";
+import { terminalMountCount, terminalUnmountCount, terminalActiveCount } from "./components/TerminalView.vue";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { useUpdater } from "./composables/useUpdater";
 import Toast from "primevue/toast";
@@ -1295,6 +1297,23 @@ onMounted(async () => {
       }
     }
   }, 3000);
+
+  // Webview ハング診断: Rust からの heartbeat ping に pong で応答
+  await listen<{ ts: number }>("__webview-heartbeat-ping", async (event) => {
+    const mem = (performance as { memory?: { usedJSHeapSize?: number } }).memory?.usedJSHeapSize;
+    await emit("__webview-heartbeat-pong", {
+      ts: event.payload.ts,
+      mem,
+      terminals: {
+        active: terminalActiveCount,
+        totalMounts: terminalMountCount,
+        totalUnmounts: terminalUnmountCount,
+      },
+    }).catch(() => {});
+  });
+
+  // Webview ハング診断: JS メインスレッドのブロック検出
+  startEventLoopMonitor();
 });
 
 </script>

--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -366,7 +366,14 @@ watch(
   }
 );
 
+// ターミナルライフサイクルカウンター（ハング診断用）
+export let terminalMountCount = 0;
+export let terminalUnmountCount = 0;
+export let terminalActiveCount = 0;
+
 onMounted(async () => {
+  terminalMountCount++;
+  terminalActiveCount++;
   debug(`[TerminalView] onMounted initialSessionId=${props.initialSessionId} autoStart=${props.autoStart} cwd=${props.cwd}`);
   initTerminal();
   if (props.initialSessionId !== undefined) {
@@ -382,6 +389,8 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  terminalUnmountCount++;
+  terminalActiveCount--;
   debug(`[TerminalView] onUnmounted sessionId=${sessionId.value} cwd=${props.cwd}`);
   if (resizeDebounce) clearTimeout(resizeDebounce);
   resizeObserver?.disconnect();

--- a/src/utils/eventLoopMonitor.ts
+++ b/src/utils/eventLoopMonitor.ts
@@ -1,0 +1,24 @@
+import { warn } from "@tauri-apps/plugin-log";
+
+const INTERVAL_MS = 2000;
+const BLOCK_THRESHOLD_MS = 5000;
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * JS メインスレッドのイベントループ遅延を監視する。
+ * setInterval の実測間隔が期待値を大幅に超えた場合、メインスレッドがブロックされていたと判定してログに記録する。
+ */
+export function startEventLoopMonitor(): void {
+  if (intervalId !== null) return;
+  let lastTs = performance.now();
+  intervalId = setInterval(() => {
+    const now = performance.now();
+    const delta = now - lastTs;
+    const blocked = delta - INTERVAL_MS;
+    if (blocked >= BLOCK_THRESHOLD_MS) {
+      warn(`[EventLoop] main thread blocked for ${Math.round(blocked)}ms`);
+    }
+    lastTs = now;
+  }, INTERVAL_MS);
+}


### PR DESCRIPTION
## Summary

- Webview フリーズ発生時（2026-04-14 21:29）のログ分析を実施。JS スレッドが 21:26:44 に停止し、21:29:24 に IPC チャネルが破綻したことを確認したが、根本原因はログのみでは特定不可
- 次回再発時に原因を秒単位で特定できるよう、以下の診断機能を追加

## 追加した診断機能

- **Webview Heartbeat** (`src-tauri/src/lib.rs`): 30 秒ごとに Rust → JS → Rust のラウンドトリップ計測。応答遅延（>5s）を warn、無応答を error でログ出力
- **JS イベントループ監視** (`src/utils/eventLoopMonitor.ts`): `setInterval` の実測間隔ドリフトでメインスレッドのブロックを検出（閾値 5s）
- **ターミナルライフサイクルカウンター** (`src/components/TerminalView.vue`): mount/unmount 回数と現在アクティブ数を pong ペイロードに含めて送信
- **emit 失敗時の詳細ログ** (`src-tauri/src/mcp_server.rs`): 失敗時にウィンドウ一覧・visible/focused 状態を記録

## Test plan

- [ ] `cargo check` でコンパイルエラーなし
- [ ] `pnpm run type-check` で型エラーなし
- [ ] `pnpm run tauri dev` 起動後、30 秒ごとに `[heartbeat] pong` がログに出ること
- [ ] pong ペイロードに `mem`・`terminals` が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)