### PR TITLE
fix: WebView2 ハング根本原因除去 — webview発ロギングIPCの源流カット (#59)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -758,7 +758,11 @@ pub fn run() {
                 .rotation_strategy(RotationStrategy::KeepAll)
                 .max_file_size(100_000_000) // 100MB
                 .timezone_strategy(TimezoneStrategy::UseLocal)
-                .level(log::LevelFilter::Debug)
+                .level(if cfg!(debug_assertions) {
+                    log::LevelFilter::Debug
+                } else {
+                    log::LevelFilter::Info
+                })
                 .build(),
         )
         .plugin(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -758,11 +758,7 @@ pub fn run() {
                 .rotation_strategy(RotationStrategy::KeepAll)
                 .max_file_size(100_000_000) // 100MB
                 .timezone_strategy(TimezoneStrategy::UseLocal)
-                .level(if cfg!(debug_assertions) {
-                    log::LevelFilter::Debug
-                } else {
-                    log::LevelFilter::Info
-                })
+                .level(log::LevelFilter::Debug)
                 .build(),
         )
         .plugin(

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,7 @@ import { useAppHotkeys } from "./composables/useAppHotkeys";
 import { useSubWindowEvents } from "./composables/useSubWindowEvents";
 import { useShutdownGuard } from "./composables/useShutdownGuard";
 import type { ArchiveRow } from "./types/archive";
-import { debug } from "@tauri-apps/plugin-log";
+import { logDebug } from "./utils/log";
 import { consumeMaxBlockedMs, startEventLoopMonitor } from "./utils/eventLoopMonitor";
 import { terminalMountCount, terminalUnmountCount, terminalActiveCount } from "./components/TerminalView.vue";
 import { ask } from "@tauri-apps/plugin-dialog";
@@ -376,7 +376,7 @@ async function switchToTerminal(terminalId: number) {
   }
   if (!worktreeId) return;
 
-  debug(`[Terminal] switchToTerminal terminalId=${terminalId} worktreeId=${worktreeId}`);
+  logDebug(`[Terminal] switchToTerminal terminalId=${terminalId} worktreeId=${worktreeId}`);
 
   const bundle = worktreeFrameBundles.get(worktreeId);
   if (bundle) {
@@ -390,23 +390,23 @@ async function switchToTerminal(terminalId: number) {
   viewMode.value = "terminal";
   activeWorktreeId.value = worktreeId;
   await nextTick();
-  debug(`[Terminal] switchToTerminal after nextTick terminalId=${terminalId}`);
+  logDebug(`[Terminal] switchToTerminal after nextTick terminalId=${terminalId}`);
 
   if (bundle) {
     bundle.frame.mountTerminalsToHosts();
-    debug(`[Terminal] switchToTerminal after mountTerminalsToHosts terminalId=${terminalId}`);
+    logDebug(`[Terminal] switchToTerminal after mountTerminalsToHosts terminalId=${terminalId}`);
     const term = bundle.terminalRefs.get(terminalId);
     if (term) {
       await term.handleTabActivated();
-      debug(`[Terminal] switchToTerminal after handleTabActivated terminalId=${terminalId}`);
+      logDebug(`[Terminal] switchToTerminal after handleTabActivated terminalId=${terminalId}`);
       term.focus();
       // 安全策: flexレイアウト確定が遅延する場合に備えた再fit
       setTimeout(() => {
-        debug(`[Terminal] switchToTerminal setTimeout re-fit terminalId=${terminalId}`);
+        logDebug(`[Terminal] switchToTerminal setTimeout re-fit terminalId=${terminalId}`);
         term.handleTabActivated();
       }, 150);
     } else {
-      debug(`[Terminal] switchToTerminal term ref not found terminalId=${terminalId}`);
+      logDebug(`[Terminal] switchToTerminal term ref not found terminalId=${terminalId}`);
     }
   }
 }
@@ -481,7 +481,7 @@ async function onAddTerminal(
   if (options?.pendingCommand !== undefined) {
     pendingByTerminal.set(terminal.id, options.pendingCommand);
   }
-  debug(`[Terminal] onAddTerminal worktreeId=${worktreeId} terminalId=${terminal.id} background=${background}`);
+  logDebug(`[Terminal] onAddTerminal worktreeId=${worktreeId} terminalId=${terminal.id} background=${background}`);
 
   // バンドルがなければ作成（ワークツリー追加直後など）
   if (!worktreeFrameBundles.has(worktreeId)) {
@@ -494,7 +494,7 @@ async function onAddTerminal(
   const targetLeafId = background
     ? getOrCreateBackgroundLeafId(bundle)
     : (bundle.frame.lastFocusedLeafId.value || bundle.frame.getAllLeafs()[0]?.id);
-  debug(`[Terminal] onAddTerminal leafId=${targetLeafId ?? "null"} terminalId=${terminal.id}`);
+  logDebug(`[Terminal] onAddTerminal leafId=${targetLeafId ?? "null"} terminalId=${terminal.id}`);
   if (targetLeafId) {
     bundle.frame.returnAllToOffscreen();
     bundle.frame.addTerminalToLeaf(targetLeafId, terminal.id);
@@ -512,28 +512,28 @@ async function onAddTerminal(
   }
 
   await nextTick();
-  debug(`[Terminal] onAddTerminal after nextTick terminalId=${terminal.id}`);
+  logDebug(`[Terminal] onAddTerminal after nextTick terminalId=${terminal.id}`);
 
   bundle.frame.mountTerminalsToHosts();
-  debug(`[Terminal] onAddTerminal after mountTerminalsToHosts terminalId=${terminal.id}`);
+  logDebug(`[Terminal] onAddTerminal after mountTerminalsToHosts terminalId=${terminal.id}`);
   const term = bundle.terminalRefs.get(terminal.id);
   if (term) {
     await term.handleTabActivated();
-    debug(`[Terminal] onAddTerminal after handleTabActivated terminalId=${terminal.id}`);
+    logDebug(`[Terminal] onAddTerminal after handleTabActivated terminalId=${terminal.id}`);
     pendingManualStart.delete(terminal.id);
     await term.startPty();
-    debug(`[Terminal] onAddTerminal after startPty terminalId=${terminal.id}`);
+    logDebug(`[Terminal] onAddTerminal after startPty terminalId=${terminal.id}`);
     if (!background) {
       term.focus();
     }
     // 安全策: flexレイアウト確定が遅延する場合に備えた再fit
     setTimeout(() => {
-      debug(`[Terminal] onAddTerminal setTimeout re-fit terminalId=${terminal.id}`);
+      logDebug(`[Terminal] onAddTerminal setTimeout re-fit terminalId=${terminal.id}`);
       term.handleTabActivated();
     }, 150);
   } else {
     pendingManualStart.delete(terminal.id);
-    debug(`[Terminal] onAddTerminal term ref not found terminalId=${terminal.id}`);
+    logDebug(`[Terminal] onAddTerminal term ref not found terminalId=${terminal.id}`);
   }
 }
 
@@ -781,7 +781,7 @@ async function onMoveToMainWindow(worktreeId: string) {
     ? await subWindowEvents.getSubWindowLayout(worktreeId)
     : { layout: null, terminals: [] };
 
-  debug(`[MoveToMain] start worktreeId=${worktreeId} savedTerminals=${JSON.stringify(savedTerminals.map(t => ({ id: t.id, sessionId: t.sessionId })))}`);
+  logDebug(`[MoveToMain] start worktreeId=${worktreeId} savedTerminals=${JSON.stringify(savedTerminals.map(t => ({ id: t.id, sessionId: t.sessionId })))}`);
 
   // ★ moveToMainWindow の前にデータを準備（Vue再描画より先にセット）
   // pendingSessionAttach はプレーンMap → Vue再描画をトリガーしない
@@ -793,15 +793,15 @@ async function onMoveToMainWindow(worktreeId: string) {
       terminalAgentStatus.set(t.id, true);
     }
   }
-  debug(`[MoveToMain] pendingSessionAttach set for terminalIds=[${[...pendingSessionAttach.keys()]}]`);
+  logDebug(`[MoveToMain] pendingSessionAttach set for terminalIds=[${[...pendingSessionAttach.keys()]}]`);
 
   // ensureWorktreeFrame は bundles.set() で再描画をトリガーするが、
   // isDetached がまだ true なので TerminalView は作成されない
   ensureWorktreeFrame(worktreeId, savedLayout ?? undefined);
-  debug(`[MoveToMain] ensureWorktreeFrame done, calling moveToMainWindow`);
+  logDebug(`[MoveToMain] ensureWorktreeFrame done, calling moveToMainWindow`);
 
   await moveToMainWindow(worktreeId);
-  debug(`[MoveToMain] moveToMainWindow done, isDetached=${isDetached(worktreeId)}`);
+  logDebug(`[MoveToMain] moveToMainWindow done, isDetached=${isDetached(worktreeId)}`);
 
   subWindowEvents.subWindowFocusMap.delete(worktreeId);
 }
@@ -1033,13 +1033,13 @@ onMounted(async () => {
       const { worktree_id, command, title } = event.payload;
       const targetWt = worktrees.value.find((w) => w.id === worktree_id);
       if (!targetWt) {
-        debug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} not found, skipping`);
+        logDebug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} not found, skipping`);
         return;
       }
       // detached（サブウィンドウ化済み）ワークツリーは onAddTerminal が
       // handleSubAddTerminalRequest に分岐し pendingCommand を消費しないため未対応
       if (isDetached(worktree_id)) {
-        debug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} is detached, not supported`);
+        logDebug(`[Terminal] mcp-spawn-terminal: worktree ${worktree_id} is detached, not supported`);
         return;
       }
       const beforeIds = new Set(targetWt.terminals.map((t) => t.id));
@@ -1050,7 +1050,7 @@ onMounted(async () => {
       try {
         await onAddTerminal(worktree_id, { background: true, pendingCommand: cmd });
       } catch (e) {
-        debug(`[Terminal] mcp-spawn-terminal: onAddTerminal failed: ${e}`);
+        logDebug(`[Terminal] mcp-spawn-terminal: onAddTerminal failed: ${e}`);
         return;
       }
       if (title) {

--- a/src/SubWindowApp.vue
+++ b/src/SubWindowApp.vue
@@ -18,7 +18,7 @@ import type { TerminalForApproval } from "./utils/autoApproval";
 import { useIdeSelect } from "./composables/useIdeSelect";
 import { useArtifactWindow } from "./composables/useArtifactWindow";
 import { invoke } from "@tauri-apps/api/core";
-import { debug } from "@tauri-apps/plugin-log";
+import { logDebug } from "./utils/log";
 import IdeSelectDialog from "./components/IdeSelectDialog.vue";
 import AutoApprovalPromptDialog from "./components/AutoApprovalPromptDialog.vue";
 import type { SubTerminalEntry, WebSessionInfo, AiSessionInfo } from "./types/terminal";
@@ -474,7 +474,7 @@ onMounted(async () => {
     if (event.payload.additionalPrompt !== undefined) {
       additionalPrompt.value = event.payload.additionalPrompt;
     }
-    await debug(`[AutoApproval] sub-try-auto-approve received autoApproval=${autoApproval.value}`);
+    logDebug(`[AutoApproval] sub-try-auto-approve received autoApproval=${autoApproval.value}`);
     if (!autoApproval.value) {
       await emitTo("main", "sub-auto-approve-result", { worktreeId, approved: false });
       return;
@@ -482,11 +482,11 @@ onMounted(async () => {
 
     // 重複防止: 既にAI判定が進行中ならスキップ
     if (aiJudging.value) {
-      await debug(`[AutoApproval] already in progress for sub-window ${worktreeId}, skipping`);
+      logDebug(`[AutoApproval] already in progress for sub-window ${worktreeId}, skipping`);
       return;
     }
 
-    await debug(`[AutoApproval] terminalEntries.size=${terminalEntries.size}`);
+    logDebug(`[AutoApproval] terminalEntries.size=${terminalEntries.size}`);
     aiJudging.value = true;
     let loopResult: { approved: boolean; lastCommand: string | undefined };
     try {
@@ -499,14 +499,14 @@ onMounted(async () => {
     } finally {
       aiJudging.value = false;
     }
-    await debug(`[AutoApproval] sub result: approved=${loopResult.approved} command=${loopResult.lastCommand ?? "none"}`);
+    logDebug(`[AutoApproval] sub result: approved=${loopResult.approved} command=${loopResult.lastCommand ?? "none"}`);
     if (loopResult.lastCommand) lastJudgedCommand.value = loopResult.lastCommand;
     await emitTo("main", "sub-auto-approve-result", { worktreeId, approved: loopResult.approved, command: loopResult.lastCommand });
   }));
 
   // AI判定キャンセル
   collect(await appWindow.listen("sub-cancel-auto-approve", async () => {
-    await debug(`[AutoApproval] sub-cancel-auto-approve received`);
+    logDebug(`[AutoApproval] sub-cancel-auto-approve received`);
     await invoke("cancel_approval", { worktreeId });
     aiJudging.value = false;
   }));

--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -18,7 +18,7 @@ import { matchesHotkey } from "../composables/useHotkeys";
 import { useTerminalSearch } from "../composables/useTerminalSearch";
 import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useI18n } from "vue-i18n";
-import { debug } from "@tauri-apps/plugin-log";
+import { logDebug } from "../utils/log";
 
 const { t } = useI18n();
 
@@ -173,7 +173,7 @@ function initTerminal() {
     const isOffscreen = !!xtermRef.value?.closest('[data-offscreen]');
     fitAddon.fit();
     const initDims = fitAddon.proposeDimensions();
-    debug(`[Terminal] initTerminal fit offscreen=${isOffscreen} dims=${JSON.stringify(initDims)} parentSize=${xtermRef.value?.parentElement?.clientWidth}x${xtermRef.value?.parentElement?.clientHeight}`);
+    logDebug(`[Terminal] initTerminal fit offscreen=${isOffscreen} dims=${JSON.stringify(initDims)} parentSize=${xtermRef.value?.parentElement?.clientWidth}x${xtermRef.value?.parentElement?.clientHeight}`);
   }
 
   terminal.onTitleChange((title) => {
@@ -237,11 +237,11 @@ function initTerminal() {
     // オフスクリーン div 内にいる場合はスキップ
     const isOffscreen = !!xtermRef.value?.closest('[data-offscreen]');
     if (isOffscreen) {
-      debug(`[Terminal] ResizeObserver skipped (offscreen) sid=${sessionId.value} w=${entry.contentRect.width} h=${entry.contentRect.height}`);
+      logDebug(`[Terminal] ResizeObserver skipped (offscreen) sid=${sessionId.value} w=${entry.contentRect.width} h=${entry.contentRect.height}`);
       return;
     }
     if (props.noResize) return;
-    debug(`[Terminal] ResizeObserver fired sid=${sessionId.value} w=${entry.contentRect.width} h=${entry.contentRect.height}`);
+    logDebug(`[Terminal] ResizeObserver fired sid=${sessionId.value} w=${entry.contentRect.width} h=${entry.contentRect.height}`);
     if (resizeDebounce) clearTimeout(resizeDebounce);
     resizeDebounce = setTimeout(() => {
       if (fitAddon && terminal) {
@@ -249,7 +249,7 @@ function initTerminal() {
         if (!props.noResize) {
           const dims = fitAddon.proposeDimensions();
           if (dims) {
-            debug(`[Terminal] ResizeObserver after fit sid=${sessionId.value} rows=${dims.rows} cols=${dims.cols}`);
+            logDebug(`[Terminal] ResizeObserver after fit sid=${sessionId.value} rows=${dims.rows} cols=${dims.cols}`);
             resize(dims.rows, dims.cols);
           }
         }
@@ -321,10 +321,10 @@ async function handleTabActivated() {
           if (!props.noResize) {
             const dimsBefore = fitAddon.proposeDimensions();
             const parentEl = xtermRef.value?.parentElement;
-            debug(`[Terminal] handleTabActivated before fit sid=${sessionId.value} dims=${JSON.stringify(dimsBefore)} parentSize=${parentEl?.clientWidth}x${parentEl?.clientHeight}`);
+            logDebug(`[Terminal] handleTabActivated before fit sid=${sessionId.value} dims=${JSON.stringify(dimsBefore)} parentSize=${parentEl?.clientWidth}x${parentEl?.clientHeight}`);
             fitAddon.fit();
             const dimsAfter = fitAddon.proposeDimensions();
-            debug(`[Terminal] handleTabActivated after fit sid=${sessionId.value} dims=${JSON.stringify(dimsAfter)}`);
+            logDebug(`[Terminal] handleTabActivated after fit sid=${sessionId.value} dims=${JSON.stringify(dimsAfter)}`);
             if (dimsAfter) {
               resize(dimsAfter.rows, dimsAfter.cols);
             }
@@ -376,13 +376,13 @@ watch(
 onMounted(async () => {
   terminalMountCount++;
   terminalActiveCount++;
-  debug(`[TerminalView] onMounted initialSessionId=${props.initialSessionId} autoStart=${props.autoStart} cwd=${props.cwd}`);
+  logDebug(`[TerminalView] onMounted initialSessionId=${props.initialSessionId} autoStart=${props.autoStart} cwd=${props.cwd}`);
   initTerminal();
   if (props.initialSessionId !== undefined) {
-    debug(`[TerminalView] attaching to session ${props.initialSessionId}`);
+    logDebug(`[TerminalView] attaching to session ${props.initialSessionId}`);
     await attachPty(props.initialSessionId, props.initialSnapshot);
   } else if (props.autoStart) {
-    debug(`[TerminalView] starting new PTY (no initialSessionId)`);
+    logDebug(`[TerminalView] starting new PTY (no initialSessionId)`);
     if (props.restoreSnapshot) {
       terminal?.write(props.restoreSnapshot);
     }
@@ -393,7 +393,7 @@ onMounted(async () => {
 onUnmounted(() => {
   terminalUnmountCount++;
   terminalActiveCount--;
-  debug(`[TerminalView] onUnmounted sessionId=${sessionId.value} cwd=${props.cwd}`);
+  logDebug(`[TerminalView] onUnmounted sessionId=${sessionId.value} cwd=${props.cwd}`);
   if (resizeDebounce) clearTimeout(resizeDebounce);
   resizeObserver?.disconnect();
   batcher.dispose();

--- a/src/composables/useAppAutoApproval.ts
+++ b/src/composables/useAppAutoApproval.ts
@@ -1,6 +1,6 @@
 import { reactive } from "vue";
 import { listen, emitTo } from "@tauri-apps/api/event";
-import { debug } from "@tauri-apps/plugin-log";
+import { logDebug } from "../utils/log";
 import { runApprovalLoop, cancelApproval } from "../utils/autoApproval";
 import type { TerminalForApproval } from "../utils/autoApproval";
 import type { Ref } from "vue";
@@ -77,24 +77,24 @@ export function useAppAutoApproval(deps: UseAppAutoApprovalDeps) {
       if (!wt) return;
       if (!autoApprovalMap.get(wt.id)) return;
 
-      debug(
+      logDebug(
         `[AutoApproval] notify-worktree received worktreeName=${worktreeName} resolved=${wt.id} autoApproval=true`
       );
 
       if (aiJudgingWorktrees.has(wt.id)) {
-        debug(`[AutoApproval] already in progress for ${wt.id}, skipping`);
+        logDebug(`[AutoApproval] already in progress for ${wt.id}, skipping`);
         return;
       }
 
       if (deps.isDetached(wt.id)) {
-        debug(`[AutoApproval] delegating to sub-window ${wt.id}`);
+        logDebug(`[AutoApproval] delegating to sub-window ${wt.id}`);
         await emitTo(`sub-${wt.id}`, "sub-try-auto-approve", {
           additionalPrompt: deps.autoApprovalPromptMap.get(wt.id) ?? "",
         });
         return;
       }
 
-      debug(`[AutoApproval] local terminals check, count=${wt.terminals.length}`);
+      logDebug(`[AutoApproval] local terminals check, count=${wt.terminals.length}`);
       aiJudgingWorktrees.add(wt.id);
       let loopResult: { approved: boolean; lastCommand: string | undefined };
       try {
@@ -116,7 +116,7 @@ export function useAppAutoApproval(deps: UseAppAutoApprovalDeps) {
         deps.lastJudgedCommandMap.set(wt.id, loopResult.lastCommand);
       }
       if (!loopResult.approved && !deps.isWorktreeFocused(wt.id)) {
-        await debug(`[AutoApproval] local: not approved → addNotification(${wt.id})`);
+        logDebug(`[AutoApproval] local: not approved → addNotification(${wt.id})`);
         deps.addNotification(wt.id, "approval");
         deps.playSoundForKind("approval");
         await deps.sendOsNotification(wt.name, deps.t("notification.titleApproval"));
@@ -128,7 +128,7 @@ export function useAppAutoApproval(deps: UseAppAutoApprovalDeps) {
       "sub-auto-approve-result",
       async (event) => {
         const { worktreeId: wid, approved, command } = event.payload;
-        await debug(
+        logDebug(
           `[AutoApproval] sub-auto-approve-result worktreeId=${wid} approved=${approved} command=${command ?? "none"}`
         );
         if (command) {

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -1,10 +1,11 @@
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import { error } from "@tauri-apps/plugin-log";
 import { platform } from "@tauri-apps/plugin-os";
 import type { AppSettings, HotkeyBinding, HotkeySettings } from "../types/settings";
 import { setLocale } from "../i18n";
+import { setVerboseLogging } from "../utils/log";
 
 const isMac = platform() === "macos";
 
@@ -63,6 +64,15 @@ const settings = ref<AppSettings>({
   hotkeys: defaultHotkeys(),
   alwaysOnTop: false,
 });
+
+// Debug Mode (settings.debugMode) を webview 側の詳細ログ override に連動させる。
+// 起動時のロード・設定タブでのトグル変更の双方でこの watch が発火する。
+// (dev ビルドでは log.ts 側で常に verbose 扱いのため override の値に関わらず詳細ログは出る)
+watch(
+  () => settings.value.debugMode,
+  (enabled) => setVerboseLogging(enabled === true),
+  { immediate: true },
+);
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/src/composables/useTerminalReparenting.ts
+++ b/src/composables/useTerminalReparenting.ts
@@ -1,5 +1,5 @@
 import { markRaw } from "vue";
-import { debug } from "@tauri-apps/plugin-log";
+import { logDebug } from "../utils/log";
 
 interface HasContainerRef {
   containerRef: HTMLElement | null;
@@ -42,7 +42,7 @@ export function useTerminalReparenting<TEntry, TRef extends HasContainerRef>(
       const host = document.getElementById(`terminal-host-${tid}`);
       const hostStatus = host ? `found(${host.clientWidth}x${host.clientHeight})` : "not_found";
       const elStatus = el ? "found" : "not_found";
-      debug(`[Terminal] mountTerminalsToHosts tid=${tid} host=${hostStatus} el=${elStatus}`);
+      logDebug(`[Terminal] mountTerminalsToHosts tid=${tid} host=${hostStatus} el=${elStatus}`);
       if (el && host && el.parentElement !== host) {
         host.appendChild(el);
       }

--- a/src/composables/useUpdater.ts
+++ b/src/composables/useUpdater.ts
@@ -1,7 +1,7 @@
 import { ref } from "vue";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { error as logError, info } from "@tauri-apps/plugin-log";
+import { logError, logInfo } from "../utils/log";
 import { invoke } from "@tauri-apps/api/core";
 
 export function useUpdater() {
@@ -14,11 +14,11 @@ export function useUpdater() {
     try {
       const update = await check();
       if (update) {
-        await info(`アップデート利用可能: ${update.version}`);
+        logInfo(`アップデート利用可能: ${update.version}`);
         return update;
       }
     } catch (e) {
-      await logError(`アップデート確認エラー: ${e}`);
+      logError(`アップデート確認エラー: ${e}`);
     } finally {
       isChecking.value = false;
     }
@@ -33,7 +33,7 @@ export function useUpdater() {
       await invoke("prepare_for_relaunch");
       await relaunch();
     } catch (e) {
-      await logError(`アップデートインストールエラー: ${e}`);
+      logError(`アップデートインストールエラー: ${e}`);
     } finally {
       isDownloading.value = false;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,10 @@ const mode = params.get("mode");
 async function mountApp() {
   document.addEventListener("contextmenu", (e) => e.preventDefault());
 
-  await attachConsole();
+  // Rust→webview ログ転送リスナーは UI スレッドコストになるため本番では張らない (issue #59)
+  if (import.meta.env.DEV) {
+    await attachConsole();
+  }
 
   // ロケール先読み
   try {

--- a/src/utils/autoApproval.test.ts
+++ b/src/utils/autoApproval.test.ts
@@ -5,6 +5,9 @@ vi.mock('@tauri-apps/api/core', () => ({
 }))
 vi.mock('@tauri-apps/plugin-log', () => ({
   debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
 }))
 
 import { hasApprovalPrompt } from './autoApproval'

--- a/src/utils/autoApproval.test.ts
+++ b/src/utils/autoApproval.test.ts
@@ -4,10 +4,10 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }))
 vi.mock('@tauri-apps/plugin-log', () => ({
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
+  debug: vi.fn(() => Promise.resolve()),
+  info: vi.fn(() => Promise.resolve()),
+  warn: vi.fn(() => Promise.resolve()),
+  error: vi.fn(() => Promise.resolve()),
 }))
 
 import { hasApprovalPrompt } from './autoApproval'

--- a/src/utils/autoApproval.ts
+++ b/src/utils/autoApproval.ts
@@ -1,6 +1,6 @@
 import type { Terminal } from "@xterm/xterm";
 import { invoke } from "@tauri-apps/api/core";
-import { debug } from "@tauri-apps/plugin-log";
+import { logDebug } from "./log";
 
 export interface TerminalForApproval {
   id: number;
@@ -52,12 +52,12 @@ export async function analyzeForApproval(
 ): Promise<JudgeResult> {
   const promptFound = hasApprovalPrompt(content);
 
-  await debug(
+  logDebug(
     `[AutoApproval] analyze start worktreeId=${worktreeId} totalLines=${content.split("\n").length} hasApprovalPrompt=${promptFound}`
   );
 
   if (!promptFound) {
-    await debug("[AutoApproval] → skip: no approval prompt detected");
+    logDebug("[AutoApproval] → skip: no approval prompt detected");
     return { safe: false };
   }
 
@@ -69,10 +69,10 @@ export async function analyzeForApproval(
       cwd,
       additionalPrompt: additionalPrompt || null,
     });
-    await debug(`[AutoApproval] AI judgment: ${result.safe ? "safe" : "unsafe"} command=${result.command ?? "none"}`);
+    logDebug(`[AutoApproval] AI judgment: ${result.safe ? "safe" : "unsafe"} command=${result.command ?? "none"}`);
     return result;
   } catch (e) {
-    await debug(`[AutoApproval] AI judgment failed: ${e}`);
+    logDebug(`[AutoApproval] AI judgment failed: ${e}`);
     return { safe: false }; // エラー時は安全側 (承認しない)
   }
 }
@@ -90,7 +90,7 @@ export async function runApprovalLoop(
   for (const termRef of terminals) {
     const terminal = termRef.getTerminal();
     if (!terminal) {
-      await debug(`[AutoApproval] tid=${termRef.id} terminal=null, skip`);
+      logDebug(`[AutoApproval] tid=${termRef.id} terminal=null, skip`);
       continue;
     }
     // 事前に末尾60行でプロンプト判定し、無ければAI判定と200行取得をスキップ。
@@ -101,7 +101,7 @@ export async function runApprovalLoop(
       continue;
     }
     const content = getRecentLines(terminal, 200);
-    await debug(`[AutoApproval] tid=${termRef.id} content(last200)=${content.slice(-200)}`);
+    logDebug(`[AutoApproval] tid=${termRef.id} content(last200)=${content.slice(-200)}`);
     const judgeResult = await analyzeForApproval(worktreeId, content, cwd, additionalPrompt);
     if (judgeResult.command) {
       lastCommand = judgeResult.command;
@@ -110,15 +110,15 @@ export async function runApprovalLoop(
       // バッファ再チェック: AI判定完了後、承認プロンプトがまだあるか確認
       const freshContent = getRecentLines(terminal, 10);
       if (!hasApprovalPrompt(freshContent)) {
-        await debug(`[AutoApproval] tid=${termRef.id} → prompt disappeared, skip Enter`);
+        logDebug(`[AutoApproval] tid=${termRef.id} → prompt disappeared, skip Enter`);
         break;
       }
-      await debug(`[AutoApproval] tid=${termRef.id} → approved, sending Enter`);
+      logDebug(`[AutoApproval] tid=${termRef.id} → approved, sending Enter`);
       await termRef.write("\r");
       approved = true;
       break;
     } else {
-      await debug(`[AutoApproval] tid=${termRef.id} → not approved`);
+      logDebug(`[AutoApproval] tid=${termRef.id} → not approved`);
     }
   }
 
@@ -130,6 +130,6 @@ export async function cancelApproval(worktreeId: string): Promise<void> {
   try {
     await invoke("cancel_approval", { worktreeId });
   } catch (e) {
-    await debug(`[AutoApproval] cancelApproval failed: ${e}`);
+    logDebug(`[AutoApproval] cancelApproval failed: ${e}`);
   }
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -23,24 +23,30 @@ export function isVerboseLogging(): boolean {
   return verbose;
 }
 
+// fire-and-forget 送出。戻り値が Promise でない場合（テスト mock 等）でも壊れないよう
+// Promise.resolve でラップしてから握り潰す。
+function fire(p: unknown): void {
+  void Promise.resolve(p).catch(() => {});
+}
+
 /** デバッグログ。本番では IPC を発生させない。 */
 export function logDebug(message: string): void {
   if (!verbose) return;
-  void debug(message).catch(() => {});
+  fire(debug(message));
 }
 
 /** 情報ログ。本番では IPC を発生させない。 */
 export function logInfo(message: string): void {
   if (!verbose) return;
-  void info(message).catch(() => {});
+  fire(info(message));
 }
 
 /** 警告ログ。常に送るが await しない。 */
 export function logWarn(message: string): void {
-  void warn(message).catch(() => {});
+  fire(warn(message));
 }
 
 /** エラーログ。常に送るが await しない。 */
 export function logError(message: string): void {
-  void error(message).catch(() => {});
+  fire(error(message));
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,0 +1,46 @@
+import { debug, info, warn, error } from "@tauri-apps/plugin-log";
+
+// ロギングゲート。
+//
+// webview 側の @tauri-apps/plugin-log の debug()/info()/warn()/error() は呼び出しごとに
+// invoke('plugin:log|log') の IPC 往復を発生させる。この往復は Rust 側のレベルフィルタに
+// 関係なく必ず発生し、ホットパスで多数発行すると WebView2 の単一 UI スレッドを飽和させ
+// 恒久フリーズを引き起こす (issue #59, cf. 77475b4)。
+//
+// 対策:
+//   - debug/info は本番ビルドでは呼び出し自体をスキップ (= IPC ゼロ)。
+//   - warn/error は低頻度かつ重要なので常に送るが await しない (fire-and-forget)。
+//   - 再現調査時は setVerboseLogging(true) で詳細ログを復帰可能。
+let verbose = import.meta.env.DEV;
+
+/** 詳細ログ (debug/info) の有効/無効を切り替える。再現調査用。 */
+export function setVerboseLogging(v: boolean): void {
+  verbose = v;
+}
+
+/** 現在の詳細ログ状態 */
+export function isVerboseLogging(): boolean {
+  return verbose;
+}
+
+/** デバッグログ。本番では IPC を発生させない。 */
+export function logDebug(message: string): void {
+  if (!verbose) return;
+  void debug(message).catch(() => {});
+}
+
+/** 情報ログ。本番では IPC を発生させない。 */
+export function logInfo(message: string): void {
+  if (!verbose) return;
+  void info(message).catch(() => {});
+}
+
+/** 警告ログ。常に送るが await しない。 */
+export function logWarn(message: string): void {
+  void warn(message).catch(() => {});
+}
+
+/** エラーログ。常に送るが await しない。 */
+export function logError(message: string): void {
+  void error(message).catch(() => {});
+}

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -10,17 +10,22 @@ import { debug, info, warn, error } from "@tauri-apps/plugin-log";
 // 対策:
 //   - debug/info は本番ビルドでは呼び出し自体をスキップ (= IPC ゼロ)。
 //   - warn/error は低頻度かつ重要なので常に送るが await しない (fire-and-forget)。
-//   - 再現調査時は setVerboseLogging(true) で詳細ログを復帰可能。
-let verbose = import.meta.env.DEV;
+//   - 設定の Debug Mode (settings.debugMode) を ON にすると本番でも詳細ログを復帰できる。
+//     dev ビルドでは常に verbose (開発時の利便性のため)。
+const isDev = import.meta.env.DEV;
+let verboseOverride = false;
 
-/** 詳細ログ (debug/info) の有効/無効を切り替える。再現調査用。 */
+/**
+ * 詳細ログ (debug/info) の override を設定する。
+ * 設定タブの Debug Mode と連動させる想定。dev ビルドでは override に関わらず常に有効。
+ */
 export function setVerboseLogging(v: boolean): void {
-  verbose = v;
+  verboseOverride = v;
 }
 
-/** 現在の詳細ログ状態 */
+/** 現在の詳細ログ状態 (dev は常に true) */
 export function isVerboseLogging(): boolean {
-  return verbose;
+  return isDev || verboseOverride;
 }
 
 // fire-and-forget 送出。戻り値が Promise でない場合（テスト mock 等）でも壊れないよう
@@ -29,15 +34,15 @@ function fire(p: unknown): void {
   void Promise.resolve(p).catch(() => {});
 }
 
-/** デバッグログ。本番では IPC を発生させない。 */
+/** デバッグログ。本番(Debug Mode OFF)では IPC を発生させない。 */
 export function logDebug(message: string): void {
-  if (!verbose) return;
+  if (!isVerboseLogging()) return;
   fire(debug(message));
 }
 
-/** 情報ログ。本番では IPC を発生させない。 */
+/** 情報ログ。本番(Debug Mode OFF)では IPC を発生させない。 */
 export function logInfo(message: string): void {
-  if (!verbose) return;
+  if (!isVerboseLogging()) return;
   fire(info(message));
 }
 


### PR DESCRIPTION
## 概要

複数 AI エージェント稼働中に WebView2 が恒久フリーズする問題 (#59) の根本原因を除去する。実ログ机上解析の結果、フリーズは AutoApproval の AI 判定 (`judge_approval`) を `await invoke` 中に WebView2 が突然全停止する **ネイティブ凍結型**（`blockedMs` 低位・`main thread blocked` 0件）で発生していた。

**根本原因**: webview 側 `@tauri-apps/plugin-log` の `debug()`/`info()` は呼び出しごとに `invoke('plugin:log|log')` の IPC 往復を発生させ、これは Rust 側レベルフィルタに関係なく必ず発生する。ホットパス（AutoApproval 承認 tick・TerminalView resize/teardown 等）が多数発行し pty-output emit と重なると WebView2 の単一 UI スレッドを飽和させ恒久 wedge する。`77475b4` が hook 経路で実証済みの機構で、approval 経路が未対応のまま残っていた。

## 変更

- **`src/utils/log.ts`（新規）**: ロギングゲート。`logDebug`/`logInfo` は非 verbose 時に呼び出し自体をスキップ（IPC ゼロ）。`logWarn`/`logError` は常に fire-and-forget。戻り値が非 Promise でも壊れないよう `Promise.resolve` でラップ。
- ホットパスの `(await) debug/info/error` を `logXxx` に置換し `await` を除去: `autoApproval.ts` / `useAppAutoApproval.ts` / `SubWindowApp.vue` / `TerminalView.vue` / `useTerminalReparenting.ts` / `useUpdater.ts` / `App.vue`。
- **`main.ts`**: `attachConsole()` を `import.meta.env.DEV` 限定に。
- **Debug Mode 連動**: `verbose = isDev || settings.debugMode`。`useSettings` で `settings.debugMode` を watch し `setVerboseLogging` に同期。dev は常時 verbose、本番は既存の設定タブ「Debug Mode」トグルで webview 詳細ログを復帰可能。
- `autoApproval.test.ts`: plugin-log mock に `info/warn/error`（`Promise.resolve` 返却）を追加。

ロジック変更なし（ログ side-effect の除去とゲーティングのみ）。自動復旧（`20cfc4f` で無効化）は据え置き。Rust 側ログレベル制御も変更なし。

## 動作

| ビルド | Debug Mode | webview debug/info | freeze 対策 |
|---|---|---|---|
| dev | — | 常に出力 | 無効（従来通り） |
| 本番 | OFF（既定） | 出力なし（IPC ゼロ） | **有効** |
| 本番 | ON | 出力（調査用） | 一時無効 |

## 検証

- `cargo check`: ✅ 通過。
- bug-review: Critical/Warning 0、Suggestion 2件（うち 1 件=非 Promise 耐性 を修正済み）。
- ⚠️ `pnpm test` / `pnpm build`: X: ドライブの pnpm install 環境問題で未実行。**正常環境での実行をお願いします。**
- ⚠️ 手動再現テスト（Windows）: AI エージェント端末 4〜5 個ビジー稼働 + AutoApproval ON で承認プロンプトを連続発生させ、`[heartbeat] webview unresponsive` が出ず pong/RTT が低位安定することを修正前ログ（`12:21` の停止）と対比で確認してください。

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)