### PR TITLE
feat: MCP 経由のターミナル制御一式と起動先切替トグル

### DIFF
--- a/src-tauri/skills/background-command/SKILL.md
+++ b/src-tauri/skills/background-command/SKILL.md
@@ -58,22 +58,50 @@ oretachi_spawn_terminal({
 
 oretachi UI に新しいタブが追加され、`pnpm dev` がそのターミナルで実行される。
 
-### Step 3: 起動確認（必要な場合）
+### Step 3: 起動確認 / ステータス確認
 
-数秒待ってから `oretachi_list_terminals({ worktree_name: "<name>" })` を呼ぶと、`session_id` / `cwd` / `isAiAgent` を含む配列が返る。直前に追加したセッションが含まれていれば起動成功。
+`oretachi_list_terminals({ worktree_name: "<name>" })` を呼ぶと、各セッションの以下を含む配列が返る:
+
+- `sessionId` / `cwd` / `isAiAgent` / `worktreeId` / `worktreeName`
+- `status`: `"running"` か `"exited"`（シェル本体が終了したか）
+- `exitCode`: シェル本体の exit code（`status: "exited"` のときのみ非 null）
+- `lastCommandExitCode`: シェル統合が拾った**直近コマンド**の exit code（`pnpm test` の pass/fail 判定などに使える）
+
+直前に追加したセッションが含まれていれば起動成功。`pnpm dev` 等が突然死した場合は `status` が `"exited"` になる。
 
 ### Step 4: 出力ログを参照する
 
 dev サーバのコンパイルエラー確認、vitest の結果確認などに使う。
 
 ```
+// 初回: バッファ末尾から最大 max_bytes バイト
 oretachi_read_terminal({
   session_id: <値>,
   max_bytes: 8192   // 省略可。デフォルト 8192。長い場合は 32768 等まで増やす
 })
+
+// 連続ポーリング: 前回 cursor 以降の差分のみ取る（推奨）
+oretachi_read_terminal({
+  session_id: <値>,
+  from_cursor: <前回レスポンスの cursor>
+})
 ```
 
-戻り値は **ANSI エスケープ除去済みの UTF-8 文字列**（バッファ末尾から `max_bytes` バイト）。リングバッファは 64KiB で、それを超える出力は古い側から破棄される。
+レスポンスは JSON 文字列:
+
+```
+{
+  "text": "<ANSI 除去済み UTF-8>",
+  "cursor": 12345,
+  "lostBytes": 0
+}
+```
+
+- `text`: バッファ内容を ANSI エスケープ除去した UTF-8。
+- `cursor`: `text` 末尾の累積バイト位置。次回呼び出しで `from_cursor` に渡すと、それ以降の新規出力だけが返ってくる（重複なし）。
+- `lostBytes`: 要求 `from_cursor` がリングバッファ範囲外だった場合の欠落バイト数。`> 0` なら出力が間引かれている（バッファは 64KiB で、それを超える分は古い側から破棄される）。
+
+長期 watch（`pnpm dev` / `vitest --watch`）をポーリングする場合は **必ず `from_cursor` を使う**こと。使わないと毎回末尾 N バイトが返り、AI 側で重複処理が必要になる。
 
 ### Step 5: ターミナルへ入力する
 
@@ -96,6 +124,28 @@ oretachi_write_terminal({
 
 `submit: true` ならコマンド送信扱い（Enter まで押す）。`submit: false` なら raw 送信。
 
+#### Ctrl-C / EOF を送る (raw キー送信)
+
+常駐プロセスを graceful に止めたい時は、Ctrl-C を raw 送信する。
+
+```
+// Ctrl-C: pnpm dev / vitest --watch 等を graceful 停止
+oretachi_write_terminal({
+  session_id: <値>,
+  text: "",   // 0x03 = ETX
+  submit: false
+})
+
+// Ctrl-D / EOF: REPL 終了
+oretachi_write_terminal({
+  session_id: <値>,
+  text: "",   // 0x04 = EOT
+  submit: false
+})
+```
+
+停止後シェルプロンプトに戻ったら、続けて `oretachi_write_terminal` で別コマンドを投入できる。常駐プロセスがそれでも止まらない場合のみ次の `oretachi_kill_terminal` で強制 kill する。
+
 ### Step 6: 停止する場合
 
 `oretachi_list_terminals` で対象の `session_id` を特定してから:
@@ -104,10 +154,7 @@ oretachi_write_terminal({
 oretachi_kill_terminal({ session_id: <値> })  // 強制 kill
 ```
 
-graceful に終了させたい場合（dev サーバの後始末を走らせたい等）は kill ではなく `oretachi_write_terminal` で `Ctrl-C` 相当のシグナルが必要。現状の write は文字列送信のみで `\x03` の効果は限定的なので、安全策としては:
-
-1. まず `oretachi_write_terminal({ text: "exit", submit: true })` を試す（シェルプロンプトに戻った状態の時のみ有効）
-2. それで終わらない常駐プロセスは `oretachi_kill_terminal` で強制 kill
+graceful 終了は Step 5 の Ctrl-C を優先する。プロセスが Ctrl-C ハンドラを持たない / プロセスがハングしている場合のみ `oretachi_kill_terminal` で強制 kill する。
 
 UI のタブは `pty-exit` イベント経由で自動的に消える。
 
@@ -118,4 +165,5 @@ UI のタブは `pty-exit` イベント経由で自動的に消える。
 - 同一ワークツリーに連続して `oretachi_spawn_terminal` を呼んでも、内部的には FIFO キューで管理されるためコマンドは取りこぼされない（先入れ先出しで対応するターミナルに流し込まれる）
 - 対象ワークツリーが**サブウィンドウ化（detached）**されている場合、`oretachi_spawn_terminal` は明示的に invalid_params エラーを返す。エラー本文に従ってメインウィンドウに戻すよう促す
 - 同名ワークツリーが複数あって `worktree_id` を指定しなかった場合は `invalid_params` エラーが返る。エラー本文に候補 ID が含まれているのでそれを使って再試行する
-- `oretachi_read_terminal` の戻り値先頭は、リングバッファ容量超過時にバイト境界調整が走るため UTF-8 マルチバイトや ANSI シーケンスの欠片が落とされる。**末尾側は正確、先頭側は近似**と理解する
+- `oretachi_read_terminal` の `from_cursor` 未指定モード（末尾 N バイト）と `lostBytes > 0` のときは、UTF-8 / ANSI 境界調整のため先頭が落とされる（**末尾側は正確、先頭側は近似**）。`from_cursor` を渡した連続ポーリングで `lostBytes == 0` のときは、cursor は文字境界済みなので欠落なし
+- `lastCommandExitCode` はシェル統合 (bash の `PROMPT_COMMAND` / zsh の `precmd` / pwsh の `prompt`) が出力する OSC 777 を Rust 側 reader が拾う仕組み。シェルプロンプトが新しく描画されるたびに更新される。`pnpm test && echo done` のようなチェーンでは最後のコマンドの結果になる

--- a/src-tauri/skills/background-command/SKILL.md
+++ b/src-tauri/skills/background-command/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: background-command
 description: pnpm dev / pnpm run tauri dev / next dev / vite / nodemon / cargo watch / docker compose up など長時間常駐する開発サーバ・watcher・background プロセスを起動するときに、bash の run_in_background ではなく oretachi MCP ツール経由で oretachi UI の新しいターミナルタブとして起動するためのスキル。起動後の出力参照・キー入力（vitest の再実行など）にも対応。
-allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_spawn_terminal, mcp__plugin_oretachi_oretachi__oretachi_list_terminals, mcp__plugin_oretachi_oretachi__oretachi_kill_terminal, mcp__plugin_oretachi_oretachi__oretachi_read_terminal, mcp__plugin_oretachi_oretachi__oretachi_write_terminal, mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status
+allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_spawn_terminal, mcp__plugin_oretachi_oretachi__oretachi_list_terminals, mcp__plugin_oretachi_oretachi__oretachi_kill_terminal, mcp__plugin_oretachi_oretachi__oretachi_read_terminal, mcp__plugin_oretachi_oretachi__oretachi_write_terminal, mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status, mcp__plugin_oretachi_oretachi__oretachi_get_app_options
 ---
 
 # background-command スキル
@@ -34,7 +34,23 @@ allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_spawn_terminal, mcp__plug
 
 判断基準: **「実行後ずっと起動し続けるか？」**「Yes」ならこのスキル、「No」なら通常の bash。
 
+ただし oretachi 設定の **「AI からの background コマンドを oretachi ターミナルで起動する」が OFF** の場合は、上記判定で「Yes」でも本スキルは使わず Claude Code の bash tool（`run_in_background: true`）でフォールバック起動する。Step 0 で確認する。
+
 ## 手順
+
+### Step 0: グローバル設定を確認する
+
+最初に `oretachi_get_app_options` を呼び、戻り値の `useOretachiTerminalForBackground` を見る。
+
+```
+oretachi_get_app_options({})
+// => { "useOretachiTerminalForBackground": true | false }
+```
+
+- `true`（既定）: Step 1 以降に進む。
+- `false`: 本スキルは使わない。Claude Code の bash tool で `run_in_background: true` を指定して起動する（例: `bash` tool で `pnpm dev` を実行、`run_in_background: true`）。oretachi UI には新タブを作らない。以降の Step もスキップ。
+
+このトグルは oretachi 設定タブ → Terminal セクションの「AI からの background コマンドを oretachi ターミナルで起動する」に対応する。
 
 ### Step 1: ワークツリーを特定する
 

--- a/src-tauri/skills/background-command/SKILL.md
+++ b/src-tauri/skills/background-command/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: background-command
+description: pnpm dev / pnpm run tauri dev / next dev / vite / nodemon / cargo watch / docker compose up など長時間常駐する開発サーバ・watcher・background プロセスを起動するときに、bash の run_in_background ではなく oretachi MCP ツール経由で oretachi UI の新しいターミナルタブとして起動するためのスキル。
+allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_spawn_terminal, mcp__plugin_oretachi_oretachi__oretachi_list_terminals, mcp__plugin_oretachi_oretachi__oretachi_kill_terminal, mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status
+---
+
+# background-command スキル
+
+長時間常駐するコマンド（開発サーバ・ファイル監視・watch ビルド・HTTP サーバ等）を実行するとき、Claude Code の `bash` tool の `run_in_background` を使うのではなく、oretachi の MCP ツールで oretachi UI 上に新しいターミナルタブを追加してそこで実行する。
+
+これにより:
+
+- 出力ログが xterm.js でユーザーに可視化される
+- ユーザーが任意タイミングで Ctrl-C / kill できる
+- 他ワークツリーへの切替・detach 等の oretachi 既存 UI が活用できる
+- Claude Code 終了後もプロセスを残せる
+
+## いつこのスキルを使うか
+
+**使う**（長時間常駐するコマンド）:
+
+- `pnpm dev`, `pnpm run dev`, `pnpm run tauri dev`, `npm start`, `yarn dev`
+- `next dev`, `vite`, `nuxt dev`, `astro dev`
+- `nodemon`, `tsc --watch`, `cargo watch`, `cargo run`（HTTP サーバ等）
+- `docker compose up`（`-d` なし）, `rails s`, `flask run`, `python -m http.server`
+- その他、Ctrl-C しない限り終了しないコマンド全般
+
+**使わない**（短命コマンド or 出力をすぐ後処理したいケース）:
+
+- `pnpm test`, `pnpm run build`, `cargo build`, `cargo check`, `tsc --noEmit`, `eslint .`, `prettier --check`
+- ビルド・テスト・lint・型チェック等、終了コードを判定したいもの
+- ユーザーが明示的に「bash で background 実行して」と指示した場合
+- 出力を即 grep / 解析したい短命スクリプト（`curl`, `git log`, `ls` 等）
+
+判断基準: **「実行後ずっと起動し続けるか？」**「Yes」ならこのスキル、「No」なら通常の bash。
+
+## 手順
+
+### Step 1: ワークツリーを特定する
+
+`oretachi_get_worktree_status` を呼び、現在の作業ディレクトリ（PWD）と一致する worktree の `name` と `id` を取得する。
+
+複数の worktree が同名だった場合は `id` も使う。
+
+### Step 2: ターミナルを起動してコマンドを流し込む
+
+```
+oretachi_spawn_terminal({
+  worktree_name: "<Step 1 で取得した name>",
+  worktree_id: "<必要なら id を指定>",
+  command: "pnpm dev",
+  title: "pnpm dev",            // タブ表示名
+  reason: "ローカルサーバ起動"  // ログ用メモ（任意）
+})
+```
+
+戻り値は `"新規ターミナルの追加リクエストを送信しました"` のみ（fire-and-forget）。
+
+oretachi UI に新しいタブが追加され、`pnpm dev` がそのターミナルで実行される。
+
+### Step 3: 起動確認（必要な場合）
+
+数秒待ってから `oretachi_list_terminals({ worktree_name: "<name>" })` を呼ぶと、`session_id` / `cwd` / `isAiAgent` を含む配列が返る。直前に追加したセッションが含まれていれば起動成功。
+
+### Step 4: 停止する場合
+
+`oretachi_list_terminals` で対象の `session_id` を特定してから:
+
+```
+oretachi_kill_terminal({ session_id: <値> })
+```
+
+UI のタブは `pty-exit` イベント経由で自動的に消える。
+
+## 注意点
+
+- `command` は末尾に改行が無くても、oretachi 側で `\n` が自動付与される
+- シェルは oretachi のデフォルト（Windows なら PowerShell、それ以外は OS のシェル）。プラットフォーム固有の構文（PowerShell の `;` と bash の `&&` の違い等）に留意
+- `pendingScripts` 機構の制限により、同一ワークツリーに連続して `oretachi_spawn_terminal` を呼ぶ場合は前のコマンド投入完了まで待つこと。並行投入すると先に積まれたコマンドが上書きされる可能性がある
+- 同名ワークツリーが複数あって `worktree_id` を指定しなかった場合は `invalid_params` エラーが返る。エラー本文に候補 ID が含まれているのでそれを使って再試行する

--- a/src-tauri/skills/background-command/SKILL.md
+++ b/src-tauri/skills/background-command/SKILL.md
@@ -67,7 +67,7 @@ oretachi UI に新しいタブが追加され、`pnpm dev` がそのターミナ
 - `exitCode`: シェル本体の exit code（`status: "exited"` のときのみ非 null）
 - `lastCommandExitCode`: シェル統合が拾った**直近コマンド**の exit code（`pnpm test` の pass/fail 判定などに使える）
 
-直前に追加したセッションが含まれていれば起動成功。`pnpm dev` 等が突然死した場合は `status` が `"exited"` になる。
+直前に追加したセッションが含まれていれば起動成功。シェル本体が `exit` 等で自然終了したセッションは（zombie 化を防ぐため）map から自動的に除去されるので、続けてポーリングすると消える ＝ 終了したと判定できる。**コマンド単位の成否は `lastCommandExitCode` を見るのが基本**で、`pnpm test` のように shell 内で実行したコマンドの結果を観察したい場合に使う。
 
 ### Step 4: 出力ログを参照する
 

--- a/src-tauri/skills/background-command/SKILL.md
+++ b/src-tauri/skills/background-command/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: background-command
-description: pnpm dev / pnpm run tauri dev / next dev / vite / nodemon / cargo watch / docker compose up など長時間常駐する開発サーバ・watcher・background プロセスを起動するときに、bash の run_in_background ではなく oretachi MCP ツール経由で oretachi UI の新しいターミナルタブとして起動するためのスキル。
-allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_spawn_terminal, mcp__plugin_oretachi_oretachi__oretachi_list_terminals, mcp__plugin_oretachi_oretachi__oretachi_kill_terminal, mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status
+description: pnpm dev / pnpm run tauri dev / next dev / vite / nodemon / cargo watch / docker compose up など長時間常駐する開発サーバ・watcher・background プロセスを起動するときに、bash の run_in_background ではなく oretachi MCP ツール経由で oretachi UI の新しいターミナルタブとして起動するためのスキル。起動後の出力参照・キー入力（vitest の再実行など）にも対応。
+allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_spawn_terminal, mcp__plugin_oretachi_oretachi__oretachi_list_terminals, mcp__plugin_oretachi_oretachi__oretachi_kill_terminal, mcp__plugin_oretachi_oretachi__oretachi_read_terminal, mcp__plugin_oretachi_oretachi__oretachi_write_terminal, mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status
 ---
 
 # background-command スキル
@@ -62,19 +62,60 @@ oretachi UI に新しいタブが追加され、`pnpm dev` がそのターミナ
 
 数秒待ってから `oretachi_list_terminals({ worktree_name: "<name>" })` を呼ぶと、`session_id` / `cwd` / `isAiAgent` を含む配列が返る。直前に追加したセッションが含まれていれば起動成功。
 
-### Step 4: 停止する場合
+### Step 4: 出力ログを参照する
+
+dev サーバのコンパイルエラー確認、vitest の結果確認などに使う。
+
+```
+oretachi_read_terminal({
+  session_id: <値>,
+  max_bytes: 8192   // 省略可。デフォルト 8192。長い場合は 32768 等まで増やす
+})
+```
+
+戻り値は **ANSI エスケープ除去済みの UTF-8 文字列**（バッファ末尾から `max_bytes` バイト）。リングバッファは 64KiB で、それを超える出力は古い側から破棄される。
+
+### Step 5: ターミナルへ入力する
+
+vitest の単一キー入力（`a` で再実行 / `q` で終了）、対話プロンプトへの応答、PowerShell へのコマンド追加投入などに使う。
+
+```
+oretachi_write_terminal({
+  session_id: <値>,
+  text: "pnpm test\n",
+  submit: true   // デフォルト true。PowerShell/conpty 互換に \r へ正規化＋末尾保証する
+})
+
+// vitest の press 'a' to re-run all 等、生キーを送りたい時
+oretachi_write_terminal({
+  session_id: <値>,
+  text: "a",
+  submit: false  // 改行付与なし、raw 送信
+})
+```
+
+`submit: true` ならコマンド送信扱い（Enter まで押す）。`submit: false` なら raw 送信。
+
+### Step 6: 停止する場合
 
 `oretachi_list_terminals` で対象の `session_id` を特定してから:
 
 ```
-oretachi_kill_terminal({ session_id: <値> })
+oretachi_kill_terminal({ session_id: <値> })  // 強制 kill
 ```
+
+graceful に終了させたい場合（dev サーバの後始末を走らせたい等）は kill ではなく `oretachi_write_terminal` で `Ctrl-C` 相当のシグナルが必要。現状の write は文字列送信のみで `\x03` の効果は限定的なので、安全策としては:
+
+1. まず `oretachi_write_terminal({ text: "exit", submit: true })` を試す（シェルプロンプトに戻った状態の時のみ有効）
+2. それで終わらない常駐プロセスは `oretachi_kill_terminal` で強制 kill
 
 UI のタブは `pty-exit` イベント経由で自動的に消える。
 
 ## 注意点
 
-- `command` は末尾に改行が無くても、oretachi 側で `\n` が自動付与される
+- `command` 中の改行は oretachi 側で `\r` に正規化され、末尾にも `\r` が保証される（PowerShell/conpty が LF だけだと Enter を発火しないため）
 - シェルは oretachi のデフォルト（Windows なら PowerShell、それ以外は OS のシェル）。プラットフォーム固有の構文（PowerShell の `;` と bash の `&&` の違い等）に留意
-- `pendingScripts` 機構の制限により、同一ワークツリーに連続して `oretachi_spawn_terminal` を呼ぶ場合は前のコマンド投入完了まで待つこと。並行投入すると先に積まれたコマンドが上書きされる可能性がある
+- 同一ワークツリーに連続して `oretachi_spawn_terminal` を呼んでも、内部的には FIFO キューで管理されるためコマンドは取りこぼされない（先入れ先出しで対応するターミナルに流し込まれる）
+- 対象ワークツリーが**サブウィンドウ化（detached）**されている場合、`oretachi_spawn_terminal` は明示的に invalid_params エラーを返す。エラー本文に従ってメインウィンドウに戻すよう促す
 - 同名ワークツリーが複数あって `worktree_id` を指定しなかった場合は `invalid_params` エラーが返る。エラー本文に候補 ID が含まれているのでそれを使って再試行する
+- `oretachi_read_terminal` の戻り値先頭は、リングバッファ容量超過時にバイト境界調整が走るため UTF-8 マルチバイトや ANSI シーケンスの欠片が落とされる。**末尾側は正確、先頭側は近似**と理解する

--- a/src-tauri/src/claude_plugin_skills.rs
+++ b/src-tauri/src/claude_plugin_skills.rs
@@ -59,4 +59,9 @@ pub const SKILL_FILES: &[(&str, &str)] = &[
         "wireframe/templates/screens--screen.example.jsx",
         include_str!("../skills/wireframe/templates/screens--screen.example.jsx"),
     ),
+    // --- background-command ---
+    (
+        "background-command/SKILL.md",
+        include_str!("../skills/background-command/SKILL.md"),
+    ),
 ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -796,6 +796,7 @@ pub fn run() {
         .manage(SettingsManager::new())
         .manage(mcp_server::McpServerManager::new())
         .manage(mcp_server::McpPeerRegistry(std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()))))
+        .manage(mcp_server::DetachedWorktreeRegistry::default())
         .manage(ai_judge::ApprovalManager::new())
         .manage(ai_commit_message::CommitMessageManager::new())
         .manage(task_executor::TaskGenerateManager::new())
@@ -842,6 +843,8 @@ pub fn run() {
             get_mcp_status,
             restart_mcp_server,
             regenerate_mcp_api_key,
+            mcp_server::register_detached_worktree,
+            mcp_server::unregister_detached_worktree,
             prepare_for_relaunch,
             ai_judge::judge_approval,
             ai_judge::cancel_approval,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -382,8 +382,10 @@ pub struct KillTerminalParams {
 pub struct ReadTerminalParams {
     #[schemars(description = "PTY セッションID（oretachi_list_terminals で取得）")]
     pub session_id: u32,
-    #[schemars(description = "末尾から取得する最大バイト数（デフォルト 8192）")]
+    #[schemars(description = "1 回の呼び出しで返す最大バイト数（デフォルト 8192）")]
     pub max_bytes: Option<usize>,
+    #[schemars(description = "前回呼び出しで返された cursor を渡すと、それ以降の新規出力だけを返す（差分読み）。省略時はバッファ末尾から max_bytes")]
+    pub from_cursor: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1190,8 +1192,8 @@ impl NotifyService {
         };
 
         let mut items: Vec<serde_json::Value> = Vec::new();
-        for (session_id, cwd, is_ai_agent) in raw {
-            let matched_wt = cwd.as_deref().and_then(|c| {
+        for info in raw {
+            let matched_wt = info.cwd.as_deref().and_then(|c| {
                 let cp = std::path::Path::new(c);
                 settings.worktrees.iter().find(|w| {
                     let wp = std::path::Path::new(&w.path);
@@ -1204,12 +1206,16 @@ impl NotifyService {
                     continue;
                 }
             }
+            let status = if info.exit_code.is_some() { "exited" } else { "running" };
             items.push(serde_json::json!({
-                "sessionId": session_id,
-                "cwd": cwd,
-                "isAiAgent": is_ai_agent,
+                "sessionId": info.session_id,
+                "cwd": info.cwd,
+                "isAiAgent": info.is_ai_agent,
                 "worktreeId": matched_wt_id,
                 "worktreeName": matched_wt.map(|w| w.name.clone()),
+                "status": status,
+                "exitCode": info.exit_code,
+                "lastCommandExitCode": info.last_command_exit_code,
             }));
         }
 
@@ -1224,7 +1230,7 @@ impl NotifyService {
         Parameters(KillTerminalParams { session_id }): Parameters<KillTerminalParams>,
     ) -> Result<CallToolResult, McpError> {
         let pty = self.app_handle.state::<PtyManager>();
-        if !pty.list_sessions().iter().any(|(id, _, _)| *id == session_id) {
+        if !pty.list_sessions().iter().any(|s| s.session_id == session_id) {
             return Err(McpError::invalid_params(
                 format!("session_id {} not found", session_id),
                 None,
@@ -1236,22 +1242,30 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text("killed")]))
     }
 
-    #[tool(description = "指定 PTY セッションの最近の出力履歴を返す（ANSI 除去済み UTF-8）。pnpm dev のログ確認や vitest の結果参照に使う。max_bytes 省略時は 8192 バイト。先に oretachi_list_terminals で session_id を取得すること")]
+    #[tool(description = "指定 PTY セッションの最近の出力履歴を返す。レスポンスは JSON: { text, cursor, lostBytes }。text は ANSI 除去済み UTF-8。連続ポーリングで重複を避けるには、次回呼び出しの from_cursor に前回の cursor を渡す（差分読み）。lostBytes>0 はリングバッファ溢れで先頭が欠落したことを意味する。先に oretachi_list_terminals で session_id を取得すること")]
     fn oretachi_read_terminal(
         &self,
-        Parameters(ReadTerminalParams { session_id, max_bytes }): Parameters<ReadTerminalParams>,
+        Parameters(ReadTerminalParams { session_id, max_bytes, from_cursor }): Parameters<ReadTerminalParams>,
     ) -> Result<CallToolResult, McpError> {
         let pty = self.app_handle.state::<PtyManager>();
-        let raw = pty
-            .read_output_history(session_id, Some(max_bytes.unwrap_or(8192)))
+        let result = pty
+            .read_output_history(session_id, Some(max_bytes.unwrap_or(8192)), from_cursor)
             .map_err(|e| McpError::invalid_params(e, None))?;
-        let text = crate::pty_manager::strip_ansi(&raw);
+        let text = crate::pty_manager::strip_ansi(&result.data);
         log::info!(
-            "[mcp] oretachi_read_terminal: session_id={} bytes={}",
+            "[mcp] oretachi_read_terminal: session_id={} bytes={} cursor={} lost_bytes={}",
             session_id,
-            raw.len()
+            result.data.len(),
+            result.cursor,
+            result.lost_bytes
         );
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        let json = serde_json::json!({
+            "text": text,
+            "cursor": result.cursor,
+            "lostBytes": result.lost_bytes,
+        })
+        .to_string();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     #[tool(description = "指定 PTY セッションへテキストを送信する。submit=true（デフォルト）なら改行を PowerShell/conpty 互換の \\r へ正規化し末尾にも保証して、コマンド送信扱いにする。submit=false なら raw のまま送る（vitest の単一キー入力など）")]
@@ -1260,7 +1274,7 @@ impl NotifyService {
         Parameters(WriteTerminalParams { session_id, text, submit }): Parameters<WriteTerminalParams>,
     ) -> Result<CallToolResult, McpError> {
         let pty = self.app_handle.state::<PtyManager>();
-        if !pty.list_sessions().iter().any(|(id, _, _)| *id == session_id) {
+        if !pty.list_sessions().iter().any(|s| s.session_id == session_id) {
             return Err(McpError::invalid_params(
                 format!("session_id {} not found", session_id),
                 None,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -17,6 +17,7 @@ use tauri::{AppHandle, Emitter, Listener, Manager};
 use tokio::sync::{broadcast, oneshot, watch, RwLock};
 
 use crate::git_worktree::get_git_remotes;
+use crate::pty_manager::PtyManager;
 use crate::settings::SettingsManager;
 
 const PORT_FILE: &str = "mcp-port";
@@ -306,6 +307,42 @@ struct CloseWorktreeEvent {
     merge_to: String,
     delete_branch: bool,
     force_branch: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SpawnTerminalParams {
+    #[schemars(description = "対象ワークツリーの名前")]
+    pub worktree_name: String,
+    #[schemars(description = "ワークツリーID（同名ワークツリーが複数ある場合に指定）")]
+    pub worktree_id: Option<String>,
+    #[schemars(description = "新規ターミナルで実行するコマンド（末尾改行は自動付与）")]
+    pub command: String,
+    #[schemars(description = "ターミナルタブのタイトル（省略時はデフォルト）")]
+    pub title: Option<String>,
+    #[schemars(description = "起動理由のメモ（ログ用、省略可）")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct SpawnTerminalEvent {
+    worktree_id: String,
+    worktree_name: String,
+    command: String,
+    title: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListTerminalsParams {
+    #[schemars(description = "絞り込みするワークツリー名（省略時は全ワークツリー横断）")]
+    pub worktree_name: Option<String>,
+    #[schemars(description = "ワークツリーID（同名ワークツリーが複数ある場合に指定）")]
+    pub worktree_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct KillTerminalParams {
+    #[schemars(description = "停止する PTY セッションID（oretachi_list_terminals で取得）")]
+    pub session_id: u32,
 }
 
 // ─── MCP Service ──────────────────────────────────────────────────────────────
@@ -988,6 +1025,145 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(
             "ワークツリーのクローズリクエストを送信しました。処理は非同期に行われます。",
         )]))
+    }
+
+    #[tool(description = "指定ワークツリーに新しいターミナルタブを追加し、与えられたコマンドを流し込む。pnpm dev / tauri dev / vite / next dev など長時間常駐するバックグラウンドコマンドを oretachi UI 上で起動するために使う")]
+    fn oretachi_spawn_terminal(
+        &self,
+        Parameters(SpawnTerminalParams { worktree_name, worktree_id, command, title, reason }): Parameters<SpawnTerminalParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let worktree_name = worktree_name.trim().to_string();
+        if worktree_name.is_empty() {
+            return Err(McpError::invalid_params("worktree_name must not be empty", None));
+        }
+        if command.trim().is_empty() {
+            return Err(McpError::invalid_params("command must not be empty", None));
+        }
+
+        let settings_manager = self.app_handle.state::<SettingsManager>();
+        let settings = settings_manager.get();
+
+        let wt = if let Some(id) = worktree_id.as_deref() {
+            settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
+                McpError::invalid_params(format!("worktree id '{}' not found", id), None)
+            })?
+        } else {
+            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == worktree_name).collect();
+            match matches.len() {
+                0 => {
+                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
+                    return Err(McpError::invalid_params(
+                        format!("worktree '{}' not found. available: [{}]", worktree_name, names.join(", ")),
+                        None,
+                    ));
+                }
+                1 => matches[0],
+                _ => {
+                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
+                    return Err(McpError::invalid_params(
+                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", worktree_name, ids.join(", ")),
+                        None,
+                    ));
+                }
+            }
+        };
+
+        let event = SpawnTerminalEvent {
+            worktree_id: wt.id.clone(),
+            worktree_name: wt.name.clone(),
+            command: command.clone(),
+            title: title.clone(),
+        };
+        self.app_handle
+            .emit("mcp-spawn-terminal", &event)
+            .map_err(|e: tauri::Error| McpError::internal_error(e.to_string(), None))?;
+        log::info!(
+            "[mcp] oretachi_spawn_terminal: worktree={} command={:?} title={:?} reason={:?}",
+            worktree_name, command, title, reason
+        );
+        Ok(CallToolResult::success(vec![Content::text(
+            "新規ターミナルの追加リクエストを送信しました。oretachi UI に新しいタブが追加され、コマンドが流し込まれます。",
+        )]))
+    }
+
+    #[tool(description = "現在の PTY セッション一覧を返す。session_id, cwd, isAiAgent, ワークツリー名/ID を含む。oretachi_kill_terminal を呼ぶ前の確認に使う")]
+    fn oretachi_list_terminals(
+        &self,
+        Parameters(ListTerminalsParams { worktree_name, worktree_id }): Parameters<ListTerminalsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let pty = self.app_handle.state::<PtyManager>();
+        let raw = pty.list_sessions();
+
+        let settings_manager = self.app_handle.state::<SettingsManager>();
+        let settings = settings_manager.get();
+
+        let filter_id: Option<String> = if let Some(id) = worktree_id.as_deref() {
+            if !settings.worktrees.iter().any(|w| w.id == id) {
+                return Err(McpError::invalid_params(format!("worktree id '{}' not found", id), None));
+            }
+            Some(id.to_string())
+        } else if let Some(name) = worktree_name.as_deref() {
+            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == name).collect();
+            match matches.len() {
+                0 => {
+                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
+                    return Err(McpError::invalid_params(
+                        format!("worktree '{}' not found. available: [{}]", name, names.join(", ")),
+                        None,
+                    ));
+                }
+                1 => Some(matches[0].id.clone()),
+                _ => {
+                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
+                    return Err(McpError::invalid_params(
+                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", name, ids.join(", ")),
+                        None,
+                    ));
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut items: Vec<serde_json::Value> = Vec::new();
+        for (session_id, cwd, is_ai_agent) in raw {
+            let matched_wt = cwd.as_deref().and_then(|c| {
+                let cp = std::path::Path::new(c);
+                settings.worktrees.iter().find(|w| {
+                    let wp = std::path::Path::new(&w.path);
+                    cp.starts_with(wp)
+                })
+            });
+            let matched_wt_id = matched_wt.map(|w| w.id.clone());
+            if let Some(ref fid) = filter_id {
+                if matched_wt_id.as_deref() != Some(fid.as_str()) {
+                    continue;
+                }
+            }
+            items.push(serde_json::json!({
+                "sessionId": session_id,
+                "cwd": cwd,
+                "isAiAgent": is_ai_agent,
+                "worktreeId": matched_wt_id,
+                "worktreeName": matched_wt.map(|w| w.name.clone()),
+            }));
+        }
+
+        let json = serde_json::to_string(&items)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "指定 PTY セッションを停止する。oretachi_list_terminals で取得した session_id を渡す。UI のタブは pty-exit イベント経由で自動的に消える")]
+    fn oretachi_kill_terminal(
+        &self,
+        Parameters(KillTerminalParams { session_id }): Parameters<KillTerminalParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let pty = self.app_handle.state::<PtyManager>();
+        pty.kill(session_id)
+            .map_err(|e| McpError::internal_error(e, None))?;
+        log::info!("[mcp] oretachi_kill_terminal: session_id={}", session_id);
+        Ok(CallToolResult::success(vec![Content::text("killed")]))
     }
 }
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -307,6 +307,9 @@ pub struct ListRepositoryParams {}
 pub struct GetWorktreeStatusParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetAppOptionsParams {}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AddTaskParams {
     #[schemars(description = "タスクのプロンプト (AIに実行させたい作業の説明)")]
     pub prompt: String,
@@ -875,6 +878,24 @@ impl NotifyService {
         let json = serde_json::to_string_pretty(&results)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         log::info!("[mcp] oretachi_get_worktree_status: {} entries", results.len());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(description = "AI agent が参照するグローバル app options (background terminal の起動先トグル等) を取得する")]
+    fn oretachi_get_app_options(
+        &self,
+        Parameters(_params): Parameters<GetAppOptionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let settings_manager = self.app_handle.state::<SettingsManager>();
+        let settings = settings_manager.get();
+        let json = serde_json::to_string(&serde_json::json!({
+            "useOretachiTerminalForBackground": settings.use_oretachi_terminal_for_background,
+        }))
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        log::info!(
+            "[mcp] oretachi_get_app_options: useOretachiTerminalForBackground={}",
+            settings.use_oretachi_terminal_for_background
+        );
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -344,6 +344,24 @@ pub struct KillTerminalParams {
     pub session_id: u32,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ReadTerminalParams {
+    #[schemars(description = "PTY セッションID（oretachi_list_terminals で取得）")]
+    pub session_id: u32,
+    #[schemars(description = "末尾から取得する最大バイト数（デフォルト 8192）")]
+    pub max_bytes: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct WriteTerminalParams {
+    #[schemars(description = "PTY セッションID（oretachi_list_terminals で取得）")]
+    pub session_id: u32,
+    #[schemars(description = "送信するテキスト")]
+    pub text: String,
+    #[schemars(description = "true なら改行を \\r 正規化＋末尾 \\r 保証してから送信（デフォルト true）。vitest の単一キー入力など改行不要時は false")]
+    pub submit: Option<bool>,
+}
+
 // ─── MCP Service ──────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -1168,6 +1186,58 @@ impl NotifyService {
             .map_err(|e| McpError::internal_error(e, None))?;
         log::info!("[mcp] oretachi_kill_terminal: session_id={}", session_id);
         Ok(CallToolResult::success(vec![Content::text("killed")]))
+    }
+
+    #[tool(description = "指定 PTY セッションの最近の出力履歴を返す（ANSI 除去済み UTF-8）。pnpm dev のログ確認や vitest の結果参照に使う。max_bytes 省略時は 8192 バイト。先に oretachi_list_terminals で session_id を取得すること")]
+    fn oretachi_read_terminal(
+        &self,
+        Parameters(ReadTerminalParams { session_id, max_bytes }): Parameters<ReadTerminalParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let pty = self.app_handle.state::<PtyManager>();
+        let raw = pty
+            .read_output_history(session_id, Some(max_bytes.unwrap_or(8192)))
+            .map_err(|e| McpError::invalid_params(e, None))?;
+        let text = crate::pty_manager::strip_ansi(&raw);
+        log::info!(
+            "[mcp] oretachi_read_terminal: session_id={} bytes={}",
+            session_id,
+            raw.len()
+        );
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(description = "指定 PTY セッションへテキストを送信する。submit=true（デフォルト）なら改行を PowerShell/conpty 互換の \\r へ正規化し末尾にも保証して、コマンド送信扱いにする。submit=false なら raw のまま送る（vitest の単一キー入力など）")]
+    fn oretachi_write_terminal(
+        &self,
+        Parameters(WriteTerminalParams { session_id, text, submit }): Parameters<WriteTerminalParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let pty = self.app_handle.state::<PtyManager>();
+        if !pty.list_sessions().iter().any(|(id, _, _)| *id == session_id) {
+            return Err(McpError::invalid_params(
+                format!("session_id {} not found", session_id),
+                None,
+            ));
+        }
+        let payload = if submit.unwrap_or(true) {
+            let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
+            if normalized.ends_with('\r') {
+                normalized
+            } else {
+                normalized + "\r"
+            }
+        } else {
+            text
+        };
+        let bytes_len = payload.len();
+        pty.write(session_id, payload.into_bytes())
+            .map_err(|e| McpError::internal_error(e, None))?;
+        log::info!(
+            "[mcp] oretachi_write_terminal: session_id={} bytes={} submit={:?}",
+            session_id,
+            bytes_len,
+            submit
+        );
+        Ok(CallToolResult::success(vec![Content::text("written")]))
     }
 }
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, path::PathBuf, sync::{Arc, Mutex, atomic::{AtomicU64, Ordering}}, time::{SystemTime, UNIX_EPOCH}};
+use std::{collections::{HashMap, HashSet}, fs, path::PathBuf, sync::{Arc, Mutex, atomic::{AtomicU64, Ordering}}, time::{SystemTime, UNIX_EPOCH}};
 use tokio::fs as tokio_fs;
 
 use axum::{extract::{Request, State}, http::StatusCode, middleware::{self, Next}, response::Response, routing::post, Json};
@@ -33,6 +33,40 @@ const PEER_NOTIFY_TIMEOUT_SECS: u64 = 5;
 
 /// 接続中のMCPクライアントのPeerを保持するTauri managed state
 pub struct McpPeerRegistry(pub PeerMap);
+
+/// サブウィンドウへ移送中の worktree ID を保持。MCP ツールが silent failure せず
+/// 即座にエラーを返すために、フロント側で detached/attached が変わるたびに更新する。
+#[derive(Default)]
+pub struct DetachedWorktreeRegistry(pub Mutex<HashSet<String>>);
+
+impl DetachedWorktreeRegistry {
+    pub fn is_detached(&self, worktree_id: &str) -> bool {
+        match self.0.lock() {
+            Ok(g) => g.contains(worktree_id),
+            Err(e) => e.into_inner().contains(worktree_id),
+        }
+    }
+}
+
+#[tauri::command]
+pub fn register_detached_worktree(
+    worktree_id: String,
+    registry: tauri::State<'_, DetachedWorktreeRegistry>,
+) {
+    if let Ok(mut g) = registry.0.lock() {
+        g.insert(worktree_id);
+    }
+}
+
+#[tauri::command]
+pub fn unregister_detached_worktree(
+    worktree_id: String,
+    registry: tauri::State<'_, DetachedWorktreeRegistry>,
+) {
+    if let Ok(mut g) = registry.0.lock() {
+        g.remove(&worktree_id);
+    }
+}
 
 static PEER_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -1084,6 +1118,20 @@ impl NotifyService {
                 }
             }
         };
+
+        // detached（サブウィンドウ化済み）ワークツリーへの spawn は App.vue 側で
+        // 早期 return されるため、MCP 経由で投入してもユーザに silent failure として
+        // 見えてしまう。事前に検知して明示的なエラーを返す。
+        let detached_registry = self.app_handle.state::<DetachedWorktreeRegistry>();
+        if detached_registry.is_detached(&wt.id) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "worktree '{}' is currently detached (open in a sub-window). MCP spawn into detached worktrees is not supported. Bring the worktree back into the main window first.",
+                    worktree_name
+                ),
+                None,
+            ));
+        }
 
         let event = SpawnTerminalEvent {
             worktree_id: wt.id.clone(),

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -326,7 +326,6 @@ pub struct SpawnTerminalParams {
 #[derive(Debug, Serialize, Clone)]
 struct SpawnTerminalEvent {
     worktree_id: String,
-    worktree_name: String,
     command: String,
     title: Option<String>,
 }
@@ -1070,7 +1069,6 @@ impl NotifyService {
 
         let event = SpawnTerminalEvent {
             worktree_id: wt.id.clone(),
-            worktree_name: wt.name.clone(),
             command: command.clone(),
             title: title.clone(),
         };
@@ -1160,6 +1158,12 @@ impl NotifyService {
         Parameters(KillTerminalParams { session_id }): Parameters<KillTerminalParams>,
     ) -> Result<CallToolResult, McpError> {
         let pty = self.app_handle.state::<PtyManager>();
+        if !pty.list_sessions().iter().any(|(id, _, _)| *id == session_id) {
+            return Err(McpError::invalid_params(
+                format!("session_id {} not found", session_id),
+                None,
+            ));
+        }
         pty.kill(session_id)
             .map_err(|e| McpError::internal_error(e, None))?;
         log::info!("[mcp] oretachi_kill_terminal: session_id={}", session_id);

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1164,7 +1164,7 @@ impl NotifyService {
                 None,
             ));
         }
-        pty.kill(session_id)
+        pty.kill(session_id, "mcp-kill-terminal")
             .map_err(|e| McpError::internal_error(e, None))?;
         log::info!("[mcp] oretachi_kill_terminal: session_id={}", session_id);
         Ok(CallToolResult::success(vec![Content::text("killed")]))

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1,11 +1,12 @@
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
 
 const AI_AGENT_NAMES: &[&str] = &["claude", "gemini", "codex", "cline"];
 const MAX_PTY_SESSIONS: usize = 32;
+const OUTPUT_HISTORY_BYTES: usize = 65_536;
 
 struct PtySession {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
@@ -16,6 +17,7 @@ struct PtySession {
     watcher_handle: Option<std::thread::JoinHandle<()>>,
     is_ai_agent: bool,
     cwd: Option<String>,
+    output_history: Arc<Mutex<VecDeque<u8>>>,
 }
 
 pub struct PtyManager {
@@ -478,6 +480,10 @@ impl PtyManager {
 
         let alive = Arc::new(Mutex::new(true));
 
+        // PTY 出力リングバッファ（MCP の oretachi_read_terminal で参照される）
+        let output_history: Arc<Mutex<VecDeque<u8>>> =
+            Arc::new(Mutex::new(VecDeque::with_capacity(OUTPUT_HISTORY_BYTES)));
+
         // child_pid と child_killer を spawn 直後に取得
         let child_pid = child.process_id();
         let child_killer = child.clone_killer();
@@ -537,6 +543,7 @@ impl PtyManager {
 
         // 読み取りスレッド起動
         let app_handle_reader = app_handle.clone();
+        let history_for_reader = output_history.clone();
         std::thread::spawn(move || {
             let mut buf = [0u8; 8192];
             loop {
@@ -544,6 +551,15 @@ impl PtyManager {
                     Ok(0) => break,
                     Ok(n) => {
                         let data = buf[..n].to_vec();
+                        // リングバッファへ push（容量超過分は先頭から drain）。
+                        // ロック失敗は best-effort で握り潰す（emit は止めない）
+                        if let Ok(mut hist) = history_for_reader.lock() {
+                            if hist.len() + n > OUTPUT_HISTORY_BYTES {
+                                let drop_n = hist.len() + n - OUTPUT_HISTORY_BYTES;
+                                hist.drain(..drop_n);
+                            }
+                            hist.extend(data.iter().copied());
+                        }
                         let _ = app_handle_reader
                             .emit("pty-output", PtyOutputPayload { session_id, data });
                     }
@@ -564,6 +580,7 @@ impl PtyManager {
             watcher_handle: Some(watcher_handle),
             is_ai_agent: false,
             cwd,
+            output_history,
         };
 
         self.sessions.lock().map_err(|e| format!("lock error: {}", e))?.insert(session_id, session);
@@ -586,6 +603,28 @@ impl PtyManager {
         writer.write_all(&data).map_err(|e| format!("Write error: {}", e))?;
         writer.flush().map_err(|e| format!("Flush error: {}", e))?;
         Ok(())
+    }
+
+    /// 指定セッションの出力履歴を取得する。
+    /// max_bytes を指定するとバッファ末尾から最大 max_bytes バイトを返す。
+    pub fn read_output_history(
+        &self,
+        session_id: u32,
+        max_bytes: Option<usize>,
+    ) -> Result<Vec<u8>, String> {
+        let history_arc = {
+            let sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            let session = sessions
+                .get(&session_id)
+                .ok_or_else(|| format!("Session {} not found", session_id))?;
+            session.output_history.clone()
+        };
+        let hist = history_arc
+            .lock()
+            .map_err(|e| format!("history lock error: {}", e))?;
+        let take = max_bytes.unwrap_or(usize::MAX).min(hist.len());
+        let start = hist.len() - take;
+        Ok(hist.iter().copied().skip(start).collect())
     }
 
     pub fn resize(&self, session_id: u32, rows: u16, cols: u16) -> Result<(), String> {
@@ -718,4 +757,50 @@ impl Drop for PtyManager {
             self.kill_all("PtyManager::drop");
         }
     }
+}
+
+/// ANSI/VT100 エスケープシーケンスを除去する単純なストリッパ。
+/// CSI (`ESC [ ... letter`)、OSC (`ESC ] ... BEL` or `ESC \`)、その他 ESC+1byte を除去。
+/// 改行・タブは保持。完全な VT100 emulation ではないが AI が読む用途には十分。
+pub fn strip_ansi(input: &[u8]) -> String {
+    let mut out: Vec<u8> = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        let b = input[i];
+        if b == 0x1b && i + 1 < input.len() {
+            let next = input[i + 1];
+            if next == b'[' {
+                i += 2;
+                while i < input.len() && !(0x40..=0x7e).contains(&input[i]) {
+                    i += 1;
+                }
+                if i < input.len() {
+                    i += 1;
+                }
+                continue;
+            } else if next == b']' {
+                i += 2;
+                while i < input.len() {
+                    if input[i] == 0x07 {
+                        i += 1;
+                        break;
+                    }
+                    if input[i] == 0x1b && i + 1 < input.len() && input[i + 1] == b'\\' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            } else {
+                i += 2;
+                continue;
+            }
+        }
+        if b >= 0x20 || b == b'\n' || b == b'\r' || b == b'\t' {
+            out.push(b);
+        }
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -24,9 +24,9 @@ struct PtySession {
     /// reader 経由で書き込まれた累積バイト数。MCP の差分読み (cursor) の起点として参照する。
     total_bytes_written: Arc<AtomicU64>,
     /// プロセス全体（PTY が走らせているシェル本体）の exit code。watcher が拾う。
-    exit_status: Arc<Mutex<Option<i32>>>,
+    exit_status: Arc<Mutex<Option<i64>>>,
     /// 直近コマンドの exit code（シェル統合の OSC 777 を reader thread が拾って保存）。
-    last_command_exit_code: Arc<Mutex<Option<i32>>>,
+    last_command_exit_code: Arc<Mutex<Option<i64>>>,
 }
 
 #[derive(Clone)]
@@ -34,8 +34,8 @@ pub struct SessionInfo {
     pub session_id: u32,
     pub cwd: Option<String>,
     pub is_ai_agent: bool,
-    pub exit_code: Option<i32>,
-    pub last_command_exit_code: Option<i32>,
+    pub exit_code: Option<i64>,
+    pub last_command_exit_code: Option<i64>,
 }
 
 pub struct ReadHistoryResult {
@@ -512,8 +512,8 @@ impl PtyManager {
 
         // 差分読みのカーソル基点 / プロセス exit / OSC 777 直近コマンド exit
         let total_bytes_written: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
-        let exit_status: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
-        let last_command_exit_code: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
+        let exit_status: Arc<Mutex<Option<i64>>> = Arc::new(Mutex::new(None));
+        let last_command_exit_code: Arc<Mutex<Option<i64>>> = Arc::new(Mutex::new(None));
 
         // child_pid と child_killer を spawn 直後に取得
         let child_pid = child.process_id();
@@ -531,6 +531,7 @@ impl PtyManager {
         let master_watcher = master_arc.clone();
         let child_watcher = child_arc.clone();
         let exit_status_setter = exit_status.clone();
+        let sessions_for_watcher = self.sessions.clone();
         let watcher_handle = std::thread::spawn(move || {
             let child_opt = match child_watcher.lock() {
                 Ok(mut g) => g.take(),
@@ -538,7 +539,7 @@ impl PtyManager {
             };
             if let Some(mut child) = child_opt {
                 // try_wait() ポーリング: alive=false (kill() 呼び出し済み) なら即座に終了
-                let mut captured_exit: Option<i32> = None;
+                let mut captured_exit: Option<i64> = None;
                 let exited = loop {
                     let alive = match alive_watcher.lock() {
                         Ok(g) => *g,
@@ -549,7 +550,8 @@ impl PtyManager {
                     }
                     match child.try_wait() {
                         Ok(Some(status)) => {
-                            captured_exit = Some(status.exit_code() as i32);
+                            // u32 → i64: Windows の異常終了コード (0xC000013A 等) を符号反転させない
+                            captured_exit = Some(status.exit_code() as i64);
                             break true;
                         }
                         Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
@@ -579,6 +581,13 @@ impl PtyManager {
                             Err(e) => { e.into_inner().take(); }
                         }
                     }
+                    // 自然終了したセッションを map から取り除く（exited zombie 防止）。
+                    // MAX_PTY_SESSIONS の枠を圧迫しないため、kill 経由でない自然終了でも remove する。
+                    // フロントは pty-exit イベントで UI タブを消すため整合性は保たれる。
+                    match sessions_for_watcher.lock() {
+                        Ok(mut s) => { s.remove(&session_id); }
+                        Err(e) => { e.into_inner().remove(&session_id); }
+                    }
                 }
             }
         });
@@ -599,16 +608,17 @@ impl PtyManager {
                     Ok(0) => break,
                     Ok(n) => {
                         let data = buf[..n].to_vec();
-                        // リングバッファへ push（容量超過分は先頭から drain）。
-                        // ロック失敗は best-effort で握り潰す（emit は止めない）
+                        // リングバッファへ push と total 更新を **同じ critical section で実行**。
+                        // 別 lock にすると read_output_history が中間状態（hist は新しいが total は古い）を観測し、
+                        // buf_start = total - hist.len() が巻き戻って差分読みが重複する。
                         if let Ok(mut hist) = history_for_reader.lock() {
                             if hist.len() + n > OUTPUT_HISTORY_BYTES {
                                 let drop_n = hist.len() + n - OUTPUT_HISTORY_BYTES;
                                 hist.drain(..drop_n);
                             }
                             hist.extend(data.iter().copied());
+                            total_for_reader.fetch_add(n as u64, Ordering::Relaxed);
                         }
-                        total_for_reader.fetch_add(n as u64, Ordering::Relaxed);
 
                         // OSC 777 直近コマンド exit code を抽出
                         osc_lookback.extend_from_slice(&buf[..n]);
@@ -693,10 +703,12 @@ impl PtyManager {
                 .ok_or_else(|| format!("Session {} not found", session_id))?;
             (session.output_history.clone(), session.total_bytes_written.clone())
         };
-        let total = total_arc.load(Ordering::Relaxed);
+        // hist lock を取った後に total を load し、reader thread の hist push + total update が
+        // 同じ lock の中で行われていることに合わせる（race による cursor 後退対策）。
         let hist = history_arc
             .lock()
             .map_err(|e| format!("history lock error: {}", e))?;
+        let total = total_arc.load(Ordering::Relaxed);
         let buf_len = hist.len() as u64;
         let buf_start = total.saturating_sub(buf_len);
 
@@ -879,7 +891,7 @@ impl Drop for PtyManager {
 ///   （次回の reader read で続きが届くのを待つ）。
 /// - 一致したシーケンスとそれより前のゴミは buf から drain される。
 /// 末尾不完全 ESC は OSC_LOOKBACK_MAX で切り詰められる呼び出し側に任せる。
-pub fn consume_osc_777_exit_code(buf: &mut Vec<u8>) -> Option<i32> {
+pub fn consume_osc_777_exit_code(buf: &mut Vec<u8>) -> Option<i64> {
     let prefix = b"\x1b]777;exit_code;";
     let start = buf.windows(prefix.len()).position(|w| w == prefix)?;
     let payload_start = start + prefix.len();
@@ -897,10 +909,14 @@ pub fn consume_osc_777_exit_code(buf: &mut Vec<u8>) -> Option<i32> {
         i += 1;
     }
     let (digits_end, total_end) = term_end?;
-    let digits = std::str::from_utf8(&buf[payload_start..digits_end]).ok()?;
-    let code: i32 = digits.trim().parse().ok()?;
+    // 終端まで来た以上、parse 成否にかかわらずシーケンスは消費する。
+    // 不正 payload を残すと次回呼び出しで同じ位置に再ヒットし、後続の正常 OSC 777 が
+    // OSC_LOOKBACK_MAX で潰されるまで検出されなくなる（last_command_exit_code の固着）。
+    let parsed = std::str::from_utf8(&buf[payload_start..digits_end])
+        .ok()
+        .and_then(|s| s.trim().parse::<i64>().ok());
     buf.drain(..total_end);
-    Some(code)
+    parsed
 }
 
 /// ANSI/VT100 エスケープシーケンスを除去する単純なストリッパ。
@@ -1044,5 +1060,46 @@ mod tests {
         assert_eq!(consume_osc_777_exit_code(&mut buf), Some(7));
         assert_eq!(consume_osc_777_exit_code(&mut buf), None);
         assert_eq!(buf, b"tail");
+    }
+
+    #[test]
+    fn osc_777_invalid_digits_drains() {
+        // 不正な digits でも終端まで来ているなら buf から消費する。
+        // 残すと後続の正常 OSC 777 が OSC_LOOKBACK_MAX で潰されるまで検出されない（リグレッション防止）
+        let mut buf = b"\x1b]777;exit_code;abc\x07after".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), None);
+        assert_eq!(buf, b"after");
+    }
+
+    #[test]
+    fn osc_777_empty_payload_drains() {
+        let mut buf = b"\x1b]777;exit_code;\x07after".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), None);
+        assert_eq!(buf, b"after");
+    }
+
+    #[test]
+    fn osc_777_invalid_then_valid_recovered() {
+        // 不正シーケンスの後ろに正常シーケンスがある場合、不正分を消費した上で
+        // 次の呼び出しで正常分が拾える
+        let mut buf = b"\x1b]777;exit_code;abc\x07\x1b]777;exit_code;42\x07tail".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), None);
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(42));
+        assert_eq!(buf, b"tail");
+    }
+
+    #[test]
+    fn osc_777_negative_exit_code() {
+        // i64 化したので Unix 系の負の signal kill 表現も保持できる
+        let mut buf = b"\x1b]777;exit_code;-1\x07".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(-1));
+    }
+
+    #[test]
+    fn osc_777_large_windows_exit_code() {
+        // Windows の Ctrl-C kill (0xC000013A = 3221225786) は u32 のため i32 では負値化するが、
+        // OSC 777 は シェルが文字列で吐くため i64 でそのまま受け取れる
+        let mut buf = b"\x1b]777;exit_code;3221225786\x07".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(3221225786));
     }
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -688,6 +688,18 @@ impl PtyManager {
         }
         ids.len()
     }
+
+    /// 全 PTY セッションを (session_id, cwd, is_ai_agent) のタプル列で返す。
+    pub fn list_sessions(&self) -> Vec<(u32, Option<String>, bool)> {
+        let sessions = match self.sessions.lock() {
+            Ok(s) => s,
+            Err(e) => e.into_inner(),
+        };
+        sessions
+            .iter()
+            .map(|(id, s)| (*id, s.cwd.clone(), s.is_ai_agent))
+            .collect()
+    }
 }
 
 impl Drop for PtyManager {

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -5,11 +5,16 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc, Mutex,
 };
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
 const AI_AGENT_NAMES: &[&str] = &["claude", "gemini", "codex", "cline"];
 const MAX_PTY_SESSIONS: usize = 32;
 const OUTPUT_HISTORY_BYTES: usize = 65_536;
+/// シェル本体が自然終了したセッションを map に残しておく寿命。
+/// この期間内なら MCP クライアントから exit code や最終ログを参照できる。
+/// MAX_PTY_SESSIONS の枠を一時的に圧迫し得るが、TTL 経過後は lazy sweep で除去される。
+const EXITED_SESSION_TTL: Duration = Duration::from_secs(30);
 
 struct PtySession {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
@@ -27,6 +32,22 @@ struct PtySession {
     exit_status: Arc<Mutex<Option<i64>>>,
     /// 直近コマンドの exit code（シェル統合の OSC 777 を reader thread が拾って保存）。
     last_command_exit_code: Arc<Mutex<Option<i64>>>,
+    /// シェル本体が自然終了した時刻。`Some` ならゾンビ状態（map 上は残っているが死亡）。
+    /// `EXITED_SESSION_TTL` 経過後の lazy sweep で除去される。
+    exited_at: Arc<Mutex<Option<Instant>>>,
+}
+
+/// 寿命の切れた exited セッションを `sessions` map から除去する。
+/// `sessions.lock()` を取った直後の各 path から呼び出すことで、MCP クライアントが
+/// 最大 `EXITED_SESSION_TTL` の間は exit code / 最終ログを参照できる状態を保つ。
+fn sweep_exited(map: &mut HashMap<u32, PtySession>) {
+    map.retain(|_, s| {
+        let exited = s.exited_at.lock().ok().and_then(|g| *g);
+        match exited {
+            None => true,
+            Some(t) => t.elapsed() < EXITED_SESSION_TTL,
+        }
+    });
 }
 
 #[derive(Clone)]
@@ -265,6 +286,7 @@ impl PtyManager {
     /// AIエージェントフラグを明示的にセットする（executeAgentWorktree 用）
     pub fn set_ai_agent(&self, session_id: u32, is_agent: bool) -> Result<(), String> {
         let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+        sweep_exited(&mut sessions);
         if let Some(session) = sessions.get_mut(&session_id) {
             session.is_ai_agent = is_agent;
             Ok(())
@@ -275,7 +297,8 @@ impl PtyManager {
 
     /// AIエージェントフラグを参照する
     pub fn is_ai_agent(&self, session_id: u32) -> Result<bool, String> {
-        let sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+        let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+        sweep_exited(&mut sessions);
         if let Some(session) = sessions.get(&session_id) {
             Ok(session.is_ai_agent)
         } else {
@@ -300,10 +323,11 @@ impl PtyManager {
 
                 // セッション情報を取得
                 let session_pids: Vec<(u32, Option<u32>)> = {
-                    let sessions = match sessions_arc.lock() {
+                    let mut sessions = match sessions_arc.lock() {
                         Ok(s) => s,
                         Err(_) => continue,
                     };
+                    sweep_exited(&mut sessions);
                     sessions.iter().map(|(&id, s)| (id, s.child_pid)).collect()
                 };
 
@@ -391,7 +415,8 @@ impl PtyManager {
     ) -> Result<u32, String> {
         log::debug!("[Terminal] pty_manager::spawn rows={} cols={} shell={:?} cwd={:?}", rows, cols, shell, cwd);
         {
-            let sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            sweep_exited(&mut sessions);
             if sessions.len() >= MAX_PTY_SESSIONS {
                 return Err(format!(
                     "PTYセッション数の上限（{}）に達しています。不要なターミナルを閉じてください",
@@ -514,6 +539,7 @@ impl PtyManager {
         let total_bytes_written: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
         let exit_status: Arc<Mutex<Option<i64>>> = Arc::new(Mutex::new(None));
         let last_command_exit_code: Arc<Mutex<Option<i64>>> = Arc::new(Mutex::new(None));
+        let exited_at: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
 
         // child_pid と child_killer を spawn 直後に取得
         let child_pid = child.process_id();
@@ -531,7 +557,7 @@ impl PtyManager {
         let master_watcher = master_arc.clone();
         let child_watcher = child_arc.clone();
         let exit_status_setter = exit_status.clone();
-        let sessions_for_watcher = self.sessions.clone();
+        let exited_at_setter = exited_at.clone();
         let watcher_handle = std::thread::spawn(move || {
             let child_opt = match child_watcher.lock() {
                 Ok(mut g) => g.take(),
@@ -581,12 +607,13 @@ impl PtyManager {
                             Err(e) => { e.into_inner().take(); }
                         }
                     }
-                    // 自然終了したセッションを map から取り除く（exited zombie 防止）。
-                    // MAX_PTY_SESSIONS の枠を圧迫しないため、kill 経由でない自然終了でも remove する。
-                    // フロントは pty-exit イベントで UI タブを消すため整合性は保たれる。
-                    match sessions_for_watcher.lock() {
-                        Ok(mut s) => { s.remove(&session_id); }
-                        Err(e) => { e.into_inner().remove(&session_id); }
+                    // 自然終了したセッションは map に残し、exited_at をセットする。
+                    // MCP クライアントが exit code / 最終ログを参照できるよう EXITED_SESSION_TTL の
+                    // 間は保持し、各 sessions.lock() path の sweep_exited で TTL 切れを除去する。
+                    // UI タブは pty-exit イベントで消える（フロント側の整合性は維持）。
+                    match exited_at_setter.lock() {
+                        Ok(mut g) => *g = Some(Instant::now()),
+                        Err(e) => *e.into_inner() = Some(Instant::now()),
                     }
                 }
             }
@@ -657,6 +684,7 @@ impl PtyManager {
             total_bytes_written,
             exit_status,
             last_command_exit_code,
+            exited_at,
         };
 
         self.sessions.lock().map_err(|e| format!("lock error: {}", e))?.insert(session_id, session);
@@ -668,7 +696,8 @@ impl PtyManager {
     pub fn write(&self, session_id: u32, data: Vec<u8>) -> Result<(), String> {
         // sessions ロックは Arc 取得のみ（瞬時）→ I/O 中は他セッション操作をブロックしない
         let writer_arc = {
-            let sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            sweep_exited(&mut sessions);
             let session = sessions
                 .get(&session_id)
                 .ok_or_else(|| format!("Session {} not found", session_id))?;
@@ -697,7 +726,8 @@ impl PtyManager {
         from_cursor: Option<u64>,
     ) -> Result<ReadHistoryResult, String> {
         let (history_arc, total_arc) = {
-            let sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            sweep_exited(&mut sessions);
             let session = sessions
                 .get(&session_id)
                 .ok_or_else(|| format!("Session {} not found", session_id))?;
@@ -748,7 +778,8 @@ impl PtyManager {
     pub fn resize(&self, session_id: u32, rows: u16, cols: u16) -> Result<(), String> {
         log::debug!("[Terminal] pty_manager::resize session_id={} rows={} cols={}", session_id, rows, cols);
         let master_arc = {
-            let sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
+            sweep_exited(&mut sessions);
             let session = sessions
                 .get(&session_id)
                 .ok_or_else(|| format!("Session {} not found", session_id))?;
@@ -777,6 +808,7 @@ impl PtyManager {
         // pty_write, pty_resize 等すべてのセッション操作がブロックされる。
         let removed = {
             let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+            sweep_exited(&mut sessions);
             if let Some(session) = sessions.remove(&session_id) {
                 // poison でも alive=false を確実にセット（ウォッチャースレッドの停止に必要）
                 match session.alive.lock() {
@@ -810,9 +842,11 @@ impl PtyManager {
     }
 
     pub fn kill_all(&self, source: &str) {
-        let ids: Vec<u32> = self.sessions.lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .keys().cloned().collect();
+        let ids: Vec<u32> = {
+            let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+            sweep_exited(&mut sessions);
+            sessions.keys().cloned().collect()
+        };
         log::info!("[Terminal] pty_manager::kill_all source={} count={}", source, ids.len());
         for id in ids {
             let _ = self.kill(id, source);
@@ -825,10 +859,11 @@ impl PtyManager {
     pub fn kill_sessions_in_dir(&self, dir: &str) -> usize {
         let target = std::path::Path::new(dir);
         let ids: Vec<u32> = {
-            let sessions = match self.sessions.lock() {
+            let mut sessions = match self.sessions.lock() {
                 Ok(s) => s,
                 Err(e) => e.into_inner(),
             };
+            sweep_exited(&mut sessions);
             sessions
                 .iter()
                 .filter(|(_, s)| {
@@ -850,10 +885,11 @@ impl PtyManager {
     /// `exit_code` は watcher が拾ったプロセス全体（シェル本体）の exit code。
     /// `last_command_exit_code` はシェル統合 OSC 777 が出した直近コマンドの exit code。
     pub fn list_sessions(&self) -> Vec<SessionInfo> {
-        let sessions = match self.sessions.lock() {
+        let mut sessions = match self.sessions.lock() {
             Ok(s) => s,
             Err(e) => e.into_inner(),
         };
+        sweep_exited(&mut sessions);
         sessions
             .iter()
             .map(|(id, s)| SessionInfo {

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -607,6 +607,10 @@ impl PtyManager {
 
     /// 指定セッションの出力履歴を取得する。
     /// max_bytes を指定するとバッファ末尾から最大 max_bytes バイトを返す。
+    /// バッファ全体を返さない場合、開始位置を以下の順で補正する:
+    ///   1) UTF-8 マルチバイト継続バイト (0b10xxxxxx) を読み飛ばし文字境界に揃える
+    ///   2) 直近 512 バイト以内に LF があれば、その直後まで進める
+    ///      （ANSI シーケンスの途中切断による strip_ansi 残骸を回避）
     pub fn read_output_history(
         &self,
         session_id: u32,
@@ -622,8 +626,27 @@ impl PtyManager {
         let hist = history_arc
             .lock()
             .map_err(|e| format!("history lock error: {}", e))?;
-        let take = max_bytes.unwrap_or(usize::MAX).min(hist.len());
-        let start = hist.len() - take;
+        let total = hist.len();
+        let take = max_bytes.unwrap_or(usize::MAX).min(total);
+        let mut start = total - take;
+
+        // 全体を返す場合は補正不要
+        if start > 0 {
+            // (1) UTF-8 継続バイトをスキップ
+            while start < total && (hist[start] & 0xC0) == 0x80 {
+                start += 1;
+            }
+            // (2) 近傍に LF があれば、その直後まで進めて中断 ANSI 残骸を捨てる
+            const NEWLINE_SCAN_WINDOW: usize = 512;
+            let scan_end = (start + NEWLINE_SCAN_WINDOW).min(total);
+            for i in start..scan_end {
+                if hist[i] == b'\n' {
+                    start = i + 1;
+                    break;
+                }
+            }
+        }
+
         Ok(hist.iter().copied().skip(start).collect())
     }
 
@@ -803,4 +826,66 @@ pub fn strip_ansi(input: &[u8]) -> String {
         i += 1;
     }
     String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_ansi_plain_text() {
+        assert_eq!(strip_ansi(b"hello\nworld"), "hello\nworld");
+    }
+
+    #[test]
+    fn strip_ansi_csi_color() {
+        // ESC[31m red ESC[0m
+        let input = b"\x1b[31mred\x1b[0m text";
+        assert_eq!(strip_ansi(input), "red text");
+    }
+
+    #[test]
+    fn strip_ansi_osc_title_bel() {
+        // ESC]0;title\x07
+        let input = b"\x1b]0;window title\x07hello";
+        assert_eq!(strip_ansi(input), "hello");
+    }
+
+    #[test]
+    fn strip_ansi_osc_title_st() {
+        // ESC]0;title ESC\\
+        let input = b"\x1b]0;t\x1b\\done";
+        assert_eq!(strip_ansi(input), "done");
+    }
+
+    #[test]
+    fn strip_ansi_incomplete_esc_at_end() {
+        // 末尾が不完全 ESC のみ → ESC は単独でも丸ごと捨てる
+        let input = b"abc\x1b";
+        assert_eq!(strip_ansi(input), "abc");
+    }
+
+    #[test]
+    fn strip_ansi_keeps_tab_and_crlf() {
+        let input = b"a\tb\r\nc";
+        assert_eq!(strip_ansi(input), "a\tb\r\nc");
+    }
+
+    #[test]
+    fn strip_ansi_drops_non_print_control() {
+        // 0x01 (SOH) など制御文字は除去
+        let input = b"a\x01b";
+        assert_eq!(strip_ansi(input), "ab");
+    }
+
+    #[test]
+    fn strip_ansi_empty() {
+        assert_eq!(strip_ansi(b""), "");
+    }
+
+    #[test]
+    fn strip_ansi_utf8_passthrough() {
+        let input = "日本語\x1b[1mbold\x1b[0m".as_bytes();
+        assert_eq!(strip_ansi(input), "日本語bold");
+    }
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1,7 +1,10 @@
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
 use tauri::{AppHandle, Emitter};
 
 const AI_AGENT_NAMES: &[&str] = &["claude", "gemini", "codex", "cline"];
@@ -18,6 +21,29 @@ struct PtySession {
     is_ai_agent: bool,
     cwd: Option<String>,
     output_history: Arc<Mutex<VecDeque<u8>>>,
+    /// reader 経由で書き込まれた累積バイト数。MCP の差分読み (cursor) の起点として参照する。
+    total_bytes_written: Arc<AtomicU64>,
+    /// プロセス全体（PTY が走らせているシェル本体）の exit code。watcher が拾う。
+    exit_status: Arc<Mutex<Option<i32>>>,
+    /// 直近コマンドの exit code（シェル統合の OSC 777 を reader thread が拾って保存）。
+    last_command_exit_code: Arc<Mutex<Option<i32>>>,
+}
+
+#[derive(Clone)]
+pub struct SessionInfo {
+    pub session_id: u32,
+    pub cwd: Option<String>,
+    pub is_ai_agent: bool,
+    pub exit_code: Option<i32>,
+    pub last_command_exit_code: Option<i32>,
+}
+
+pub struct ReadHistoryResult {
+    pub data: Vec<u8>,
+    /// data 末尾に対応する累積バイト位置。次回呼び出しで `from_cursor` に渡せば差分が取れる。
+    pub cursor: u64,
+    /// 要求 cursor がリングバッファ範囲外だったときに失われた先頭バイト数。
+    pub lost_bytes: u64,
 }
 
 pub struct PtyManager {
@@ -484,6 +510,11 @@ impl PtyManager {
         let output_history: Arc<Mutex<VecDeque<u8>>> =
             Arc::new(Mutex::new(VecDeque::with_capacity(OUTPUT_HISTORY_BYTES)));
 
+        // 差分読みのカーソル基点 / プロセス exit / OSC 777 直近コマンド exit
+        let total_bytes_written: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+        let exit_status: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
+        let last_command_exit_code: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
+
         // child_pid と child_killer を spawn 直後に取得
         let child_pid = child.process_id();
         let child_killer = child.clone_killer();
@@ -499,6 +530,7 @@ impl PtyManager {
         let alive_watcher = alive.clone();
         let master_watcher = master_arc.clone();
         let child_watcher = child_arc.clone();
+        let exit_status_setter = exit_status.clone();
         let watcher_handle = std::thread::spawn(move || {
             let child_opt = match child_watcher.lock() {
                 Ok(mut g) => g.take(),
@@ -506,6 +538,7 @@ impl PtyManager {
             };
             if let Some(mut child) = child_opt {
                 // try_wait() ポーリング: alive=false (kill() 呼び出し済み) なら即座に終了
+                let mut captured_exit: Option<i32> = None;
                 let exited = loop {
                     let alive = match alive_watcher.lock() {
                         Ok(g) => *g,
@@ -515,13 +548,22 @@ impl PtyManager {
                         break false;
                     }
                     match child.try_wait() {
-                        Ok(Some(_)) => break true,
+                        Ok(Some(status)) => {
+                            captured_exit = Some(status.exit_code() as i32);
+                            break true;
+                        }
                         Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
                         Err(_) => break false,
                     }
                 };
                 // 自然終了した場合のみ master を drop して reader に EOF を送る
                 if exited {
+                    if let Some(code) = captured_exit {
+                        match exit_status_setter.lock() {
+                            Ok(mut s) => *s = Some(code),
+                            Err(e) => *e.into_inner() = Some(code),
+                        }
+                    }
                     let should_drop = match alive_watcher.lock() {
                         Ok(mut g) => {
                             if *g { *g = false; true } else { false }
@@ -544,8 +586,14 @@ impl PtyManager {
         // 読み取りスレッド起動
         let app_handle_reader = app_handle.clone();
         let history_for_reader = output_history.clone();
+        let total_for_reader = total_bytes_written.clone();
+        let last_cmd_exit_for_reader = last_command_exit_code.clone();
         std::thread::spawn(move || {
             let mut buf = [0u8; 8192];
+            // OSC 777 のシーケンスは reader read の境界をまたぐ可能性があるため、
+            // 末尾数バイトを次回読み取り時の頭にくっつけてパースする
+            let mut osc_lookback: Vec<u8> = Vec::new();
+            const OSC_LOOKBACK_MAX: usize = 256;
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
@@ -560,6 +608,21 @@ impl PtyManager {
                             }
                             hist.extend(data.iter().copied());
                         }
+                        total_for_reader.fetch_add(n as u64, Ordering::Relaxed);
+
+                        // OSC 777 直近コマンド exit code を抽出
+                        osc_lookback.extend_from_slice(&buf[..n]);
+                        while let Some(code) = consume_osc_777_exit_code(&mut osc_lookback) {
+                            match last_cmd_exit_for_reader.lock() {
+                                Ok(mut s) => *s = Some(code),
+                                Err(e) => *e.into_inner() = Some(code),
+                            }
+                        }
+                        if osc_lookback.len() > OSC_LOOKBACK_MAX {
+                            let drop_n = osc_lookback.len() - OSC_LOOKBACK_MAX;
+                            osc_lookback.drain(..drop_n);
+                        }
+
                         let _ = app_handle_reader
                             .emit("pty-output", PtyOutputPayload { session_id, data });
                     }
@@ -581,6 +644,9 @@ impl PtyManager {
             is_ai_agent: false,
             cwd,
             output_history,
+            total_bytes_written,
+            exit_status,
+            last_command_exit_code,
         };
 
         self.sessions.lock().map_err(|e| format!("lock error: {}", e))?.insert(session_id, session);
@@ -606,48 +672,65 @@ impl PtyManager {
     }
 
     /// 指定セッションの出力履歴を取得する。
-    /// max_bytes を指定するとバッファ末尾から最大 max_bytes バイトを返す。
-    /// バッファ全体を返さない場合、開始位置を以下の順で補正する:
-    ///   1) UTF-8 マルチバイト継続バイト (0b10xxxxxx) を読み飛ばし文字境界に揃える
-    ///   2) 直近 512 バイト以内に LF があれば、その直後まで進める
-    ///      （ANSI シーケンスの途中切断による strip_ansi 残骸を回避）
+    /// - `from_cursor` を指定すると、それ以降の新規バイトのみを返す（差分読み）。
+    ///   要求 cursor がリングバッファ範囲外の場合は `lost_bytes` で先頭の欠落量を通知する。
+    /// - `from_cursor` 未指定の場合は、バッファ末尾から `max_bytes` バイトを返す（従来挙動）。
+    /// - 開始位置がバッファ先頭でない場合のみ、UTF-8 / ANSI 境界補正を実施する:
+    ///   1) UTF-8 継続バイト (0b10xxxxxx) を読み飛ばし文字境界に揃える
+    ///   2) 直近 512 バイト以内に LF があればその直後まで進める（ANSI 中断残骸の回避）
+    ///   ただし from_cursor 連続呼び出し（lost_bytes == 0）では cursor が文字境界済みなので
+    ///   補正をスキップして差分の先頭バイトを欠落させない。
     pub fn read_output_history(
         &self,
         session_id: u32,
         max_bytes: Option<usize>,
-    ) -> Result<Vec<u8>, String> {
-        let history_arc = {
+        from_cursor: Option<u64>,
+    ) -> Result<ReadHistoryResult, String> {
+        let (history_arc, total_arc) = {
             let sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
             let session = sessions
                 .get(&session_id)
                 .ok_or_else(|| format!("Session {} not found", session_id))?;
-            session.output_history.clone()
+            (session.output_history.clone(), session.total_bytes_written.clone())
         };
+        let total = total_arc.load(Ordering::Relaxed);
         let hist = history_arc
             .lock()
             .map_err(|e| format!("history lock error: {}", e))?;
-        let total = hist.len();
-        let take = max_bytes.unwrap_or(usize::MAX).min(total);
-        let mut start = total - take;
+        let buf_len = hist.len() as u64;
+        let buf_start = total.saturating_sub(buf_len);
 
-        // 全体を返す場合は補正不要
-        if start > 0 {
-            // (1) UTF-8 継続バイトをスキップ
-            while start < total && (hist[start] & 0xC0) == 0x80 {
-                start += 1;
+        let req_start = match from_cursor {
+            None => total.saturating_sub(max_bytes.unwrap_or(usize::MAX) as u64),
+            Some(c) => c.min(total),
+        };
+        let actual_start = req_start.max(buf_start);
+        let lost_bytes = actual_start - req_start;
+
+        let mut buf_idx = (actual_start - buf_start) as usize;
+
+        let needs_alignment = from_cursor.is_none() || lost_bytes > 0;
+        if needs_alignment && buf_idx > 0 && buf_idx < hist.len() {
+            while buf_idx < hist.len() && (hist[buf_idx] & 0xC0) == 0x80 {
+                buf_idx += 1;
             }
-            // (2) 近傍に LF があれば、その直後まで進めて中断 ANSI 残骸を捨てる
             const NEWLINE_SCAN_WINDOW: usize = 512;
-            let scan_end = (start + NEWLINE_SCAN_WINDOW).min(total);
-            for i in start..scan_end {
+            let scan_end = (buf_idx + NEWLINE_SCAN_WINDOW).min(hist.len());
+            for i in buf_idx..scan_end {
                 if hist[i] == b'\n' {
-                    start = i + 1;
+                    buf_idx = i + 1;
                     break;
                 }
             }
         }
 
-        Ok(hist.iter().copied().skip(start).collect())
+        let take_n = max_bytes
+            .unwrap_or(usize::MAX)
+            .min(hist.len() - buf_idx);
+        let data: Vec<u8> = hist.iter().skip(buf_idx).take(take_n).copied().collect();
+        let cursor = buf_start + buf_idx as u64 + take_n as u64;
+
+        Ok(ReadHistoryResult { data, cursor, lost_bytes })
     }
 
     pub fn resize(&self, session_id: u32, rows: u16, cols: u16) -> Result<(), String> {
@@ -751,15 +834,23 @@ impl PtyManager {
         ids.len()
     }
 
-    /// 全 PTY セッションを (session_id, cwd, is_ai_agent) のタプル列で返す。
-    pub fn list_sessions(&self) -> Vec<(u32, Option<String>, bool)> {
+    /// 全 PTY セッションを `SessionInfo` のリストで返す。
+    /// `exit_code` は watcher が拾ったプロセス全体（シェル本体）の exit code。
+    /// `last_command_exit_code` はシェル統合 OSC 777 が出した直近コマンドの exit code。
+    pub fn list_sessions(&self) -> Vec<SessionInfo> {
         let sessions = match self.sessions.lock() {
             Ok(s) => s,
             Err(e) => e.into_inner(),
         };
         sessions
             .iter()
-            .map(|(id, s)| (*id, s.cwd.clone(), s.is_ai_agent))
+            .map(|(id, s)| SessionInfo {
+                session_id: *id,
+                cwd: s.cwd.clone(),
+                is_ai_agent: s.is_ai_agent,
+                exit_code: s.exit_status.lock().ok().and_then(|g| *g),
+                last_command_exit_code: s.last_command_exit_code.lock().ok().and_then(|g| *g),
+            })
             .collect()
     }
 }
@@ -780,6 +871,36 @@ impl Drop for PtyManager {
             self.kill_all("PtyManager::drop");
         }
     }
+}
+
+/// シェル統合の OSC 777 シーケンス `\x1b]777;exit_code;<digits>(\x07|\x1b\\)` を
+/// 1 個消費し、パースした exit code を返す。
+/// - 終端 (BEL or ESC\) まで届いていない場合は `None` を返し、buf を保持する
+///   （次回の reader read で続きが届くのを待つ）。
+/// - 一致したシーケンスとそれより前のゴミは buf から drain される。
+/// 末尾不完全 ESC は OSC_LOOKBACK_MAX で切り詰められる呼び出し側に任せる。
+pub fn consume_osc_777_exit_code(buf: &mut Vec<u8>) -> Option<i32> {
+    let prefix = b"\x1b]777;exit_code;";
+    let start = buf.windows(prefix.len()).position(|w| w == prefix)?;
+    let payload_start = start + prefix.len();
+    let mut term_end: Option<(usize, usize)> = None;
+    let mut i = payload_start;
+    while i < buf.len() {
+        if buf[i] == 0x07 {
+            term_end = Some((i, i + 1));
+            break;
+        }
+        if buf[i] == 0x1b && i + 1 < buf.len() && buf[i + 1] == b'\\' {
+            term_end = Some((i, i + 2));
+            break;
+        }
+        i += 1;
+    }
+    let (digits_end, total_end) = term_end?;
+    let digits = std::str::from_utf8(&buf[payload_start..digits_end]).ok()?;
+    let code: i32 = digits.trim().parse().ok()?;
+    buf.drain(..total_end);
+    Some(code)
 }
 
 /// ANSI/VT100 エスケープシーケンスを除去する単純なストリッパ。
@@ -887,5 +1008,41 @@ mod tests {
     fn strip_ansi_utf8_passthrough() {
         let input = "日本語\x1b[1mbold\x1b[0m".as_bytes();
         assert_eq!(strip_ansi(input), "日本語bold");
+    }
+
+    #[test]
+    fn osc_777_bel_terminator() {
+        let mut buf = b"prefix\x1b]777;exit_code;0\x07tail".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(0));
+        // start より前の "prefix" もシーケンス全体と一緒に drain される
+        assert_eq!(buf, b"tail");
+    }
+
+    #[test]
+    fn osc_777_st_terminator() {
+        let mut buf = b"\x1b]777;exit_code;42\x1b\\rest".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(42));
+        assert_eq!(buf, b"rest");
+    }
+
+    #[test]
+    fn osc_777_split_across_reads() {
+        // 1 回目: 終端なし → None、buf はそのまま
+        let mut buf = b"\x1b]777;exit_code;1".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), None);
+        assert_eq!(buf, b"\x1b]777;exit_code;1");
+        // 2 回目: 続きを足して再パース
+        buf.extend_from_slice(b"23\x07after");
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(123));
+        assert_eq!(buf, b"after");
+    }
+
+    #[test]
+    fn osc_777_multiple_in_one_buffer() {
+        let mut buf = b"\x1b]777;exit_code;0\x07ok\x1b]777;exit_code;7\x07tail".to_vec();
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(0));
+        assert_eq!(consume_osc_777_exit_code(&mut buf), Some(7));
+        assert_eq!(consume_osc_777_exit_code(&mut buf), None);
+        assert_eq!(buf, b"tail");
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -237,6 +237,8 @@ impl Default for AppearanceSettings {
 
 fn default_ai_timeout_secs() -> u64 { 120 }
 
+fn default_use_oretachi_terminal_for_background() -> bool { true }
+
 fn default_notification_volume() -> u32 { 80 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -337,6 +339,8 @@ pub struct AppSettings {
     pub ai_timeout_secs: u64,
     #[serde(default, rename = "debugMode")]
     pub debug_mode: bool,
+    #[serde(default = "default_use_oretachi_terminal_for_background", rename = "useOretachiTerminalForBackground")]
+    pub use_oretachi_terminal_for_background: bool,
 }
 
 impl AppSettings {
@@ -371,6 +375,7 @@ impl Default for AppSettings {
             enable_home_cat: false,
             ai_timeout_secs: default_ai_timeout_secs(),
             debug_mode: false,
+            use_oretachi_terminal_for_background: default_use_oretachi_terminal_for_background(),
         }
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -165,6 +165,8 @@ pub struct TerminalSettings {
     pub font_size: u32,
     #[serde(default)]
     pub shell: Option<String>,
+    #[serde(default, rename = "backgroundPaneSplitDirection")]
+    pub background_pane_split_direction: Option<String>,
 }
 
 fn default_font_size() -> u32 {
@@ -176,6 +178,7 @@ impl Default for TerminalSettings {
         TerminalSettings {
             font_size: default_font_size(),
             shell: None,
+            background_pane_split_direction: Some("bottom".to_string()),
         }
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -990,14 +990,22 @@ onMounted(async () => {
   });
 
   // MCPからの新規ターミナル追加（pnpm dev など長時間バックグラウンドコマンド用）
-  await listen<{ worktree_id: string; worktree_name: string; command: string; title: string | null }>(
+  await listen<{ worktree_id: string; command: string; title: string | null }>(
     "mcp-spawn-terminal",
     async (event) => {
       const { worktree_id, command, title } = event.payload;
-      if (!worktrees.value.find((w) => w.id === worktree_id)) {
+      const targetWt = worktrees.value.find((w) => w.id === worktree_id);
+      if (!targetWt) {
         debug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} not found, skipping`);
         return;
       }
+      // detached（サブウィンドウ化済み）ワークツリーは onAddTerminal が
+      // handleSubAddTerminalRequest に分岐し pendingScripts を消費しないため未対応
+      if (isDetached(worktree_id)) {
+        debug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} is detached, not supported`);
+        return;
+      }
+      const beforeIds = new Set(targetWt.terminals.map((t) => t.id));
       const cmd = command.endsWith("\n") ? command : command + "\n";
       pendingScripts.set(worktree_id, cmd);
       try {
@@ -1009,7 +1017,7 @@ onMounted(async () => {
       }
       if (title) {
         const wt = worktrees.value.find((w) => w.id === worktree_id);
-        const newTerm = wt?.terminals[wt.terminals.length - 1];
+        const newTerm = wt?.terminals.find((t) => !beforeIds.has(t.id));
         if (newTerm) onTerminalTitleChange(worktree_id, newTerm.id, title);
       }
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@ import { useTaskExecution } from "./composables/useTaskExecution";
 import { useWorktreeTaskMap } from "./composables/useWorktreeTaskMap";
 import { useAutoApprovalPrompt } from "./composables/useAutoApprovalPrompt";
 import type { FrameNode } from "./types/frame";
-import { useWorktreeFrameBundles } from "./composables/useWorktreeFrameBundles";
+import { useWorktreeFrameBundles, type WorktreeFrameBundle } from "./composables/useWorktreeFrameBundles";
 import { useCodeReviewChatListener } from "./composables/useCodeReviewLineChat";
 import { saveWindowState, StateFlags } from "@tauri-apps/plugin-window-state";
 import { useWorktreeRemove } from "./composables/useWorktreeRemove";
@@ -435,7 +435,31 @@ async function closeWindow() {
   await getCurrentWindow().close();
 }
 
-async function onAddTerminal(worktreeId: string) {
+/**
+ * バックグラウンド専用リーフ（pnpm dev 等を MCP 経由で投入する用）の id を返す。
+ * - 既存の背景リーフがあれば再利用
+ * - ターミナル未配置の単一リーフが存在すれば、それを背景化して再利用
+ * - それ以外は設定の分割方向で last-focused から新リーフを切り出す
+ */
+function getOrCreateBackgroundLeafId(bundle: WorktreeFrameBundle): string {
+  const existing = bundle.frame.findBackgroundLeaf();
+  if (existing) return existing.id;
+
+  const allLeafs = bundle.frame.getAllLeafs();
+  const noTerminalsAtAll = allLeafs.every((l) => l.terminalIds.length === 0);
+  if (noTerminalsAtAll && allLeafs.length === 1) {
+    bundle.frame.markLeafBackground(allLeafs[0].id, true);
+    return allLeafs[0].id;
+  }
+
+  const dir = (settings.value.terminal.backgroundPaneSplitDirection ?? "bottom") as
+    "left" | "right" | "top" | "bottom";
+  const newLeaf = bundle.frame.addBackgroundLeaf(dir);
+  return newLeaf.id;
+}
+
+async function onAddTerminal(worktreeId: string, options?: { background?: boolean }) {
+  const background = options?.background === true;
   clearNotification(worktreeId);
   if (isDetached(worktreeId)) {
     await handleSubAddTerminalRequest(worktreeId);
@@ -445,7 +469,7 @@ async function onAddTerminal(worktreeId: string) {
   const terminal = addTerminal(worktreeId);
   pendingManualStart.add(terminal.id);
   terminalWorktreeMap.set(terminal.id, worktreeId);
-  debug(`[Terminal] onAddTerminal worktreeId=${worktreeId} terminalId=${terminal.id}`);
+  debug(`[Terminal] onAddTerminal worktreeId=${worktreeId} terminalId=${terminal.id} background=${background}`);
 
   // バンドルがなければ作成（ワークツリー追加直後など）
   if (!worktreeFrameBundles.has(worktreeId)) {
@@ -455,19 +479,25 @@ async function onAddTerminal(worktreeId: string) {
   const bundle = worktreeFrameBundles.get(worktreeId)!;
   bundle.terminalEntries.set(terminal.id, { id: terminal.id, title: terminal.title, sessionId: 0, snapshot: "" });
 
-  const leafId = bundle.frame.lastFocusedLeafId.value || bundle.frame.getAllLeafs()[0]?.id;
-  debug(`[Terminal] onAddTerminal leafId=${leafId ?? "null"} terminalId=${terminal.id}`);
-  if (leafId) {
+  const targetLeafId = background
+    ? getOrCreateBackgroundLeafId(bundle)
+    : (bundle.frame.lastFocusedLeafId.value || bundle.frame.getAllLeafs()[0]?.id);
+  debug(`[Terminal] onAddTerminal leafId=${targetLeafId ?? "null"} terminalId=${terminal.id}`);
+  if (targetLeafId) {
     bundle.frame.returnAllToOffscreen();
-    bundle.frame.addTerminalToLeaf(leafId, terminal.id);
-    bundle.frame.lastFocusedLeafId.value = leafId;
+    bundle.frame.addTerminalToLeaf(targetLeafId, terminal.id);
+    if (!background) {
+      bundle.frame.lastFocusedLeafId.value = targetLeafId;
+    }
   } else {
     bundle.frame.initLayout([terminal.id]);
     bundle.frame.lastFocusedLeafId.value = bundle.frame.getAllLeafs()[0]?.id ?? "";
   }
 
-  viewMode.value = "terminal";
-  activeWorktreeId.value = worktreeId;
+  if (!background) {
+    viewMode.value = "terminal";
+    activeWorktreeId.value = worktreeId;
+  }
 
   await nextTick();
   debug(`[Terminal] onAddTerminal after nextTick terminalId=${terminal.id}`);
@@ -481,7 +511,9 @@ async function onAddTerminal(worktreeId: string) {
     pendingManualStart.delete(terminal.id);
     await term.startPty();
     debug(`[Terminal] onAddTerminal after startPty terminalId=${terminal.id}`);
-    term.focus();
+    if (!background) {
+      term.focus();
+    }
     // 安全策: flexレイアウト確定が遅延する場合に備えた再fit
     setTimeout(() => {
       debug(`[Terminal] onAddTerminal setTimeout re-fit terminalId=${terminal.id}`);
@@ -1006,10 +1038,13 @@ onMounted(async () => {
         return;
       }
       const beforeIds = new Set(targetWt.terminals.map((t) => t.id));
-      const cmd = command.endsWith("\n") ? command : command + "\n";
+      // PowerShell/conpty は LF だけだとプロンプト継続行扱いになり Enter が発火しない。
+      // FramePane.vue / TerminalView.vue paste と同じく \r に正規化する。
+      const normalized = command.replace(/\r?\n/g, "\r");
+      const cmd = normalized.endsWith("\r") ? normalized : normalized + "\r";
       pendingScripts.set(worktree_id, cmd);
       try {
-        await onAddTerminal(worktree_id);
+        await onAddTerminal(worktree_id, { background: true });
       } catch (e) {
         pendingScripts.delete(worktree_id);
         debug(`[Terminal] mcp-spawn-terminal: onAddTerminal failed: ${e}`);

--- a/src/App.vue
+++ b/src/App.vue
@@ -173,37 +173,12 @@ const { setup: setupCodeReviewChatListener } = useCodeReviewChatListener({
 // terminalId → サムネイル data URL
 const thumbnailUrls = reactive(new Map<number, string>());
 
-// worktreeId → 実行待ちスクリプトコマンド文字列の FIFO キュー
-// MCP からの連続 oretachi_spawn_terminal でコマンドを取りこぼさないためにキュー化している。
-// 同じワークツリーで複数ターミナルが立ち上がる順に shift して消費する。
-const pendingScripts = new Map<string, string[]>();
-
-function pushPendingScript(worktreeId: string, command: string): void {
-  const existing = pendingScripts.get(worktreeId);
-  if (existing) {
-    existing.push(command);
-  } else {
-    pendingScripts.set(worktreeId, [command]);
-  }
-}
-
-function shiftPendingScript(worktreeId: string): string | undefined {
-  const queue = pendingScripts.get(worktreeId);
-  if (!queue || queue.length === 0) return undefined;
-  const cmd = queue.shift();
-  if (queue.length === 0) pendingScripts.delete(worktreeId);
-  return cmd;
-}
-
-function dropLastPendingScript(worktreeId: string, expected: string): void {
-  // pushPendingScript の直後に失敗した場合のロールバック用。末尾が expected と一致する時のみ削除。
-  const queue = pendingScripts.get(worktreeId);
-  if (!queue || queue.length === 0) return;
-  if (queue[queue.length - 1] === expected) {
-    queue.pop();
-    if (queue.length === 0) pendingScripts.delete(worktreeId);
-  }
-}
+// terminalId → 実行待ちスクリプトコマンド文字列
+// onAddTerminal がターミナルを採番した直後に terminalId キーで pending を結びつける（atomic）。
+// onTerminalReady でその terminalId 専用の command を取得して書き込む。
+// worktree 粒度の FIFO ではないため、同じ worktree で別由来（ユーザー Ctrl+T 等）のタブが
+// 立ち上がっても誤投入されない。多重 spawn の race も terminalId 単位で完全分離される。
+const pendingByTerminal = new Map<number, string>();
 
 // terminalId → 復元スナップショット（起動時セッション復元用）
 const pendingSnapshots = new Map<number, string>();
@@ -281,7 +256,6 @@ const { executeAddWorktree, executeAgentWorktree, resolveShell, buildPendingComm
     onAddTerminal,
     onMoveToSubWindow,
     loadingWorktrees,
-    pendingScripts,
     autoApprovalMap,
     onWebSessionDetected: (terminalId, info) => {
       terminalWebSessions.set(terminalId, info);
@@ -383,8 +357,9 @@ async function onTerminalReady(worktreeId: string, terminalId: number) {
   }
   pendingSnapshots.delete(terminalId);
   pendingSessionAttach.delete(terminalId);
-  const command = shiftPendingScript(worktreeId);
-  if (command) {
+  const command = pendingByTerminal.get(terminalId);
+  if (command !== undefined) {
+    pendingByTerminal.delete(terminalId);
     const ref = getTerminalRef(terminalId);
     await ref?.write(command);
   }
@@ -486,10 +461,14 @@ function getOrCreateBackgroundLeafId(bundle: WorktreeFrameBundle): string {
   return newLeaf.id;
 }
 
-async function onAddTerminal(worktreeId: string, options?: { background?: boolean }) {
+async function onAddTerminal(
+  worktreeId: string,
+  options?: { background?: boolean; pendingCommand?: string },
+) {
   const background = options?.background === true;
   clearNotification(worktreeId);
   if (isDetached(worktreeId)) {
+    // detached worktree は handleSubAddTerminalRequest 経由で処理し、pendingCommand 連携は未対応。
     await handleSubAddTerminalRequest(worktreeId);
     return;
   }
@@ -497,6 +476,11 @@ async function onAddTerminal(worktreeId: string, options?: { background?: boolea
   const terminal = addTerminal(worktreeId);
   pendingManualStart.add(terminal.id);
   terminalWorktreeMap.set(terminal.id, worktreeId);
+  // ターミナル採番の直後に pendingCommand を結びつけることで、後続の onTerminalReady が
+  // この terminalId に対応する command を確実に取り出す。worktree 粒度でなく terminalId 粒度。
+  if (options?.pendingCommand !== undefined) {
+    pendingByTerminal.set(terminal.id, options.pendingCommand);
+  }
   debug(`[Terminal] onAddTerminal worktreeId=${worktreeId} terminalId=${terminal.id} background=${background}`);
 
   // バンドルがなければ作成（ワークツリー追加直後など）
@@ -665,16 +649,9 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
       }
     }
 
-    // パッケージマネージャーinstall・スクリプトをペンディング登録
-    if (repo) {
-      const pending = buildPendingCommand(repo, entry);
-      if (pending) {
-        pushPendingScript(entry.id, pending);
-      }
-    }
-
-    // ワークツリー作成後、自動でターミナルを1つ追加
-    await onAddTerminal(entry.id);
+    // パッケージマネージャーinstall・スクリプトを最初のターミナルに紐付けて起動
+    const pending = repo ? buildPendingCommand(repo, entry) : null;
+    await onAddTerminal(entry.id, pending ? { pendingCommand: pending } : undefined);
 
     // パッケージマネージャーinstall・スクリプトの完了を待つ
     if (repo?.packageManager || repo?.execScript) {
@@ -1060,7 +1037,7 @@ onMounted(async () => {
         return;
       }
       // detached（サブウィンドウ化済み）ワークツリーは onAddTerminal が
-      // handleSubAddTerminalRequest に分岐し pendingScripts を消費しないため未対応
+      // handleSubAddTerminalRequest に分岐し pendingCommand を消費しないため未対応
       if (isDetached(worktree_id)) {
         debug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} is detached, not supported`);
         return;
@@ -1070,11 +1047,9 @@ onMounted(async () => {
       // FramePane.vue / TerminalView.vue paste と同じく \r に正規化する。
       const normalized = command.replace(/\r?\n/g, "\r");
       const cmd = normalized.endsWith("\r") ? normalized : normalized + "\r";
-      pushPendingScript(worktree_id, cmd);
       try {
-        await onAddTerminal(worktree_id, { background: true });
+        await onAddTerminal(worktree_id, { background: true, pendingCommand: cmd });
       } catch (e) {
-        dropLastPendingScript(worktree_id, cmd);
         debug(`[Terminal] mcp-spawn-terminal: onAddTerminal failed: ${e}`);
         return;
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -173,8 +173,37 @@ const { setup: setupCodeReviewChatListener } = useCodeReviewChatListener({
 // terminalId → サムネイル data URL
 const thumbnailUrls = reactive(new Map<number, string>());
 
-// worktreeId → 実行待ちスクリプトコマンド文字列
-const pendingScripts = new Map<string, string>();
+// worktreeId → 実行待ちスクリプトコマンド文字列の FIFO キュー
+// MCP からの連続 oretachi_spawn_terminal でコマンドを取りこぼさないためにキュー化している。
+// 同じワークツリーで複数ターミナルが立ち上がる順に shift して消費する。
+const pendingScripts = new Map<string, string[]>();
+
+function pushPendingScript(worktreeId: string, command: string): void {
+  const existing = pendingScripts.get(worktreeId);
+  if (existing) {
+    existing.push(command);
+  } else {
+    pendingScripts.set(worktreeId, [command]);
+  }
+}
+
+function shiftPendingScript(worktreeId: string): string | undefined {
+  const queue = pendingScripts.get(worktreeId);
+  if (!queue || queue.length === 0) return undefined;
+  const cmd = queue.shift();
+  if (queue.length === 0) pendingScripts.delete(worktreeId);
+  return cmd;
+}
+
+function dropLastPendingScript(worktreeId: string, expected: string): void {
+  // pushPendingScript の直後に失敗した場合のロールバック用。末尾が expected と一致する時のみ削除。
+  const queue = pendingScripts.get(worktreeId);
+  if (!queue || queue.length === 0) return;
+  if (queue[queue.length - 1] === expected) {
+    queue.pop();
+    if (queue.length === 0) pendingScripts.delete(worktreeId);
+  }
+}
 
 // terminalId → 復元スナップショット（起動時セッション復元用）
 const pendingSnapshots = new Map<number, string>();
@@ -354,9 +383,8 @@ async function onTerminalReady(worktreeId: string, terminalId: number) {
   }
   pendingSnapshots.delete(terminalId);
   pendingSessionAttach.delete(terminalId);
-  const command = pendingScripts.get(worktreeId);
+  const command = shiftPendingScript(worktreeId);
   if (command) {
-    pendingScripts.delete(worktreeId);
     const ref = getTerminalRef(terminalId);
     await ref?.write(command);
   }
@@ -641,7 +669,7 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
     if (repo) {
       const pending = buildPendingCommand(repo, entry);
       if (pending) {
-        pendingScripts.set(entry.id, pending);
+        pushPendingScript(entry.id, pending);
       }
     }
 
@@ -1042,11 +1070,11 @@ onMounted(async () => {
       // FramePane.vue / TerminalView.vue paste と同じく \r に正規化する。
       const normalized = command.replace(/\r?\n/g, "\r");
       const cmd = normalized.endsWith("\r") ? normalized : normalized + "\r";
-      pendingScripts.set(worktree_id, cmd);
+      pushPendingScript(worktree_id, cmd);
       try {
         await onAddTerminal(worktree_id, { background: true });
       } catch (e) {
-        pendingScripts.delete(worktree_id);
+        dropLastPendingScript(worktree_id, cmd);
         debug(`[Terminal] mcp-spawn-terminal: onAddTerminal failed: ${e}`);
         return;
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -989,6 +989,32 @@ onMounted(async () => {
     });
   });
 
+  // MCPからの新規ターミナル追加（pnpm dev など長時間バックグラウンドコマンド用）
+  await listen<{ worktree_id: string; worktree_name: string; command: string; title: string | null }>(
+    "mcp-spawn-terminal",
+    async (event) => {
+      const { worktree_id, command, title } = event.payload;
+      if (!worktrees.value.find((w) => w.id === worktree_id)) {
+        debug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} not found, skipping`);
+        return;
+      }
+      const cmd = command.endsWith("\n") ? command : command + "\n";
+      pendingScripts.set(worktree_id, cmd);
+      try {
+        await onAddTerminal(worktree_id);
+      } catch (e) {
+        pendingScripts.delete(worktree_id);
+        debug(`[Terminal] mcp-spawn-terminal: onAddTerminal failed: ${e}`);
+        return;
+      }
+      if (title) {
+        const wt = worktrees.value.find((w) => w.id === worktree_id);
+        const newTerm = wt?.terminals[wt.terminals.length - 1];
+        if (newTerm) onTerminalTitleChange(worktree_id, newTerm.id, title);
+      }
+    },
+  );
+
   // サブウィンドウ準備完了 → init データをイベントで送信（サブウィンドウ復元より前に登録必須）
   await listen<{ worktreeId: string }>("sub-ready", async (event) => {
     const { worktreeId } = event.payload;

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -498,6 +498,19 @@ function getSoundLabel(sound: string | null | undefined): string {
           @change="(e) => { const v = (e.target as HTMLInputElement).value.trim(); settings.terminal.shell = v || undefined; scheduleSave(); }"
         />
       </div>
+      <div class="row-input row-input--inline mt-8">
+        <span class="inline-label">{{ t('terminal.backgroundPaneSplitDirection') }}</span>
+        <select
+          class="text-input"
+          :value="settings.terminal.backgroundPaneSplitDirection ?? 'bottom'"
+          @change="(e) => { settings.terminal.backgroundPaneSplitDirection = (e.target as HTMLSelectElement).value as 'left' | 'right' | 'top' | 'bottom'; scheduleSave(); }"
+        >
+          <option value="bottom">{{ t('terminal.bgSplit.bottom') }}</option>
+          <option value="right">{{ t('terminal.bgSplit.right') }}</option>
+          <option value="top">{{ t('terminal.bgSplit.top') }}</option>
+          <option value="left">{{ t('terminal.bgSplit.left') }}</option>
+        </select>
+      </div>
     </div>
 
     <!-- ワークツリー追加先ディレクトリ -->
@@ -1138,7 +1151,14 @@ function getSoundLabel(sound: string | null | undefined): string {
       "label": "Terminal",
       "fontSize": "Font size",
       "defaultShell": "Default shell",
-      "shellPlaceholder": "Empty = system default"
+      "shellPlaceholder": "Empty = system default",
+      "backgroundPaneSplitDirection": "Background pane split direction",
+      "bgSplit": {
+        "bottom": "Bottom",
+        "right": "Right",
+        "top": "Top",
+        "left": "Left"
+      }
     },
     "worktreeBaseDir": {
       "label": "Worktree base directory",
@@ -1232,7 +1252,14 @@ function getSoundLabel(sound: string | null | undefined): string {
       "label": "ターミナル",
       "fontSize": "文字サイズ",
       "defaultShell": "デフォルトシェル",
-      "shellPlaceholder": "空欄 = システムデフォルト"
+      "shellPlaceholder": "空欄 = システムデフォルト",
+      "backgroundPaneSplitDirection": "バックグラウンドペイン分割方向",
+      "bgSplit": {
+        "bottom": "下",
+        "right": "右",
+        "top": "上",
+        "left": "左"
+      }
     },
     "worktreeBaseDir": {
       "label": "ワークツリーの追加先ディレクトリ",

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -511,6 +511,17 @@ function getSoundLabel(sound: string | null | undefined): string {
           <option value="left">{{ t('terminal.bgSplit.left') }}</option>
         </select>
       </div>
+      <div class="row-input row-input--inline mt-8">
+        <input
+          id="use-oretachi-terminal-for-background"
+          type="checkbox"
+          class="toggle-checkbox"
+          :checked="settings.useOretachiTerminalForBackground ?? true"
+          @change="(e) => { settings.useOretachiTerminalForBackground = (e.target as HTMLInputElement).checked; scheduleSave(); }"
+        />
+        <label for="use-oretachi-terminal-for-background" class="inline-label toggle-label">{{ t('terminal.useOretachiTerminalForBackground') }}</label>
+      </div>
+      <p class="field-description">{{ t('terminal.useOretachiTerminalForBackgroundDesc') }}</p>
     </div>
 
     <!-- ワークツリー追加先ディレクトリ -->
@@ -1036,6 +1047,12 @@ function getSoundLabel(sound: string | null | undefined): string {
   color: #6c7086;
 }
 
+.field-description {
+  margin: 6px 0 0;
+  font-size: 11px;
+  color: #6c7086;
+}
+
 .appearance-acrylic-controls {
   margin-top: 10px;
   display: flex;
@@ -1158,7 +1175,9 @@ function getSoundLabel(sound: string | null | undefined): string {
         "right": "Right",
         "top": "Top",
         "left": "Left"
-      }
+      },
+      "useOretachiTerminalForBackground": "Use oretachi terminal for AI background commands",
+      "useOretachiTerminalForBackgroundDesc": "When OFF, AI agents launch pnpm dev / vite / nodemon etc. via Claude Code's bash run_in_background instead of an oretachi terminal tab."
     },
     "worktreeBaseDir": {
       "label": "Worktree base directory",
@@ -1259,7 +1278,9 @@ function getSoundLabel(sound: string | null | undefined): string {
         "right": "右",
         "top": "上",
         "left": "左"
-      }
+      },
+      "useOretachiTerminalForBackground": "AI からの background コマンドを oretachi ターミナルで起動する",
+      "useOretachiTerminalForBackgroundDesc": "OFF の場合、AI Agent は pnpm dev / vite / nodemon 等を oretachi のターミナルタブではなく Claude Code の bash run_in_background で起動します。"
     },
     "worktreeBaseDir": {
       "label": "ワークツリーの追加先ディレクトリ",

--- a/src/composables/useAppHotkeys.ts
+++ b/src/composables/useAppHotkeys.ts
@@ -17,7 +17,10 @@ interface UseAppHotkeysDeps {
   isDetached: (id: string) => boolean;
   switchToWorktree: (id: string) => void;
   focusSubWindow: (id: string) => Promise<void>;
-  onAddTerminal: (id: string) => Promise<void>;
+  onAddTerminal: (
+    id: string,
+    opts?: { background?: boolean; pendingCommand?: string },
+  ) => Promise<void>;
   showAddTaskDialog: Ref<boolean>;
   goHome: () => void;
   onTrayButtonClick: () => Promise<void>;

--- a/src/composables/useFrameLayout.ts
+++ b/src/composables/useFrameLayout.ts
@@ -6,13 +6,15 @@ function newId(prefix: string): string {
   return `${prefix}-${++idCounter}`;
 }
 
-function makeLeaf(terminalIds: number[]): FrameLeaf {
-  return {
+function makeLeaf(terminalIds: number[], isBackground = false): FrameLeaf {
+  const leaf: FrameLeaf = {
     type: "leaf",
     id: newId("leaf"),
     terminalIds: [...terminalIds],
     activeTerminalId: terminalIds[0] ?? null,
   };
+  if (isBackground) leaf.isBackground = true;
+  return leaf;
 }
 
 function makeContainer(
@@ -95,11 +97,12 @@ export function useFrameLayout() {
   function splitLeaf(
     leafId: string,
     direction: "left" | "right" | "top" | "bottom",
-    terminalIds: number[] = []
+    terminalIds: number[] = [],
+    isBackground = false
   ): FrameLeaf {
     const layout = direction === "left" || direction === "right" ? "horizontal" : "vertical";
     const insertBefore = direction === "left" || direction === "top";
-    const newLeaf = makeLeaf(terminalIds);
+    const newLeaf = makeLeaf(terminalIds, isBackground);
 
     const parentInfo = findParent(leafId);
     const existingLeaf = findLeafById(leafId);
@@ -263,6 +266,20 @@ export function useFrameLayout() {
     return leafs;
   }
 
+  function findBackgroundLeaf(): FrameLeaf | null {
+    return getAllLeafs().find((l) => l.isBackground) ?? null;
+  }
+
+  function markLeafBackground(leafId: string, value: boolean) {
+    const leaf = findLeafById(leafId);
+    if (!leaf) return;
+    if (value) {
+      leaf.isBackground = true;
+    } else {
+      delete leaf.isBackground;
+    }
+  }
+
   return {
     root,
     initLayout,
@@ -274,5 +291,7 @@ export function useFrameLayout() {
     setActiveTerminal,
     pruneTree,
     getAllLeafs,
+    findBackgroundLeaf,
+    markLeafBackground,
   };
 }

--- a/src/composables/useSubWindows.ts
+++ b/src/composables/useSubWindows.ts
@@ -1,7 +1,15 @@
 import { reactive } from "vue";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { emitTo, listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import type { FrameNode } from "../types/frame";
+
+// Rust 側 DetachedWorktreeRegistry に通知して MCP ツールの状態と同期する。
+// 失敗してもフロントの動作には影響しないため握りつぶす。
+function syncDetachedToBackend(worktreeId: string, detached: boolean): void {
+  const cmd = detached ? "register_detached_worktree" : "unregister_detached_worktree";
+  invoke(cmd, { worktreeId }).catch(() => {});
+}
 
 export interface SubLayoutResponse {
   layout: FrameNode | null;
@@ -102,6 +110,7 @@ export function useSubWindows() {
       pendingInitData.delete(worktreeId);
       subWindowMap.delete(worktreeId);
       detachedWorktrees.delete(worktreeId);
+      syncDetachedToBackend(worktreeId, false);
     });
 
     // ターミナルデータはサブウィンドウ準備完了後にイベントで送る
@@ -117,6 +126,7 @@ export function useSubWindows() {
 
     subWindowMap.set(worktreeId, win);
     detachedWorktrees.add(worktreeId);
+    syncDetachedToBackend(worktreeId, true);
   }
 
   async function moveToMainWindow(worktreeId: string): Promise<void> {
@@ -154,6 +164,7 @@ export function useSubWindows() {
     }
     worktreeTerminalMap.delete(worktreeId);
     detachedWorktrees.delete(worktreeId);
+    syncDetachedToBackend(worktreeId, false);
   }
 
   async function focusSubWindow(worktreeId: string): Promise<void> {
@@ -171,6 +182,7 @@ export function useSubWindows() {
     }
     worktreeTerminalMap.delete(worktreeId);
     detachedWorktrees.delete(worktreeId);
+    syncDetachedToBackend(worktreeId, false);
   }
 
   function getPendingInitData(worktreeId: string): PendingInitData | undefined {
@@ -226,11 +238,18 @@ export function useSubWindows() {
       try { await win.destroy(); } catch { /* 既に閉じ済み */ }
     }
 
+    // Rust 側 registry を全 ID 分解除（フロントの Set をクリアする前にスナップショット）
+    const detachedSnapshot = Array.from(detachedWorktrees);
+
     subWindowMap.clear();
     pendingInitData.clear();
     terminalSessionMap.clear();
     worktreeTerminalMap.clear();
     detachedWorktrees.clear();
+
+    for (const id of detachedSnapshot) {
+      syncDetachedToBackend(id, false);
+    }
   }
 
   return {

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -25,7 +25,7 @@ export function useTaskExecution(deps: {
   onAddTerminal: (worktreeId: string) => Promise<void>;
   onMoveToSubWindow: (worktreeId: string) => Promise<void>;
   loadingWorktrees: Map<string, string>;
-  pendingScripts: Map<string, string>;
+  pendingScripts: Map<string, string[]>;
   autoApprovalMap: Map<string, boolean>;
   onWebSessionDetected?: (terminalId: number, info: WebSessionInfo) => void;
 }) {
@@ -277,7 +277,12 @@ export function useTaskExecution(deps: {
 
       const pending = buildPendingCommand(repo, entry);
       if (pending) {
-        pendingScripts.set(entry.id, pending);
+        const existing = pendingScripts.get(entry.id);
+        if (existing) {
+          existing.push(pending);
+        } else {
+          pendingScripts.set(entry.id, [pending]);
+        }
       }
 
       await onAddTerminal(entry.id);

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -22,10 +22,12 @@ export function useTaskExecution(deps: {
   tryAutoAssignHotkey: (worktreeId: string) => void;
   terminalAgentStatus: Map<number, boolean>;
   getTerminalRef: (terminalId: number) => InstanceType<typeof TerminalView> | undefined;
-  onAddTerminal: (worktreeId: string) => Promise<void>;
+  onAddTerminal: (
+    worktreeId: string,
+    opts?: { background?: boolean; pendingCommand?: string },
+  ) => Promise<void>;
   onMoveToSubWindow: (worktreeId: string) => Promise<void>;
   loadingWorktrees: Map<string, string>;
-  pendingScripts: Map<string, string[]>;
   autoApprovalMap: Map<string, boolean>;
   onWebSessionDetected?: (terminalId: number, info: WebSessionInfo) => void;
 }) {
@@ -45,7 +47,6 @@ export function useTaskExecution(deps: {
     onAddTerminal,
     onMoveToSubWindow,
     loadingWorktrees,
-    pendingScripts,
     autoApprovalMap,
     onWebSessionDetected,
   } = deps;
@@ -276,16 +277,7 @@ export function useTaskExecution(deps: {
       }
 
       const pending = buildPendingCommand(repo, entry);
-      if (pending) {
-        const existing = pendingScripts.get(entry.id);
-        if (existing) {
-          existing.push(pending);
-        } else {
-          pendingScripts.set(entry.id, [pending]);
-        }
-      }
-
-      await onAddTerminal(entry.id);
+      await onAddTerminal(entry.id, pending ? { pendingCommand: pending } : undefined);
       await waitForSessionReady(entry.id);
 
       if (repo.packageManager || repo.execScript) {

--- a/src/composables/useWorktreeFrame.ts
+++ b/src/composables/useWorktreeFrame.ts
@@ -2,6 +2,7 @@ import { ref, nextTick } from "vue";
 import { useFrameLayout } from "./useFrameLayout";
 import { useTerminalReparenting } from "./useTerminalReparenting";
 import type { SubTerminalEntry } from "../types/terminal";
+import type { FrameLeaf } from "../types/frame";
 import type TerminalView from "../components/TerminalView.vue";
 
 /**
@@ -29,6 +30,8 @@ export function useWorktreeFrame(options: {
     pruneTree,
     findLeafByTerminalId,
     getAllLeafs,
+    findBackgroundLeaf,
+    markLeafBackground,
   } = useFrameLayout();
 
   const lastFocusedLeafId = ref<string>("");
@@ -111,6 +114,15 @@ export function useWorktreeFrame(options: {
       if (term) await term.handleTabActivated();
     }
     return newLeaf;
+  }
+
+  /**
+   * 背景専用ペイン（isBackground）を新規に追加する。
+   * lastFocusedLeafId を更新せずフォアグラウンドのフォーカスを維持する。
+   */
+  function addBackgroundLeaf(direction: "left" | "right" | "top" | "bottom"): FrameLeaf {
+    const targetLeafId = lastFocusedLeafId.value || getAllLeafs()[0]?.id || "";
+    return splitLeaf(targetLeafId, direction, [], true);
   }
 
   function onTabReorder(leafId: string, terminalId: number, insertIndex: number) {
@@ -218,5 +230,8 @@ export function useWorktreeFrame(options: {
     onTabDrop,
     onTabEdgeDrop,
     onTabReorder,
+    findBackgroundLeaf,
+    markLeafBackground,
+    addBackgroundLeaf,
   };
 }

--- a/src/types/frame.ts
+++ b/src/types/frame.ts
@@ -4,6 +4,8 @@ export interface FrameLeaf {
   id: string;
   terminalIds: number[];
   activeTerminalId: number | null;
+  /** MCP 等から起動するバックグラウンドコマンド（pnpm dev 等）専用ペイン */
+  isBackground?: boolean;
 }
 
 /** コンテナ: Splitter で子を並べる */

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -114,4 +114,5 @@ export interface AppSettings {
   enableHomeCat?: boolean;
   aiTimeoutSecs?: number; // AIタイムアウト秒数 (デフォルト: 120)
   debugMode?: boolean;
+  useOretachiTerminalForBackground?: boolean; // AI からの background コマンドを oretachi ターミナルで起動するか (デフォルト: true)
 }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -30,6 +30,8 @@ export interface WorktreeEntry {
 export interface TerminalSettings {
   fontSize: number;
   shell?: string; // デフォルトシェル (空 = 各 OS のデフォルトにフォールバック)
+  /** MCP 等で起動する背景ペインの分割方向 (デフォルト: bottom) */
+  backgroundPaneSplitDirection?: "left" | "right" | "top" | "bottom";
 }
 
 export interface HotkeyBinding {


### PR DESCRIPTION
## Summary

- AI Agent から oretachi UI の新規ターミナルタブを操作するための MCP ツール群（spawn / list / kill / read / write / get_app_options）を追加
- `oretachi_read_terminal` に差分読み取り（`from_cursor`）、`status` / `lastCommandExitCode`（OSC 777 経由）、ANSI 除去、ロストバイト報告を実装
- MCP 起動ターミナルを背景ペインへ隔離する分割レイアウト（左右上下選択可）と PowerShell Enter 正規化を実装
- 設定タブに「AI からの background コマンドを oretachi ターミナルで起動する」グローバルトグル（デフォルト ON）を追加。OFF にすると background-command スキルは Claude Code の bash run_in_background にフォールバック
- `background-command` スキル（SKILL.md）を整備し、Step 0 〜 6 の手順、差分読み・キー入力・Ctrl-C 送信などをドキュメント化

## Test plan

- [ ] `cargo check` / `pnpm run type-check` がパスすること
- [ ] `pnpm run tauri dev` で起動し、設定タブ → Terminal セクションに新トグルが表示されること
- [ ] トグル ON 状態で AI から `pnpm dev` を依頼 → oretachi に新タブが立ち、`oretachi_spawn_terminal` 経由で起動すること
- [ ] トグル OFF 状態で同じ依頼 → bash run_in_background にフォールバックし、oretachi にタブが立たないこと
- [ ] `oretachi_get_app_options` が `{ "useOretachiTerminalForBackground": bool }` を返すこと
- [ ] アプリ再起動後にトグル状態が永続化されていること（`%APPDATA%\com.ia.oretachi\settings.json`）
- [ ] 言語切替（en/ja）でラベル/説明文が正しく表示されること
- [ ] `oretachi_read_terminal` の `from_cursor` 連続ポーリングで重複なく差分が取得できること
- [ ] `oretachi_write_terminal` で `pnpm test\n` 投入 → `lastCommandExitCode` が反映されること
- [ ] Ctrl-C raw 送信で常駐プロセスが graceful 停止すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)