### PR TITLE
fix(terminal): PTY 書き込みバッファのオクルージョン時無制限増大を解消 (#66)

### DIFF
--- a/src/composables/usePtyWriteBatcher.test.ts
+++ b/src/composables/usePtyWriteBatcher.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Terminal } from "@xterm/xterm";
+
+import { usePtyWriteBatcher } from "./usePtyWriteBatcher";
+
+// vitest 環境は node のため requestAnimationFrame 等は未定義。
+// テストごとに stub し、「rAF を発火させない=オクルージョン」状況を再現する。
+
+const FALLBACK_FLUSH_MS = 200;
+const HIGH_WATERMARK_BYTES = 8 * 1024 * 1024;
+
+function makeTerminal(): { terminal: Terminal; write: ReturnType<typeof vi.fn> } {
+  const write = vi.fn();
+  // 必要なメソッドのみのスタブ。型は Terminal として扱う。
+  const terminal = { write } as unknown as Terminal;
+  return { terminal, write };
+}
+
+/** rAF を「id を返すが never fire(オクルージョン)」にする。 */
+function stubRafNeverFire() {
+  let nextId = 1;
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn(() => nextId++)
+  );
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+}
+
+/** rAF を「登録時に即座に同期発火(前面)」にする。 */
+function stubRafImmediate() {
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    })
+  );
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("usePtyWriteBatcher", () => {
+  describe("ケースA: フォールバック排出 (rAF停止・setTimeout が排出)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      stubRafNeverFire();
+    });
+
+    it("rAF が発火しなくても FALLBACK_FLUSH_MS 後に 1回マージして write される", () => {
+      const { terminal, write } = makeTerminal();
+      const { enqueue } = usePtyWriteBatcher(() => terminal);
+
+      enqueue(new Uint8Array([1, 2]));
+      enqueue(new Uint8Array([3]));
+      enqueue(new Uint8Array([4, 5]));
+
+      // rAF は never fire。タイマ未経過では write されない。
+      expect(write).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(FALLBACK_FLUSH_MS);
+
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(write.mock.calls[0][0]).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    });
+
+    it("flush 後に新たな enqueue があれば次のタイマで再度排出される", () => {
+      const { terminal, write } = makeTerminal();
+      const { enqueue } = usePtyWriteBatcher(() => terminal);
+
+      enqueue(new Uint8Array([1]));
+      vi.advanceTimersByTime(FALLBACK_FLUSH_MS);
+      expect(write).toHaveBeenCalledTimes(1);
+
+      enqueue(new Uint8Array([2]));
+      vi.advanceTimersByTime(FALLBACK_FLUSH_MS);
+      expect(write).toHaveBeenCalledTimes(2);
+      expect(write.mock.calls[1][0]).toEqual(new Uint8Array([2]));
+    });
+  });
+
+  describe("ケースB: 上限即時排出 (HIGH_WATERMARK 超過)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      stubRafNeverFire();
+    });
+
+    it("合計が HIGH_WATERMARK_BYTES を超えたら、タイマを進めずに即時 write される", () => {
+      const { terminal, write } = makeTerminal();
+      const { enqueue } = usePtyWriteBatcher(() => terminal);
+
+      const half = Math.floor(HIGH_WATERMARK_BYTES / 2) + 1; // 2回で上限超過
+      enqueue(new Uint8Array(half));
+      expect(write).not.toHaveBeenCalled(); // 1回目は上限未満
+
+      enqueue(new Uint8Array(half)); // ここで上限超過 → 同期 flush
+
+      // タイマを一切進めていないことが要点(throttle 非依存の上限保証)。
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(write.mock.calls[0][0].length).toBe(half * 2);
+    });
+
+    it("上限 flush 後はバッファがリセットされ、再蓄積が 0 から始まる", () => {
+      const { terminal, write } = makeTerminal();
+      const { enqueue } = usePtyWriteBatcher(() => terminal);
+
+      enqueue(new Uint8Array(HIGH_WATERMARK_BYTES)); // 単発で上限到達 → 即 flush
+      expect(write).toHaveBeenCalledTimes(1);
+
+      // リセットされていれば、小チャンクは上限に達せずタイマ排出になる。
+      enqueue(new Uint8Array([9]));
+      expect(write).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(FALLBACK_FLUSH_MS);
+      expect(write).toHaveBeenCalledTimes(2);
+      expect(write.mock.calls[1][0]).toEqual(new Uint8Array([9]));
+    });
+  });
+
+  describe("ケースC: 前面・回帰 (rAF 即時発火)", () => {
+    beforeEach(() => {
+      stubRafImmediate();
+    });
+
+    it("rAF が即発火する環境では 1 enqueue ごとに従来どおり write される", () => {
+      const { terminal, write } = makeTerminal();
+      const { enqueue } = usePtyWriteBatcher(() => terminal);
+
+      enqueue(new Uint8Array([1, 2, 3]));
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(write.mock.calls[0][0]).toEqual(new Uint8Array([1, 2, 3]));
+    });
+  });
+
+  describe("dispose", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      stubRafNeverFire();
+    });
+
+    it("保留中チャンクを flush し、スケジュールを解除する", () => {
+      const { terminal, write } = makeTerminal();
+      const { enqueue, dispose } = usePtyWriteBatcher(() => terminal);
+
+      enqueue(new Uint8Array([7, 8]));
+      dispose();
+
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(write.mock.calls[0][0]).toEqual(new Uint8Array([7, 8]));
+
+      // dispose 後にタイマが進んでも追加 write は起きない(スケジュール解除済み)。
+      vi.advanceTimersByTime(FALLBACK_FLUSH_MS * 2);
+      expect(write).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/composables/usePtyWriteBatcher.ts
+++ b/src/composables/usePtyWriteBatcher.ts
@@ -1,24 +1,62 @@
 import type { Terminal } from "@xterm/xterm";
 
+/** rAF が停止(オクルージョン)している場合のフォールバック排出間隔(ms)。 */
+const FALLBACK_FLUSH_MS = 200;
 /**
- * PTY 出力データを requestAnimationFrame ベースでバッチ化し、
- * 1フレームに1回だけ terminal.write() を呼ぶ。
+ * 蓄積バイトのハード上限。これを超えたら rAF/タイマを待たず即時 flush する。
+ * Rust 側 `pty_manager.rs` の `MAX_PENDING_BYTES`(8MB)と揃える。
+ */
+const HIGH_WATERMARK_BYTES = 8 * 1024 * 1024;
+
+/**
+ * PTY 出力データをバッチ化し、まとめて terminal.write() を呼ぶ。
+ *
+ * 通常(前面表示)は requestAnimationFrame で 1フレームに 1回 flush する。
+ * ただし WebView2/Chromium はウィンドウのオクルージョン(最小化・完全被覆・
+ * 別仮想デスクトップ表示)時に rAF を停止する一方、`pty-output` IPC は届き続けるため、
+ * rAF 一本に依存するとバッファが無制限に増大し、復帰時の巨大 write でメインスレッドが
+ * 恒久ブロックする。これを防ぐため次の二段のフォールバックを併用する:
+ *   1. setTimeout によるフォールバック排出(rAF が来なくても排出する)。
+ *   2. HIGH_WATERMARK_BYTES 超過時の同期即時 flush(タイマ throttle に依存せず上限を保証)。
  */
 export function usePtyWriteBatcher(getTerminal: () => Terminal | null) {
   let chunks: Uint8Array[] = [];
   let totalLength = 0;
   let rafId: number | null = null;
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  function clearScheduled(): void {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+  }
 
   function enqueue(data: Uint8Array): void {
     chunks.push(data);
     totalLength += data.length;
+    // 上限超過時はタイマ throttle 非依存でその場排出し、ヒープを上限内に固定する。
+    if (totalLength >= HIGH_WATERMARK_BYTES) {
+      flush();
+      return;
+    }
+    // 前面では rAF が先に発火して滑らかにバッチ。オクルージョン時は rAF が来ないため
+    // setTimeout 側が排出する(両方張っておき、flush 時に両方 cancel)。
     if (rafId === null) {
       rafId = requestAnimationFrame(flush);
+    }
+    if (timerId === null) {
+      timerId = setTimeout(flush, FALLBACK_FLUSH_MS);
     }
   }
 
   function flush(): void {
-    rafId = null;
+    // rAF/タイマの二重発火を防止(自分自身を起動した側の cancel は no-op で安全)。
+    clearScheduled();
     const terminal = getTerminal();
     if (!terminal || chunks.length === 0) {
       chunks = [];
@@ -43,10 +81,7 @@ export function usePtyWriteBatcher(getTerminal: () => Terminal | null) {
   }
 
   function dispose(): void {
-    if (rafId !== null) {
-      cancelAnimationFrame(rafId);
-      rafId = null;
-    }
+    clearScheduled();
     flush();
   }
 


### PR DESCRIPTION
## 概要

issue #66 の恒久ハング根本対応。PTY 書き込みバッチャ `usePtyWriteBatcher` のオクルージョン時バッファ無制限増大を解消する。

Closes #66

## 根本原因（机上検証済み）

`src/composables/usePtyWriteBatcher.ts` は `requestAnimationFrame` 一本でのみ `flush()` しており、(1) バイト上限が無く (2) rAF 以外の排出経路が無かった。

WebView2/Chromium はウィンドウのオクルージョン（別仮想デスクトップ表示・最小化・完全被覆）時に rAF を停止する。一方 Tauri の `pty-output` IPC はオクルージョン中も JS に届き続ける（`usePtyDispatcher.ts` → handler → `TerminalView.vue` の `batcher.enqueue`）。結果 `chunks` が無制限に増大し、デスクトップ復帰時に巨大 `terminal.write()` 一発で UI スレッドを恒久ブロック（またはヒープ枯渇）してフリーズしていた。

Rust 側 `MAX_PENDING_BYTES=8MB`（`pty_manager.rs`）は Rust の `output_pending` にしか効かず、フロント `chunks` が唯一の無制限リンクだった。「別仮想デスクトップ表示中に多発、前面では稀」というユーザ観察とも一致する。

## 変更内容

排出を「rAF 一本足」→「**rAF + setTimeout フォールバック + ハイウォーターマーク即時排出**」の二段構えに拡張（既存の merge/write ロジックは温存）。

- **setTimeout(200ms) フォールバック**: rAF が来なくても排出。前面では rAF が先に発火して滑らかにバッチ（従来通り）、オクルージョン時は setTimeout 側が排出。
- **HIGH_WATERMARK_BYTES(8MB) 超過時の同期即時 flush**: `enqueue` 内でその場 flush。`enqueue` は IPC 駆動でオクルージョン中も呼ばれ続けるため、Chromium の hidden タイマ throttle（最小1s〜最大1/分）と無関係にヒープを 8MB で固定できる（本質的な上限保証）。Rust 側 pending 上限と一致。

バイトのドロップ（VT エスケープ列破壊の恐れ）は行わない。前面時は 1フレーム1 write で回帰なし。共通経路のため main / サブ両ウィンドウに同時に効く。

## 対象外

- 無効化中の自動復旧（webview reload / recreate, `lib.rs` heartbeat）は無効のまま（根本原因を断てば不要・復旧自体にクラッシュ実績あり）。診断 heartbeat ログは維持。
- Rust 側 `pty_manager.rs` のコアレッシング/backpressure は変更しない（既に妥当）。

## 検証

- ✅ `pnpm test`: 17/17 passed（新規 `usePtyWriteBatcher.test.ts` のフォールバック排出 / 上限即時排出 / 前面回帰 / dispose を含む）
- ✅ `pnpm type-check`（vue-tsc）通過
- ✅ `/bug-review` 実行: Critical なし

### 手動検証（実機・要確認）

1. `pnpm tauri dev` でターミナルに連続大量出力を流す
2. oretachi を別の Windows 仮想デスクトップに置いたまま数分放置
3. デスクトップを戻して即操作できる（フリーズしない）ことを確認
4. 放置中のメモリが概ね一定（8MB 上限内）で青天井に増えないことを確認
5. 前面での表示・スクロール・入力が従来同様に滑らかであること（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
