### PR TITLE
fix: webview ハング時のリカバリとハング診断を強化

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1002,6 +1002,8 @@ pub fn run() {
                     struct PongPayload {
                         ts: u64,
                         mem: Option<u64>,
+                        #[serde(rename = "blockedMs")]
+                        blocked_ms: Option<u64>,
                         terminals: Option<TerminalStats>,
                     }
                     #[derive(serde::Deserialize)]
@@ -1020,16 +1022,26 @@ pub fn run() {
                     if let Ok(payload) = serde_json::from_str::<PongPayload>(event.payload()) {
                         let rtt = now_ms.saturating_sub(payload.ts);
                         let mem_mb = payload.mem.unwrap_or(0) / 1024 / 1024;
+                        let blocked_ms = payload.blocked_ms.unwrap_or(0);
                         if let Some(t) = &payload.terminals {
                             log::debug!(
-                                "[heartbeat] pong rtt={}ms mem={}MB terminals(active={} mounts={} unmounts={})",
-                                rtt, mem_mb, t.active, t.total_mounts, t.total_unmounts
+                                "[heartbeat] pong rtt={}ms mem={}MB blockedMs={} terminals(active={} mounts={} unmounts={})",
+                                rtt, mem_mb, blocked_ms, t.active, t.total_mounts, t.total_unmounts
                             );
                         } else {
-                            log::debug!("[heartbeat] pong rtt={}ms mem={}MB", rtt, mem_mb);
+                            log::debug!(
+                                "[heartbeat] pong rtt={}ms mem={}MB blockedMs={}",
+                                rtt, mem_mb, blocked_ms
+                            );
                         }
                         if rtt > 5000 {
                             log::warn!("[heartbeat] webview response slow: rtt={}ms", rtt);
+                        }
+                        if blocked_ms >= 5000 {
+                            log::warn!(
+                                "[heartbeat] main thread blocked since last pong: {}ms",
+                                blocked_ms
+                            );
                         }
                     }
                 });
@@ -1038,6 +1050,7 @@ pub fn run() {
                 let ping_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     let mut ping_pending_since: Option<u64> = None;
+                    let mut unresponsive_logged_until_secs: u64 = 0;
                     loop {
                         tokio::time::sleep(Duration::from_secs(30)).await;
                         let now_ms = SystemTime::now()
@@ -1048,21 +1061,35 @@ pub fn run() {
                         let last_pong = last_pong_ms.load(Ordering::Relaxed);
                         if last_pong > 0 && now_ms.saturating_sub(last_pong) < 35_000 {
                             ping_pending_since = None;
+                            unresponsive_logged_until_secs = 0;
                         }
                         // クリアされずに残っている場合のみ本当の未応答と判定
                         if let Some(pending_since) = ping_pending_since {
                             let unresponsive_secs = now_ms.saturating_sub(pending_since) / 1000;
-                            log::error!(
-                                "[heartbeat] webview unresponsive, no pong for {}s",
-                                unresponsive_secs
-                            );
-                            // 最初の unresponsive 検出時にメインウィンドウの強制リロードを試みる
+                            // 90秒までは毎回、以降は 300秒到達時に 1 回だけログ（無限連続出力を抑制）
+                            if unresponsive_secs <= 90 || unresponsive_secs >= 300 {
+                                if unresponsive_secs < 300 || unresponsive_logged_until_secs < 300 {
+                                    log::error!(
+                                        "[heartbeat] webview unresponsive, no pong for {}s",
+                                        unresponsive_secs
+                                    );
+                                    if unresponsive_secs >= 300 {
+                                        unresponsive_logged_until_secs = 300;
+                                    }
+                                }
+                            }
+                            // 最初の unresponsive 検出時にメインウィンドウの強制リロードを試みる。
+                            // eval("location.reload()") は JS タスクキュー経由のため、
+                            // JS メインスレッドが詰まっていると実行されない。
+                            // WebviewWindow::reload() は Tauri runtime 経由で UI スレッドに
+                            // post され、wry から ICoreWebView2::Reload() をネイティブ呼び出しするため、
+                            // JS がブロック状態でも復帰できる。
                             if unresponsive_secs < 35 {
                                 log::warn!("[heartbeat] attempting webview reload to recover from hang");
                                 for (label, webview) in ping_handle.webview_windows() {
                                     if label == "main" {
-                                        if let Err(e) = webview.eval("location.reload()") {
-                                            log::error!("[heartbeat] reload eval failed for {}: {}", label, e);
+                                        if let Err(e) = webview.reload() {
+                                            log::error!("[heartbeat] reload failed for {}: {}", label, e);
                                         } else {
                                             log::info!("[heartbeat] reload triggered for {}", label);
                                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1066,16 +1066,26 @@ pub fn run() {
                         // クリアされずに残っている場合のみ本当の未応答と判定
                         if let Some(pending_since) = ping_pending_since {
                             let unresponsive_secs = now_ms.saturating_sub(pending_since) / 1000;
-                            // 90秒までは毎回、以降は 300秒到達時に 1 回だけログ（無限連続出力を抑制）
-                            if unresponsive_secs <= 90 || unresponsive_secs >= 300 {
-                                if unresponsive_secs < 300 || unresponsive_logged_until_secs < 300 {
-                                    log::error!(
-                                        "[heartbeat] webview unresponsive, no pong for {}s",
-                                        unresponsive_secs
-                                    );
-                                    if unresponsive_secs >= 300 {
-                                        unresponsive_logged_until_secs = 300;
-                                    }
+                            // 90秒までは毎回、180秒で 1 回中間サイン、300秒で 1 回最終警告
+                            // （無限連続出力を抑制しつつ、長時間フリーズ継続中かどうかの目安を残す）
+                            let should_log = if unresponsive_secs <= 90 {
+                                true
+                            } else if unresponsive_secs >= 180
+                                && unresponsive_logged_until_secs < 180
+                            {
+                                true
+                            } else {
+                                unresponsive_secs >= 300 && unresponsive_logged_until_secs < 300
+                            };
+                            if should_log {
+                                log::error!(
+                                    "[heartbeat] webview unresponsive, no pong for {}s",
+                                    unresponsive_secs
+                                );
+                                if unresponsive_secs >= 300 {
+                                    unresponsive_logged_until_secs = 300;
+                                } else if unresponsive_secs >= 180 {
+                                    unresponsive_logged_until_secs = 180;
                                 }
                             }
                             // 最初の unresponsive 検出時にメインウィンドウの強制リロードを試みる。
@@ -1106,6 +1116,7 @@ pub fn run() {
                             Err(e) => {
                                 log::error!("[heartbeat] ping emit failed: {}", e);
                                 ping_pending_since = None;
+                                unresponsive_logged_until_secs = 0;
                             }
                         }
                     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1298,6 +1298,10 @@ onMounted(async () => {
     }
   }, 3000);
 
+  // Webview ハング診断: JS メインスレッドのブロック検出
+  // pong listen より先に起動して、初回 pong までのブロック時間も漏れなく測定する
+  startEventLoopMonitor();
+
   // Webview ハング診断: Rust からの heartbeat ping に pong で応答
   await listen<{ ts: number }>("__webview-heartbeat-ping", async (event) => {
     const mem = (performance as { memory?: { usedJSHeapSize?: number } }).memory?.usedJSHeapSize;
@@ -1312,9 +1316,6 @@ onMounted(async () => {
       },
     }).catch(() => {});
   });
-
-  // Webview ハング診断: JS メインスレッドのブロック検出
-  startEventLoopMonitor();
 });
 
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,7 @@ import { useSubWindowEvents } from "./composables/useSubWindowEvents";
 import { useShutdownGuard } from "./composables/useShutdownGuard";
 import type { ArchiveRow } from "./types/archive";
 import { debug } from "@tauri-apps/plugin-log";
-import { startEventLoopMonitor } from "./utils/eventLoopMonitor";
+import { consumeMaxBlockedMs, startEventLoopMonitor } from "./utils/eventLoopMonitor";
 import { terminalMountCount, terminalUnmountCount, terminalActiveCount } from "./components/TerminalView.vue";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { useUpdater } from "./composables/useUpdater";
@@ -1304,6 +1304,7 @@ onMounted(async () => {
     await emit("__webview-heartbeat-pong", {
       ts: event.payload.ts,
       mem,
+      blockedMs: consumeMaxBlockedMs(),
       terminals: {
         active: terminalActiveCount,
         totalMounts: terminalMountCount,

--- a/src/utils/eventLoopMonitor.ts
+++ b/src/utils/eventLoopMonitor.ts
@@ -4,6 +4,7 @@ const INTERVAL_MS = 2000;
 const BLOCK_THRESHOLD_MS = 5000;
 
 let intervalId: ReturnType<typeof setInterval> | null = null;
+let maxBlockedMs = 0;
 
 /**
  * JS メインスレッドのイベントループ遅延を監視する。
@@ -16,9 +17,22 @@ export function startEventLoopMonitor(): void {
     const now = performance.now();
     const delta = now - lastTs;
     const blocked = delta - INTERVAL_MS;
+    if (blocked > 0 && blocked > maxBlockedMs) {
+      maxBlockedMs = blocked;
+    }
     if (blocked >= BLOCK_THRESHOLD_MS) {
       warn(`[EventLoop] main thread blocked for ${Math.round(blocked)}ms`);
     }
     lastTs = now;
   }, INTERVAL_MS);
+}
+
+/**
+ * 前回取得時点からの最大ブロック時間(ms)を返し、カウンタをリセットする。
+ * heartbeat pong 送信時に呼び出して Rust 側で診断に利用する。
+ */
+export function consumeMaxBlockedMs(): number {
+  const value = Math.round(maxBlockedMs);
+  maxBlockedMs = 0;
+  return value;
 }


### PR DESCRIPTION
## Summary

- 運用中に Webview の完全ハングが計 3 回発生し、いずれも `[heartbeat] reload triggered for main` 後に回復せず手動強制終了を強いられていた問題を解消する
- 現行の `eval(\"location.reload()\")` は JS タスクキュー経由のため JS メインスレッドが詰まっていると実行されない。`WebviewWindow::reload()` に置換して wry→`ICoreWebView2::Reload()` のネイティブ呼び出しで復帰できるようにした
- pong に `blockedMs` を載せ、未応答ログのスパムを抑制しつつ 180s 中間サインで長時間フリーズを検知できるようにした

## 背景

ログ `D:\AKITO\Document\work\oretachi.log` (04-15〜04-17) および `20260420\oretachi.log` を解析したところ、以下の同一シグネチャのハングが 3 回再現:

- 04-17 12:29:42、21:18:55、04-20 13:06:51 で `[heartbeat] webview unresponsive` → `reload triggered for main` を発火したが復帰せず、数分間未応答 ERROR が続きユーザが強制終了
- 直前に hook/approval 通知バースト + TerminalView 再マウントが観測される

`eval(\"location.reload()\")` は JS 実行キューに enqueue されるだけで、JS が詰まっている限り実行されない。Tauri 2.10.3 の `WebviewWindow::reload()` は dispatcher→wry 経由で UI スレッドに post され、最終的に `ICoreWebView2::Reload()` をネイティブ呼び出しするため JS ブロック中でも復帰できる。

## 主な変更

### 1. 回復経路の修正 (`src-tauri/src/lib.rs`)

- `webview.eval(\"location.reload()\")` → `webview.reload()`
- ハング中でもネイティブ側で reload が走るため、次の ping 周期までに pong が再開すれば自動復帰する

### 2. 未応答ログのスパム抑制 + 中間サイン (`src-tauri/src/lib.rs`)

- 従来は 30 秒ごとに延々と ERROR が出続け、04-17 のログだけで 15 件以上
- 新ルール: 90s までは毎回、180s で 1 回中間サイン、300s で 1 回最終警告
- pong 受信 / ping emit 失敗時の双方で `unresponsive_logged_until_secs` をリセット（抜け経路の解消）

### 3. ハング診断強化 (`src/utils/eventLoopMonitor.ts` + `src/App.vue` + `src-tauri/src/lib.rs`)

- `consumeMaxBlockedMs()` を追加: 前回 pong 以降の最大メインスレッドブロック時間(ms)を返してリセット
- pong ペイロードに `blockedMs` を追加、Rust 側 `PongPayload` でログ出力、5000ms 超で WARN
- これでハング直前に JS が何秒詰まっていたかが heartbeat ログに残り、次回再発時の原因特定が進む
- `startEventLoopMonitor()` を pong listen 登録より前に移動し、初回 pong までのブロック計測漏れを解消

## 関連 Issue (参考)

- [tauri#8177](https://github.com/tauri-apps/tauri/issues/8177) / [tauri#11787](https://github.com/tauri-apps/tauri/issues/11787) — 高頻度 emit / emit_to で webview がフリーズする上流既知問題
- [tauri#12388](https://github.com/tauri-apps/tauri/issues/12388) — `location.reload()` と listen リーク

## Test plan

- [ ] `cd src-tauri && cargo check` パス
- [ ] `pnpm run type-check` パス
- [ ] `pnpm run tauri dev` で起動し、DevTools コンソールから意図的にメインスレッドを固める（例: `setTimeout(() => { const end = Date.now() + 40000; while (Date.now() < end) {} }, 100)`）
- [ ] 30 秒後に `[heartbeat] webview unresponsive` → `[heartbeat] reload triggered for main` が出てページが実際に再ロードされ、pong が再開することを確認
- [ ] 通常運用で pong ログに `blockedMs=N` が乗り、アイドル時は 0〜数十 ms に収まることを確認
- [ ] 180s / 300s 地点で中間サイン・最終警告が 1 回ずつ出ることをログ抑制動作として確認（長時間の強制ブロック下）

🤖 Generated with [Claude Code](https://claude.com/claude-code)