### PR TITLE
feat(home): description をクリック開閉 + ワークツリー毎に保存

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -48,6 +48,8 @@ pub struct WorktreeEntry {
     pub auto_approval_prompt: Option<String>,
     #[serde(default, rename = "description")]
     pub description: Option<String>,
+    #[serde(default, rename = "descriptionOpen")]
+    pub description_open: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/task_executor.rs
+++ b/src-tauri/src/task_executor.rs
@@ -361,6 +361,7 @@ mod tests {
             auto_approval: None,
             auto_approval_prompt: None,
             description: None,
+            description_open: None,
         }
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -103,6 +103,19 @@ const notificationCounts = computed(() => {
 // ワークツリーごとのアーティファクト数
 const artifactCounts = reactive(new Map<string, number>());
 
+// ホームカードの description 開閉状態（ワークツリー毎・settings.json に永続化）
+const descriptionOpenMap = reactive(new Map<string, boolean>());
+
+function onToggleDescription(worktreeId: string) {
+  const cur = descriptionOpenMap.get(worktreeId) ?? false;
+  descriptionOpenMap.set(worktreeId, !cur);
+  const entry = settings.value.worktrees.find((w) => w.id === worktreeId);
+  if (entry) {
+    entry.descriptionOpen = !cur ? true : undefined; // false は省略して JSON をクリーンに保つ
+    scheduleSave();
+  }
+}
+
 async function refreshArtifactCount(worktreeId: string) {
   try {
     const list = await invoke<unknown[]>("list_artifacts", { worktreeId });
@@ -989,6 +1002,11 @@ onMounted(async () => {
   loadWorktreesFromSettings();
   restoreAutoApprovalPrompts();
 
+  // 保存された description 開閉状態を復元
+  for (const wt of settings.value.worktrees) {
+    if (wt.descriptionOpen === true) descriptionOpenMap.set(wt.id, true);
+  }
+
   // 保存されたサブウィンドウを復元
   const savedDetachedIds = settings.value.detachedWorktreeIds ?? [];
 
@@ -1543,6 +1561,7 @@ onMounted(async () => {
         :auto-approvals="autoApprovalMap"
         :ai-judging-worktrees="aiJudgingWorktrees"
         :card-tooltips="worktreeCardTooltips"
+        :description-opens="descriptionOpenMap"
         @select-terminal="switchToTerminal"
         @add-worktree="onShowAddWorktreeDialog"
         @remove-worktree="onRemoveWorktree"
@@ -1558,6 +1577,7 @@ onMounted(async () => {
         @cancel-ai-judging="onCancelAiJudging"
         @cancel-remove="cancelWorktreeRemove"
         @duplicate-worktree="onDuplicateWorktree"
+        @toggle-description="onToggleDescription"
         @reorder-worktrees="reorderWorktree"
         @commit-reorder="saveWorktreeOrder"
         @cancel-reorder="restoreWorktreeOrder"

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -170,7 +170,11 @@ const props = defineProps<{
   autoApprovals: Map<string, boolean>;
   aiJudgingWorktrees: Set<string>;
   cardTooltips?: Map<string, string | undefined>;
+  descriptionOpens?: Map<string, boolean>;
 }>();
+
+// json の開閉状態を一時的に無視して全カードの description を開く（セッション限り・非永続）
+const showAllDescriptions = ref(false);
 
 const emit = defineEmits<{
   selectTerminal: [terminalId: number];
@@ -191,6 +195,7 @@ const emit = defineEmits<{
   cancelAiJudging: [worktreeId: string];
   cancelRemove: [worktreeId: string];
   duplicateWorktree: [worktreeId: string];
+  toggleDescription: [worktreeId: string];
   addTask: [];
   removeTask: [taskId: string];
   rerunTask: [taskId: string];
@@ -295,6 +300,14 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
       </select>
       <div class="header-actions">
         <template v-if="panelMode === 'worktree'">
+          <button
+            class="btn-icon-header"
+            :class="{ 'btn-active': showAllDescriptions }"
+            :title="t('toggleShowAllDescriptions')"
+            @click="showAllDescriptions = !showAllDescriptions"
+          >
+            <i :class="showAllDescriptions ? 'pi pi-eye' : 'pi pi-eye-slash'"></i>
+          </button>
           <button class="btn-icon-header" :title="t('focusAllSubWindows')" @click="emit('focusAllSubWindows')">
             <i class="pi pi-window-maximize"></i>
           </button>
@@ -374,6 +387,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
               :auto-approval="autoApprovals.get(worktree.id) ?? false"
               :ai-judging="aiJudgingWorktrees.has(worktree.id)"
               :tooltip="cardTooltips?.get(worktree.id)"
+              :description-open="showAllDescriptions || (descriptionOpens?.get(worktree.id) ?? false)"
               @drag-start="onCardDragStart"
               @drag-end="onDragEnd"
               @select-terminal="emit('selectTerminal', $event)"
@@ -389,6 +403,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
               @cancel-ai-judging="emit('cancelAiJudging', $event)"
               @cancel-remove="emit('cancelRemove', $event)"
               @duplicate-worktree="emit('duplicateWorktree', $event)"
+              @toggle-description="emit('toggleDescription', $event)"
             />
           </div>
         </div>
@@ -524,6 +539,11 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
   background: #313244;
 }
 
+.btn-icon-header.btn-active {
+  color: #cba6f7;
+  background: #313244;
+}
+
 /* ワークツリーパネル（マソンリーレイアウト） */
 .worktree-list {
   display: flex;
@@ -620,6 +640,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
   "en": {
     "worktreeTitle": "Worktrees",
     "worktreeEmpty": "No worktrees. Click the + button to create one.",
+    "toggleShowAllDescriptions": "Show all descriptions",
     "focusAllSubWindows": "Bring all sub windows",
     "addWorktreeButton": "Add worktree",
     "taskTitle": "Tasks",
@@ -634,6 +655,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
   "ja": {
     "worktreeTitle": "ワークツリー",
     "worktreeEmpty": "ワークツリーがありません。右上の + ボタンで作成してください。",
+    "toggleShowAllDescriptions": "すべての説明を表示",
     "focusAllSubWindows": "すべてのサブウィンドウを呼び出す",
     "addWorktreeButton": "ワークツリー追加",
     "taskTitle": "タスク",

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -176,6 +176,12 @@ const props = defineProps<{
 // json の開閉状態を一時的に無視して全カードの description を開く（セッション限り・非永続）
 const showAllDescriptions = ref(false);
 
+// 全表示中はカードが強制 open のため、クリックでの個別状態の書き換えを抑止する
+function onCardToggleDescription(worktreeId: string) {
+  if (showAllDescriptions.value) return;
+  emit("toggleDescription", worktreeId);
+}
+
 const emit = defineEmits<{
   selectTerminal: [terminalId: number];
   reorderWorktrees: [fromId: string, toId: string];
@@ -403,7 +409,7 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
               @cancel-ai-judging="emit('cancelAiJudging', $event)"
               @cancel-remove="emit('cancelRemove', $event)"
               @duplicate-worktree="emit('duplicateWorktree', $event)"
-              @toggle-description="emit('toggleDescription', $event)"
+              @toggle-description="onCardToggleDescription"
             />
           </div>
         </div>

--- a/src/components/WorktreeCard.vue
+++ b/src/components/WorktreeCard.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   autoApproval?: boolean;
   aiJudging?: boolean;
   tooltip?: string;
+  descriptionOpen?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -39,7 +40,15 @@ const emit = defineEmits<{
   cancelAiJudging: [worktreeId: string];
   openArtifacts: [worktreeId: string];
   duplicateWorktree: [worktreeId: string];
+  toggleDescription: [worktreeId: string];
 }>();
+
+// ボタン類・ターミナルサムネイル領域以外のクリックで description を開閉する
+function onCardClick(event: MouseEvent) {
+  const target = event.target as HTMLElement;
+  if (target.closest("button, .terminals-row")) return;
+  emit("toggleDescription", props.worktree.id);
+}
 
 const menuRef = ref<InstanceType<typeof Popover> | null>(null);
 
@@ -94,7 +103,7 @@ const terminalList = computed(() =>
 </script>
 
 <template>
-  <div class="worktree-card" :class="{ 'card-detached': detached, 'card-notified': notificationCount && notificationCount > 0 }">
+  <div class="worktree-card" :class="{ 'card-detached': detached, 'card-notified': notificationCount && notificationCount > 0 }" @click="onCardClick">
     <Badge v-if="notificationCount && notificationCount > 0" :value="notificationCount" severity="danger" class="notification-badge" />
     <div v-if="hotkeyChar || (artifactCount && artifactCount > 0)" class="top-left-badges">
       <div v-if="hotkeyChar" class="hotkey-badge">Alt+{{ hotkeyChar }}</div>
@@ -145,8 +154,8 @@ const terminalList = computed(() =>
       </div>
     </div>
 
-    <!-- ホバーでヘッダー直下に開く description エリア (description優先・なければタスク一覧) -->
-    <div v-if="tooltip" class="card-desc-wrap">
+    <!-- クリックでヘッダー直下に開く description エリア (description優先・なければタスク一覧) -->
+    <div v-if="tooltip" class="card-desc-wrap" :class="{ 'desc-open': descriptionOpen }">
       <div class="card-desc">
         <div class="card-desc-inner" v-html="tooltip" />
       </div>
@@ -373,14 +382,14 @@ const terminalList = computed(() =>
   padding: 4px 0;
 }
 
-/* ホバーで開く description エリア: grid-template-rows 0fr→1fr で高さauto をアニメーション */
+/* クリックで開く description エリア: grid-template-rows 0fr→1fr で高さauto をアニメーション */
 .card-desc-wrap {
   display: grid;
   grid-template-rows: 0fr;
   transition: grid-template-rows 0.25s ease;
 }
 
-.worktree-card:hover .card-desc-wrap {
+.card-desc-wrap.desc-open {
   grid-template-rows: 1fr;
 }
 

--- a/src/components/WorktreeCard.vue
+++ b/src/components/WorktreeCard.vue
@@ -43,8 +43,29 @@ const emit = defineEmits<{
   toggleDescription: [worktreeId: string];
 }>();
 
+// ドラッグ（カード名のD&D並べ替え）直後に発火しうる click を1回だけ無視するためのフラグ。
+// Chromium は通常 drag 後に click を出さないが、ブラウザ差異に備えてガードする。
+let suppressNextClick = false;
+
+function onNameDragStart(event: DragEvent) {
+  suppressNextClick = true;
+  emit("dragStart", props.worktree.id, event);
+}
+
+function onNameDragEnd() {
+  emit("dragEnd");
+  // click が来なかった場合にフラグが残り続けないよう、次のタスクで解除する
+  setTimeout(() => {
+    suppressNextClick = false;
+  }, 0);
+}
+
 // ボタン類・ターミナルサムネイル領域以外のクリックで description を開閉する
 function onCardClick(event: MouseEvent) {
+  if (suppressNextClick) {
+    suppressNextClick = false;
+    return;
+  }
   const target = event.target as HTMLElement;
   if (target.closest("button, .terminals-row")) return;
   emit("toggleDescription", props.worktree.id);
@@ -117,8 +138,8 @@ const terminalList = computed(() =>
         <span
           class="card-name"
           draggable="true"
-          @dragstart.stop="$emit('dragStart', worktree.id, $event)"
-          @dragend.stop="$emit('dragEnd')"
+          @dragstart.stop="onNameDragStart($event)"
+          @dragend.stop="onNameDragEnd()"
         >{{ worktree.name }}</span>
         <span class="card-branch">{{ worktree.branchName }}</span>
         <span v-if="detached" class="card-detached-badge">{{ t('subWindowBadge') }}</span>

--- a/src/components/WorktreeCard.vue
+++ b/src/components/WorktreeCard.vue
@@ -68,6 +68,8 @@ function onCardClick(event: MouseEvent) {
   }
   const target = event.target as HTMLElement;
   if (target.closest("button, .terminals-row")) return;
+  // 表示する内容（description / タスク一覧）が無いカードはトグル対象外（無意味な永続化を防ぐ）
+  if (!props.tooltip) return;
   emit("toggleDescription", props.worktree.id);
 }
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -26,6 +26,7 @@ export interface WorktreeEntry {
   autoApproval?: boolean;
   autoApprovalPrompt?: string;
   description?: string; // AIが自動生成する説明（ExitPlanMode hookでプランを要約してセット）
+  descriptionOpen?: boolean; // ホームカードの description 開閉状態（ワークツリー毎）
 }
 
 export interface TerminalSettings {


### PR DESCRIPTION
@
## 概要
ホーム画面のワークツリーカードの description 表示仕様を変更しました。

1. **マウスオーバー開閉を廃止**し、カードの「ボタン・ターミナル領域以外」をクリックして description を開閉するように変更
2. 開閉状態を **ワークツリー毎に `settings.json` へ永続化**（`WorktreeEntry.descriptionOpen`）
3. json 設定を**一時的に無視して全カードを開くトグルアイコン**を「すべてのサブウィンドウ呼び出し」ボタンの左に設置（セッション限り・非永続）

## 変更ファイル
- `src-tauri/src/settings.rs` — `WorktreeEntry` に `description_open: Option<bool>` 追加
- `src-tauri/src/task_executor.rs` — テストヘルパーに `description_open: None`
- `src/types/settings.ts` — `descriptionOpen?: boolean`
- `src/App.vue` — `descriptionOpenMap`(reactive Map)・`onToggleDescription`・onMounted での復元・HomeView 配線
- `src/components/HomeView.vue` — `descriptionOpens` prop / `toggleDescription` emit / `showAllDescriptions` トグル / i18n / CSS
- `src/components/WorktreeCard.vue` — クリック開閉ハンドラ・クラス駆動 CSS・hover 削除

## バグレビュー対応
2回のバグレビューで挙がった指摘を反映済み:
- 全表示 ON 中はカードクリックでの開閉状態書き換えを抑止
- カード名ドラッグ直後の click による誤トグルを抑止
- 表示内容が無いカードのクリックでは状態を保存しない

## 動作確認の観点
- マウスオーバーで開かないこと / ボタン・ターミナル以外のクリックで開閉すること
- 再起動で各ワークツリーの開閉状態が復元されること
- 全表示トグル ON で全カードが開き、OFF で保存状態へ戻ること（再起動で OFF）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@