### PR TITLE
feat: ワークツリー追加設定で .tsbuildinfo ファイルを自動検出

### DIFF
--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -736,6 +736,40 @@ pub fn read_gitignore(repo_path: &str) -> Result<Vec<String>, String> {
     Ok(entries)
 }
 
+/// リポジトリ内の .tsbuildinfo ファイルを検出して相対パスのリストを返す。
+/// node_modules, .git, target 等は除外する。
+pub fn detect_tsbuildinfo_files(repo_path: &str) -> Result<Vec<String>, String> {
+    let repo = std::path::Path::new(repo_path);
+    let pattern = format!("{}/**/*.tsbuildinfo", repo_path.replace('\\', "/"));
+    let mut results = Vec::new();
+
+    let exclude_dirs = ["node_modules", ".git", "target"];
+
+    let iter = match glob::glob(&pattern) {
+        Ok(iter) => iter,
+        Err(e) => {
+            log::warn!("tsbuildinfo glob error: {}", e);
+            return Ok(results);
+        }
+    };
+
+    for entry in iter.filter_map(|r| r.ok()) {
+        if !entry.is_file() {
+            continue;
+        }
+        let rel = entry.strip_prefix(repo).unwrap_or(&entry);
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        if exclude_dirs.iter().any(|d| {
+            rel_str.starts_with(&format!("{}/", d)) || rel_str.contains(&format!("/{}/", d))
+        }) {
+            continue;
+        }
+        results.push(rel_str);
+    }
+
+    Ok(results)
+}
+
 fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<u32, String> {
     std::fs::create_dir_all(dst).map_err(|e| format!("failed to create dir {:?}: {}", dst, e))?;
     let mut count = 0u32;

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -737,13 +737,14 @@ pub fn read_gitignore(repo_path: &str) -> Result<Vec<String>, String> {
 }
 
 /// リポジトリ内の .tsbuildinfo ファイルを検出して相対パスのリストを返す。
-/// node_modules, .git, target 等は除外する。
+/// .git, target は除外。node_modules 内はパッケージディレクトリを除外し、
+/// .cache 等のドットディレクトリのみ検索する。
 pub fn detect_tsbuildinfo_files(repo_path: &str) -> Result<Vec<String>, String> {
     let repo = std::path::Path::new(repo_path);
     let pattern = format!("{}/**/*.tsbuildinfo", repo_path.replace('\\', "/"));
     let mut results = Vec::new();
 
-    let exclude_dirs = ["node_modules", ".git", "target"];
+    let exclude_dirs = [".git", "target"];
 
     let iter = match glob::glob(&pattern) {
         Ok(iter) => iter,
@@ -764,10 +765,33 @@ pub fn detect_tsbuildinfo_files(repo_path: &str) -> Result<Vec<String>, String> 
         }) {
             continue;
         }
+        // node_modules 内のパッケージディレクトリを除外（.cache 等のドットディレクトリは許可）
+        if is_in_node_modules_package(&rel_str) {
+            continue;
+        }
         results.push(rel_str);
     }
 
     Ok(results)
+}
+
+/// node_modules/ 直下のパッケージディレクトリ内かどうかを判定する。
+/// `node_modules/.cache/` 等のドットディレクトリは許可、それ以外（パッケージ）は除外。
+fn is_in_node_modules_package(rel_str: &str) -> bool {
+    let nm = "node_modules/";
+    let mut search_from = 0;
+    while let Some(pos) = rel_str[search_from..].find(nm) {
+        let after_nm = search_from + pos + nm.len();
+        if after_nm < rel_str.len() {
+            let next_char = rel_str.as_bytes()[after_nm];
+            // ドットで始まるディレクトリ (.cache 等) は許可、それ以外はパッケージ
+            if next_char != b'.' {
+                return true;
+            }
+        }
+        search_from = after_nm;
+    }
+    false
 }
 
 fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<u32, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,6 +244,11 @@ async fn read_gitignore(repo_path: String) -> Result<Vec<String>, String> {
 }
 
 #[tauri::command]
+async fn detect_tsbuildinfo_files(repo_path: String) -> Result<Vec<String>, String> {
+    run_git(move || git_worktree::detect_tsbuildinfo_files(&repo_path)).await
+}
+
+#[tauri::command]
 async fn copy_gitignore_targets(
     repo_path: String,
     worktree_path: String,
@@ -813,6 +818,7 @@ pub fn run() {
             git_list_branches,
             detect_package_manager,
             read_gitignore,
+            detect_tsbuildinfo_files,
             copy_gitignore_targets,
             write_claude_plugin_config,
             copy_claude_session_data,

--- a/src/components/PostAddSettingsDialog.vue
+++ b/src/components/PostAddSettingsDialog.vue
@@ -54,7 +54,15 @@ onMounted(async () => {
       invoke<string[]>("read_gitignore", { repoPath: props.repoPath }),
       invoke<string[]>("detect_package_manager", { repoPath: props.repoPath }),
     ]);
-    entries.value = gitignoreResult;
+    const tsbiResult = await invoke<string[]>("detect_tsbuildinfo_files", { repoPath: props.repoPath }).catch(() => []);
+    // gitignore エントリに .tsbuildinfo 検出結果を統合（重複除外）
+    const merged = [...gitignoreResult];
+    for (const tsbi of tsbiResult) {
+      if (!merged.includes(tsbi)) {
+        merged.push(tsbi);
+      }
+    }
+    entries.value = merged;
     detectedPMs.value = detectedResult;
     // 未設定かつ検出結果があれば自動選択
     if (selectedPM.value === undefined && detectedResult.length > 0) {
@@ -195,6 +203,7 @@ function onConfirm() {
               @change="toggle(entry)"
             />
             <span class="entry-text">{{ entry }}</span>
+            <span v-if="entry.endsWith('.tsbuildinfo')" class="badge-ts">TS cache</span>
           </label>
         </div>
       </div>
@@ -464,6 +473,17 @@ function onConfirm() {
 .hook-kind-select:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.badge-ts {
+  font-size: 10px;
+  color: #89b4fa;
+  background: #1e3a5f;
+  border: 1px solid #3a5a8f;
+  border-radius: 3px;
+  padding: 1px 5px;
+  margin-left: auto;
+  white-space: nowrap;
 }
 </style>
 


### PR DESCRIPTION
## Summary

- `detect_tsbuildinfo_files` (Rust) を追加し、`**/*.tsbuildinfo` をglob検索してリポジトリ内のキャッシュファイルを検出（`node_modules` / `.git` / `target` 以下は除外）
- ワークツリー追加設定ダイアログ (`PostAddSettingsDialog.vue`) の初期化時に検出結果を gitignore コピーリストにマージ表示
- `.tsbuildinfo` エントリには「TS cache」バッジを表示して視覚的に区別
- 検出が失敗しても既存の gitignore リスト・パッケージマネージャ自動選択に影響しないよう、独立した呼び出しに分離

## Test plan

- [ ] TypeScript プロジェクトのリポジトリを登録し「設定」ダイアログを開く → `.tsbuildinfo` ファイルが「TS cache」バッジ付きでリストに表示される
- [ ] `.gitignore` に `*.tsbuildinfo` が書かれていないプロジェクトでも検出される
- [ ] `node_modules` 以下の `.tsbuildinfo` は表示されない
- [ ] チェックして保存後、ワークツリー追加時にファイルがコピーされる
- [ ] `cargo check` / `pnpm run type-check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)