### PR TITLE
fix(ci): クロスコンパイル時の target triple でサイドカーをビルド

### DIFF
--- a/scripts/build-sidecar.mjs
+++ b/scripts/build-sidecar.mjs
@@ -25,18 +25,24 @@ function hostTargetTriple() {
   return match[1].trim();
 }
 
-const triple = hostTargetTriple();
+// ビルド対象の target triple を解決する。
+// `tauri build [--target <triple>]` 実行時、Tauri は beforeBuildCommand に
+// TAURI_ENV_TARGET_TRIPLE（CLI がビルド中の triple）を渡す。これを最優先で尊重し、
+// クロスコンパイル時にも要求される triple のサイドカーを生成する。
+// 未設定時（例: pnpm install の prepare フック）は host triple にフォールバックする。
+const envTriple = process.env.TAURI_ENV_TARGET_TRIPLE?.trim();
+const triple = envTriple || hostTargetTriple();
 const isWindows = triple.includes("windows");
 const exeExt = isWindows ? ".exe" : "";
 
 console.log(`  building oretachi-notify sidecar for ${triple} ...`);
 execFileSync(
   "cargo",
-  ["build", "--release", "-p", "oretachi-notify"],
+  ["build", "--release", "-p", "oretachi-notify", "--target", triple],
   { cwd: srcTauri, stdio: "inherit" }
 );
 
-const builtPath = path.join(srcTauri, "target", "release", `oretachi-notify${exeExt}`);
+const builtPath = path.join(srcTauri, "target", triple, "release", `oretachi-notify${exeExt}`);
 if (!fs.existsSync(builtPath)) {
   throw new Error(`Built sidecar not found at ${builtPath}`);
 }


### PR DESCRIPTION
## 背景

リリース 0.21.1 の GitHub Actions（[run 27223607728](https://github.com/ishida-supsys/oretachi/actions/runs/27223607728/job/80384750085)）で `build (macos-latest, --target x86_64-apple-darwin)` ジョブが失敗していた:

```
resource path `binaries/oretachi-notify-x86_64-apple-darwin` doesn't exist
Error failed to build app
```

## 根本原因

`scripts/build-sidecar.mjs` は **host の** target triple（`rustc -vV` の `host:`）でしかサイドカー `oretachi-notify` をビルドしておらず、`tauri build --target <triple>` のクロスコンパイル先を無視していた。

GitHub の `macos-latest` ランナーは Apple Silicon（host = `aarch64-apple-darwin`）のため:

| ジョブ | host | target | 生成 | 結果 |
|---|---|---|---|---|
| windows-latest | x86_64-pc-windows-msvc | (host) | `...-x86_64-pc-windows-msvc.exe` | ✅ |
| macOS aarch64 | aarch64-apple-darwin | aarch64-apple-darwin | `...-aarch64-apple-darwin` | ✅ |
| macOS x86_64 | aarch64-apple-darwin | **x86_64**-apple-darwin | `...-**aarch64**-apple-darwin` | ❌ |

host == target のジョブはたまたま成功し、クロスコンパイルする x86_64 ジョブだけが要求バイナリを生成できず失敗していた。

## 修正

`scripts/build-sidecar.mjs` を、Tauri が `beforeBuildCommand` に渡す環境変数 `TAURI_ENV_TARGET_TRIPLE`（CLI がビルド中の triple）を優先して解決するよう変更:

- triple の解決: `TAURI_ENV_TARGET_TRIPLE` 優先 → 未設定時（`pnpm install` の prepare 等）は host triple にフォールバック
- 常に `cargo build --release -p oretachi-notify --target <triple>` でビルドし、`target/<triple>/release/` から参照

CI ワークフロー（`release.yml`）の変更は不要（env は `beforeBuildCommand` 経由で自動的に渡る）。x86_64-apple-darwin の rustup ターゲットは既にインストール済み。

## 検証

ローカル（Windows）で両経路を確認済み:
- host フォールバック: `pnpm build:sidecar` → `oretachi-notify-x86_64-pc-windows-msvc.exe` 生成 ✅
- env 指定: `TAURI_ENV_TARGET_TRIPLE=x86_64-pc-windows-msvc pnpm build:sidecar` → 同バイナリ生成 ✅

本命の macOS x86_64 クロスビルドはマージ後の CI で確認。

> 注: 失敗した 0.21.1 の run は同じコミットを指すため、実際に macOS x86_64 のリリース成果物を出すにはマージ後に新しいパッチタグが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)