### PR TITLE
fix: TerminalView.vue の script setup 内の不正な export を修正

### DIFF
--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -1,3 +1,10 @@
+<script lang="ts">
+// ターミナルライフサイクルカウンター（ハング診断用）
+export let terminalMountCount = 0;
+export let terminalUnmountCount = 0;
+export let terminalActiveCount = 0;
+</script>
+
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { Terminal } from "@xterm/xterm";
@@ -365,11 +372,6 @@ watch(
     }
   }
 );
-
-// ターミナルライフサイクルカウンター（ハング診断用）
-export let terminalMountCount = 0;
-export let terminalUnmountCount = 0;
-export let terminalActiveCount = 0;
 
 onMounted(async () => {
   terminalMountCount++;


### PR DESCRIPTION
## Summary

- `src/components/TerminalView.vue` の `<script setup>` 内に `export let` が含まれており、Vue の `<script setup>` では ES module exports が禁止されているため全プラットフォームの CI ビルドが失敗していた
- `terminalMountCount` / `terminalUnmountCount` / `terminalActiveCount` の export 定義を `<script setup>` から分離し、ファイル先頭の独立した `<script lang="ts">` ブロックに移動
- `App.vue` 側の import は変更不要

## Root cause

コミット `d096686` (feat: webview ハング診断機能を追加) で導入されたカウンター変数が `<script setup>` 内で `export let` されていた。

Fixes: [actions/runs/24412042784](https://github.com/ishida-supsys/oretachi/actions/runs/24412042784)

## Test plan

- [x] `pnpm run type-check` — エラーなし
- [x] `pnpm build` (vite build) — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)