### PR TITLE
feat(home): ワークツリーカードのターミナル表示を1行最大2つ＆リスト中央寄せ

### DIFF
--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -528,6 +528,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
   flex-wrap: wrap;
   gap: 12px;
   align-items: flex-start;
+  justify-content: center;
 }
 
 .masonry-column {

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -258,10 +258,11 @@ const naturalCardWidth = computed(() => {
   const THUMBNAIL_GAP = 8;  // .terminals-row の gap
   const CARD_PADDING = 24;  // .worktree-card の padding 12px × 2
   const MIN_WIDTH = 260;    // ヘッダーボタンが収まる最小幅
+  const MAX_TERMINALS_PER_ROW = 2;  // 1行に表示するターミナルの最大数
 
   let max = MIN_WIDTH;
   for (const wt of props.worktrees) {
-    const n = wt.terminals.length;
+    const n = Math.min(wt.terminals.length, MAX_TERMINALS_PER_ROW);
     if (n <= 0) continue;
     const w = CARD_PADDING + n * THUMBNAIL_W + (n - 1) * THUMBNAIL_GAP;
     if (w > max) max = w;


### PR DESCRIPTION
## 概要

ホーム画面のワークツリーカードについて以下を変更しました。

1. **1行に表示するターミナルを最大2つに制限**
   `HomeView.vue` の `naturalCardWidth` で masonry 列幅計算に使うターミナル数を `Math.min(wt.terminals.length, 2)` でクランプ。カード幅が最大2サムネイル分に抑えられ、3個目以降は `.terminals-row` の既存 `flex-wrap: wrap` で折り返される。

2. **カードリストを中央寄せ**
   `.worktree-list` に `justify-content: center` を追加。カラムは `maxWidth` で頭打ちになるため、余った横スペースが左右均等に配分され中央に揃う。

## 備考

- `.worktree-list` クラスはワークツリー一覧とタスク一覧で共有されているため、タスクパネルのカードリストも中央寄せになります。
- `pnpm run type-check` 通過済み。bug-review 実施済み（指摘なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)