### PR TITLE
fix: 通知ウィンドウで分割リーフのサイズがメインと一致しない問題を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1575,7 +1575,7 @@ onMounted(async () => {
               @tab-edge-drop="(sl, tid, tl, dir) => onFrameTabEdgeDrop(wt.id, sl, tid, tl, dir)"
               @tab-reorder="(lid, tid, idx) => onFrameTabReorder(wt.id, lid, tid, idx)"
               @request-add-terminal="(leafId) => onFrameAddTerminal(wt.id, leafId)"
-              @resize-end="() => {}"
+              @resize-end="(nodeId, sizes) => worktreeFrameBundles.get(wt.id)?.frame.updateContainerSizes(nodeId, sizes)"
             />
           </div>
         </div>

--- a/src/SubWindowApp.vue
+++ b/src/SubWindowApp.vue
@@ -123,6 +123,7 @@ const {
   onTabDrop,
   onTabEdgeDrop,
   onTabReorder,
+  updateContainerSizes,
 } = useWorktreeFrame({
   terminalEntries,
   terminalRefs,
@@ -579,7 +580,7 @@ async function onCancelAiJudging() {
           @tab-edge-drop="onTabEdgeDrop"
           @tab-reorder="onTabReorder"
           @request-add-terminal="requestAddTerminal"
-          @resize-end="() => {}"
+          @resize-end="updateContainerSizes"
         />
       </div>
     </template>

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -60,6 +60,7 @@ const {
   switchNextTerminal,
   switchPrevTerminal,
   closeActiveTerminal,
+  updateContainerSizes,
 } = useWorktreeFrame({
   terminalEntries,
   terminalRefs,
@@ -422,7 +423,7 @@ onUnmounted(() => {
         @tab-edge-drop="onTabEdgeDrop"
         @tab-reorder="onTabReorder"
         @request-add-terminal="() => {}"
-        @resize-end="() => {}"
+        @resize-end="updateContainerSizes"
       />
 
       <div v-else-if="initialized" class="flex items-center justify-center h-full text-[#6c7086] text-sm">

--- a/src/composables/useFrameLayout.ts
+++ b/src/composables/useFrameLayout.ts
@@ -58,6 +58,23 @@ export function useFrameLayout() {
     return null;
   }
 
+  function findContainerById(nodeId: string, node: FrameNode = root.value): FrameContainer | null {
+    if (node.type !== "container") return null;
+    if (node.id === nodeId) return node;
+    for (const child of node.children) {
+      const result = findContainerById(nodeId, child);
+      if (result) return result;
+    }
+    return null;
+  }
+
+  function updateContainerSizes(containerId: string, sizes: number[]) {
+    const container = findContainerById(containerId);
+    if (!container) return;
+    if (container.children.length !== sizes.length) return;
+    container.sizes = [...sizes];
+  }
+
   function findParent(
     nodeId: string,
     node: FrameNode = root.value,
@@ -293,5 +310,6 @@ export function useFrameLayout() {
     getAllLeafs,
     findBackgroundLeaf,
     markLeafBackground,
+    updateContainerSizes,
   };
 }

--- a/src/composables/useWorktreeFrame.ts
+++ b/src/composables/useWorktreeFrame.ts
@@ -32,6 +32,7 @@ export function useWorktreeFrame(options: {
     getAllLeafs,
     findBackgroundLeaf,
     markLeafBackground,
+    updateContainerSizes,
   } = useFrameLayout();
 
   const lastFocusedLeafId = ref<string>("");
@@ -233,5 +234,6 @@ export function useWorktreeFrame(options: {
     findBackgroundLeaf,
     markLeafBackground,
     addBackgroundLeaf,
+    updateContainerSizes,
   };
 }


### PR DESCRIPTION
## Summary
- 通知ウィンドウ（TrayPopupApp）で Splitter 分割されたワークツリーを表示するとリーフ（ターミナル）の表示サイズがメインウィンドウと一致しない問題を修正
- 根本原因: `FrameContainer` の `resize-end` イベントを App.vue / SubWindowApp.vue / TrayPopupApp.vue すべてで空ハンドラ `() => {}` で握りつぶしていたため、ドラッグした比率が `root.value.sizes` に永続化されず、トレイへ送る layout には初期均等分割値が入っていた
- `useFrameLayout` に `updateContainerSizes(containerId, sizes)` を追加し、3画面の `@resize-end` から呼び出すように変更

## Test plan
- [ ] `pnpm run tauri dev` で起動
- [ ] メインでワークツリーを開き、ターミナルを 2 つ作成 → 水平分割 → gutter を 70/30 程度にドラッグ
- [ ] 通知をトリガーしてトレイポップアップを開く → 2 panel が 70/30 で表示され、各 xterm が panel ピッタリに描画されることを目視確認
- [ ] 垂直分割 + ネスト分割パターンでも比率が反映されること
- [ ] detached サブウィンドウからのトレイ表示でも同様に比率反映
- [ ] 単一リーフ・往復遷移の回帰確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)