### PR TITLE
fix(codereview): ファイルツリーに gitignore 対象ファイルを表示

### DIFF
--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -292,14 +292,104 @@ pub fn delete_branch(repo_path: &str, branch_name: &str, force: bool) -> Result<
 
 // ─── コードレビュー用 Git 関数 ───────────────────────────────────────────────
 
-pub fn list_tracked_files(repo_path: &str) -> Result<Vec<String>, String> {
-    let stdout = run_git_in(repo_path, &["ls-files"])?;
-    let files = stdout
+/// QuickOpen 用のファイル一覧を返す。
+/// 「追跡 + 未追跡（.gitignore 尊重）」に加え、.gitignore に *ファイルとして直接記載* された
+/// ものだけを追加する（例: `.claude/CLAUDE.md`）。`node_modules` 等の ignore ディレクトリ
+/// 配下は含めない。
+pub fn list_quick_open_files(repo_path: &str) -> Result<Vec<String>, String> {
+    let stdout = run_git_in(
+        repo_path,
+        &["ls-files", "--cached", "--others", "--exclude-standard"],
+    )?;
+    let mut files: std::collections::HashSet<String> = stdout
         .lines()
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty())
         .collect();
-    Ok(files)
+
+    // .gitignore に直接記載されたファイル（glob でもディレクトリでもないもの）を追加
+    for entry in read_gitignore(repo_path)? {
+        if entry.contains('*')
+            || entry.contains('?')
+            || entry.contains('[')
+            || entry.ends_with('/')
+            || entry.contains("..")
+        {
+            continue;
+        }
+        let full = std::path::Path::new(repo_path).join(&entry);
+        if full.is_file() {
+            // パス区切りを forward slash に正規化
+            files.insert(entry.replace('\\', "/"));
+        }
+    }
+
+    let mut result: Vec<String> = files.into_iter().collect();
+    result.sort();
+    Ok(result)
+}
+
+/// ディレクトリ内のエントリ（ツリーの遅延読み込み用）
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DirEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+}
+
+/// 指定ディレクトリ直下のエントリを列挙する。`rel_path` が空文字ならリポジトリルート。
+/// `.git` ディレクトリは除外する。ツリーの遅延読み込みに使用。
+pub fn list_dir_entries(repo_path: &str, rel_path: &str) -> Result<Vec<DirEntry>, String> {
+    // パストラバーサル検証（read_file_content と同じ規則）
+    let normalized = std::path::Path::new(rel_path);
+    for component in normalized.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                return Err("パスに '..' は使用できません".to_string());
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return Err("絶対パスは使用できません".to_string());
+            }
+            _ => {}
+        }
+    }
+
+    let dir = std::path::Path::new(repo_path).join(rel_path);
+    let read = std::fs::read_dir(&dir).map_err(|e| format!("ディレクトリ読み込みエラー: {}", e))?;
+
+    let mut entries: Vec<DirEntry> = Vec::new();
+    for item in read {
+        let item = match item {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        let name = item.file_name().to_string_lossy().into_owned();
+        // .git は除外
+        if name == ".git" {
+            continue;
+        }
+        // シンボリックリンクを辿らずに種別を判定
+        let is_dir = match item.file_type() {
+            Ok(ft) => ft.is_dir(),
+            Err(_) => false,
+        };
+        let path = if rel_path.is_empty() {
+            name.clone()
+        } else {
+            format!("{}/{}", rel_path, name)
+        };
+        entries.push(DirEntry { name, path, is_dir });
+    }
+
+    // ディレクトリ優先 → 名前の大文字小文字無視昇順
+    entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+
+    Ok(entries)
 }
 
 pub fn read_file_content(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -317,7 +317,15 @@ async fn git_worktree_restore(repo_path: String, worktree_path: String, branch_n
 
 #[tauri::command]
 async fn git_list_files(repo_path: String) -> Result<Vec<String>, String> {
-    run_git(move || git_worktree::list_tracked_files(&repo_path)).await
+    run_git(move || git_worktree::list_quick_open_files(&repo_path)).await
+}
+
+#[tauri::command]
+async fn list_dir_entries(
+    repo_path: String,
+    rel_path: String,
+) -> Result<Vec<git_worktree::DirEntry>, String> {
+    run_git(move || git_worktree::list_dir_entries(&repo_path, &rel_path)).await
 }
 
 #[tauri::command]
@@ -829,6 +837,7 @@ pub fn run() {
             git_merge_branch,
             git_delete_branch,
             git_list_files,
+            list_dir_entries,
             git_read_file,
             git_get_merge_message,
             git_get_status,

--- a/src/components/codereview/FileTreePanel.vue
+++ b/src/components/codereview/FileTreePanel.vue
@@ -66,8 +66,8 @@ async function loadRoot() {
 }
 
 async function onNodeExpand(node: TreeNode) {
-  // ディレクトリ以外、またはロード済みならスキップ
-  if (node.leaf || Array.isArray(node.children)) return;
+  // ディレクトリ以外、ロード済み、またはロード中ならスキップ（再入による二重フェッチ防止）
+  if (node.leaf || Array.isArray(node.children) || node.loading) return;
   node.loading = true;
   try {
     node.children = await fetchEntries(node.key as string);

--- a/src/components/codereview/FileTreePanel.vue
+++ b/src/components/codereview/FileTreePanel.vue
@@ -11,79 +11,92 @@ const { t } = useI18n();
 const props = defineProps<{ repoPath: string }>();
 const emit = defineEmits<{ (e: "open-file", filePath: string): void }>();
 
+interface DirEntry {
+  name: string;
+  path: string;
+  isDir: boolean;
+}
+
 const nodes = ref<TreeNode[]>([]);
 const selectedKey = ref<Record<string, boolean>>({});
+const expandedKeys = ref<Record<string, boolean>>({});
 const loading = ref(false);
 const error = ref("");
 
-function buildTree(files: string[]): TreeNode[] {
-  const root: Map<string, TreeNode> = new Map();
-
-  for (const file of files) {
-    const parts = file.split("/");
-    let currentMap = root;
-    let currentPath = "";
-
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      currentPath = currentPath ? `${currentPath}/${part}` : part;
-      const isFile = i === parts.length - 1;
-
-      if (!currentMap.has(part)) {
-        const node: TreeNode = {
-          key: currentPath,
-          label: part,
-          icon: isFile ? "pi pi-file" : "pi pi-folder",
-          data: isFile ? currentPath : null,
-          leaf: isFile,
-          children: isFile ? undefined : [],
-        };
-        currentMap.set(part, node);
-      }
-
-      if (!isFile) {
-        const parentNode = currentMap.get(part)!;
-        // 子ノード用 Map を作成（再利用）
-        if (!parentNode._childMap) {
-          (parentNode as any)._childMap = new Map<string, TreeNode>();
-          parentNode.children = [];
-        }
-        currentMap = (parentNode as any)._childMap;
-      }
-    }
+function toNode(entry: DirEntry): TreeNode {
+  if (entry.isDir) {
+    // children を未設定にしておき、展開時に遅延取得する
+    return {
+      key: entry.path,
+      label: entry.name,
+      icon: "pi pi-folder",
+      data: null,
+      leaf: false,
+      loading: false,
+    };
   }
-
-  // Map を配列に変換（ディレクトリ優先ソート）
-  function mapToNodes(map: Map<string, TreeNode>): TreeNode[] {
-    const arr = Array.from(map.values());
-    arr.sort((a, b) => {
-      if (!a.leaf && b.leaf) return -1;
-      if (a.leaf && !b.leaf) return 1;
-      return (a.label ?? "").localeCompare(b.label ?? "");
-    });
-    for (const node of arr) {
-      if (!node.leaf && (node as any)._childMap) {
-        node.children = mapToNodes((node as any)._childMap);
-        delete (node as any)._childMap;
-      }
-    }
-    return arr;
-  }
-
-  return mapToNodes(root);
+  return {
+    key: entry.path,
+    label: entry.name,
+    icon: "pi pi-file",
+    data: entry.path,
+    leaf: true,
+  };
 }
 
-async function loadFiles() {
+async function fetchEntries(relPath: string): Promise<TreeNode[]> {
+  const entries = await invoke<DirEntry[]>("list_dir_entries", {
+    repoPath: props.repoPath,
+    relPath,
+  });
+  return entries.map(toNode);
+}
+
+async function loadRoot() {
   if (!props.repoPath) return;
   loading.value = true;
   error.value = "";
   try {
-    const files = await invoke<string[]>("git_list_files", { repoPath: props.repoPath });
-    nodes.value = buildTree(files);
+    nodes.value = await fetchEntries("");
   } catch (e) {
     error.value = String(e);
   } finally {
     loading.value = false;
+  }
+}
+
+async function onNodeExpand(node: TreeNode) {
+  // ディレクトリ以外、またはロード済みならスキップ
+  if (node.leaf || Array.isArray(node.children)) return;
+  node.loading = true;
+  try {
+    node.children = await fetchEntries(node.key as string);
+  } catch {
+    node.children = [];
+  } finally {
+    node.loading = false;
+  }
+}
+
+function findNode(list: TreeNode[], key: string): TreeNode | null {
+  for (const n of list) {
+    if (n.key === key) return n;
+    if (Array.isArray(n.children)) {
+      const found = findNode(n.children, key);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+// FS 変更時: ルートを再取得し、展開中だったディレクトリを浅い順に再ロードして展開状態を保つ
+async function refresh() {
+  const expanded = Object.keys(expandedKeys.value).filter((k) => expandedKeys.value[k]);
+  await loadRoot();
+  expanded.sort((a, b) => a.split("/").length - b.split("/").length);
+  for (const key of expanded) {
+    const node = findNode(nodes.value, key);
+    if (node && !node.leaf) await onNodeExpand(node);
   }
 }
 
@@ -97,12 +110,12 @@ let unlistenFsChanged: (() => void) | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 onMounted(async () => {
-  loadFiles();
+  loadRoot();
   unlistenFsChanged = await listen("codereview-fs-changed", () => {
     if (debounceTimer !== null) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
       debounceTimer = null;
-      loadFiles();
+      refresh();
     }, 500);
   });
 });
@@ -126,9 +139,12 @@ onUnmounted(() => {
       v-else
       :value="nodes"
       v-model:selection-keys="selectedKey"
+      v-model:expanded-keys="expandedKeys"
       selection-mode="single"
+      loading-mode="icon"
       class="text-sm w-full border-none bg-transparent"
       @node-select="onNodeSelect"
+      @node-expand="onNodeExpand"
     />
   </div>
 </template>


### PR DESCRIPTION
## 概要

CodeReviewer のファイルツリーと QuickOpen で `.claude/CLAUDE.md` など一部のファイルが表示されない問題を修正します。

## 原因

ファイルツリー／QuickOpen はバックエンドの `git_list_files`（`git ls-files`）に依存しており、**追跡ファイルのみ**を返していました。そのため `.gitignore` に登録されたファイルが一覧に出ません。

本リポジトリでは以下が `.gitignore` に直接記載されており表示されませんでした:
- `.claude/CLAUDE.md`
- `.claude/settings.local.json`
- `.gemini/settings.json`

一方 `.claude/settings.json` や `.claude/skills/**` は追跡済みのため表示され、「`.claude` の一部のファイルだけ出ない」という症状になっていました。

## 変更内容

### バックエンド (Rust)
- `git_worktree.rs`
  - `list_tracked_files` を **`list_quick_open_files`** に置換。`git ls-files --cached --others --exclude-standard`（追跡 + 未追跡、gitignore尊重）に加え、`.gitignore` に**ファイルとして直接記載**されたもの（glob／ディレクトリを除く実在ファイル）を追加。
  - **`list_dir_entries`** を新規追加（`DirEntry { name, path, isDir }`）。指定ディレクトリ直下を実ファイルシステムから列挙し、`.git` のみ除外。パストラバーサル検証は `read_file_content` と同じ規則を流用。
- `lib.rs`
  - `git_list_files` の呼び先を `list_quick_open_files` に変更。
  - `list_dir_entries` コマンドを追加・登録。

### フロントエンド (Vue)
- `FileTreePanel.vue`: PrimeVue Tree を**遅延読み込み**へ改修。ルートは `list_dir_entries(repoPath, "")` で取得し、フォルダ展開時 (`@node-expand`) に子を遅延取得。`node_modules` 等も肥大化せずブラウズ可能。FS変更時は展開状態を保ったまま再読込。
- `useQuickOpen.ts`: 変更なし（バックエンドの戻り値拡張で自動的に仕様準拠）。

## 挙動

- **ツリー**: ディスク上の全ファイルを表示（`.git` のみ除外）。gitignore 対象ディレクトリの中身は展開時に遅延取得。
- **QuickOpen**: gitignore 対象ディレクトリ配下は検索対象外。ただし `.gitignore` に直接記載されたファイルは対象内。

## 確認

- ✅ `cargo check` 成功
- ⚠️ `pnpm run type-check` は既知の環境問題（`@volar/typescript` のシンボリックリンク欠落）で実行不可。TS変更は型整合を手動確認済み。
- bug-review 実施済み（Critical/Warning なし、Suggestion 1件を反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)