### PR TITLE
fix(app): 未定義の debug() を logDebug() に修正してリリースCIを復旧

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1042,10 +1042,10 @@ onMounted(async () => {
         const entry = settings.value.worktrees.find((w) => w.id === rt.id);
         if (entry) entry.description = trimmed;
         scheduleSave();
-        debug(`[Description] set for worktree=${worktree}: ${trimmed}`);
+        logDebug(`[Description] set for worktree=${worktree}: ${trimmed}`);
       }
     } catch (e) {
-      debug(`[Description] generate failed for worktree=${worktree}: ${e}`);
+      logDebug(`[Description] generate failed for worktree=${worktree}: ${e}`);
     }
   });
 


### PR DESCRIPTION
## 概要
リリースワークフロー（[run 27222844221](https://github.com/ishida-supsys/oretachi/actions/runs/27222844221), タグ 0.21.0）が **全プラットフォーム（windows / macos x86_64 / macos aarch64）でビルド失敗**していた問題を修正します。

## 原因
`beforeBuildCommand` の `vue-tsc --noEmit` が以下の型エラーで停止していました:

```
src/App.vue(1045,9): error TS2304: Cannot find name 'debug'.
src/App.vue(1048,7): error TS2304: Cannot find name 'debug'.
```

`set-worktree-description` リスナー内の2箇所で、App.vue にインポートされていない `debug()` を呼んでいました。`debug` は `@tauri-apps/plugin-log` の関数名で、App.vue はローカルラッパー `logDebug`（`./utils/log`）を import して全体で使用しているため、タイポと判断しました。

## 修正
当該2箇所を `debug(` → `logDebug(` に置換。追加 import 不要（`logDebug` は import 済み）。

## 検証
- `pnpm run type-check`（= `vue-tsc --noEmit`）がエラー0件で通過することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)