### PR TITLE
fix(terminal): 同期 PTY コマンドによるメインスレッド恒久ブロックを解消

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,7 +191,14 @@ async fn git_worktree_remove(
     worktree_path: String,
 ) -> Result<(), String> {
     // 削除対象ディレクトリをcwdとして掴んでいるPTYセッションを先にkill
-    let killed = pty_manager.kill_sessions_in_dir(&worktree_path);
+    // (taskkill 最大10秒 + watcher join を含むため tokio ワーカーを塞がないよう spawn_blocking)
+    let killed = {
+        let manager = pty_manager.inner().clone();
+        let dir = worktree_path.clone();
+        tauri::async_runtime::spawn_blocking(move || manager.kill_sessions_in_dir(&dir))
+            .await
+            .map_err(|e| format!("spawn_blocking join error: {}", e))?
+    };
     if killed > 0 {
         // プロセスが完全に終了してファイルハンドルを解放するまで待機
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -1298,14 +1305,12 @@ pub fn run() {
             {
                 use std::sync::Arc;
                 use std::sync::atomic::{AtomicU64, Ordering};
-                use std::time::{Duration, SystemTime, UNIX_EPOCH};
+                use std::time::{Duration, Instant};
 
-                fn epoch_ms() -> u64 {
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64
-                }
+                // SystemTime は NTP 補正等で巻き戻り、blocked の誤検知を生むため、
+                // 単調な Instant 起点の経過 ms で比較する。
+                let watchdog_start = Instant::now();
+                let elapsed_ms = move || watchdog_start.elapsed().as_millis() as u64;
 
                 let main_ack_ms = Arc::new(AtomicU64::new(0));
                 let watchdog_handle = app.handle().clone();
@@ -1314,11 +1319,11 @@ pub fn run() {
                     let mut last_blocked_log_ms: u64 = 0;
                     loop {
                         tokio::time::sleep(Duration::from_secs(15)).await;
-                        let sent = epoch_ms();
+                        let sent = elapsed_ms();
                         let ack = main_ack_ms.clone();
                         if watchdog_handle
                             .run_on_main_thread(move || {
-                                ack.store(epoch_ms(), Ordering::Relaxed);
+                                ack.store(elapsed_ms(), Ordering::Relaxed);
                             })
                             .is_err()
                         {
@@ -1331,16 +1336,16 @@ pub fn run() {
                             if let Some(since) = blocked_since.take() {
                                 log::warn!(
                                     "[main-thread-watchdog] main thread recovered after {}s",
-                                    epoch_ms().saturating_sub(since) / 1000
+                                    elapsed_ms().saturating_sub(since) / 1000
                                 );
                             }
                             last_blocked_log_ms = 0;
                         } else {
                             let since = *blocked_since.get_or_insert(sent);
-                            let blocked_secs = epoch_ms().saturating_sub(since) / 1000;
+                            let blocked_secs = elapsed_ms().saturating_sub(since) / 1000;
                             // 継続ブロック中の連続出力は 55 秒に 1 回へ抑制（初回は即時）
-                            if epoch_ms().saturating_sub(last_blocked_log_ms) >= 55_000 {
-                                last_blocked_log_ms = epoch_ms();
+                            if elapsed_ms().saturating_sub(last_blocked_log_ms) >= 55_000 {
+                                last_blocked_log_ms = elapsed_ms();
                                 log::error!(
                                     "[main-thread-watchdog] tao main thread blocked for {}s (run_on_main_thread closure not executed within 5s)",
                                     blocked_secs

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,33 +51,49 @@ fn artifacts_dir(
 // ─── PTY コマンド ────────────────────────────────────────────────────────────
 
 #[tauri::command]
-fn pty_spawn(
+async fn pty_spawn(
     app_handle: tauri::AppHandle,
-    state: State<PtyManager>,
+    state: State<'_, PtyManager>,
     rows: u16,
     cols: u16,
     shell: Option<String>,
     cwd: Option<String>,
 ) -> Result<u32, String> {
     log::debug!("[Terminal] cmd::pty_spawn rows={} cols={} shell={:?} cwd={:?}", rows, cols, shell, cwd);
-    state.spawn(app_handle, rows, cols, shell, cwd)
+    // ConPTY 生成 + プロセス spawn はブロッキング I/O のため spawn_blocking で実行し、
+    // 同期コマンドとしてメインスレッド (WebView2 UI スレッド) を塞がないようにする。
+    let manager = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || manager.spawn(app_handle, rows, cols, shell, cwd))
+        .await
+        .map_err(|e| format!("spawn_blocking join error: {}", e))?
 }
 
+// pty_write は enqueue のみで非ブロッキング (実 I/O はセッション毎の writer スレッド)。
+// 同期コマンドのままにすることで、メインスレッド上の実行順 = チャネル投入順となり
+// キー入力の順序が保証される (async 化すると並列実行で順序が壊れうる)。
 #[tauri::command]
 fn pty_write(state: State<PtyManager>, session_id: u32, data: Vec<u8>) -> Result<(), String> {
     state.write(session_id, data)
 }
 
 #[tauri::command]
-fn pty_resize(state: State<PtyManager>, session_id: u32, rows: u16, cols: u16) -> Result<(), String> {
+async fn pty_resize(state: State<'_, PtyManager>, session_id: u32, rows: u16, cols: u16) -> Result<(), String> {
     log::debug!("[Terminal] cmd::pty_resize session_id={} rows={} cols={}", session_id, rows, cols);
-    state.resize(session_id, rows, cols)
+    // ConPTY の resize は conhost への RPC でブロックしうるため spawn_blocking で実行
+    let manager = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || manager.resize(session_id, rows, cols))
+        .await
+        .map_err(|e| format!("spawn_blocking join error: {}", e))?
 }
 
 #[tauri::command]
-fn pty_kill(state: State<PtyManager>, session_id: u32) -> Result<(), String> {
+async fn pty_kill(state: State<'_, PtyManager>, session_id: u32) -> Result<(), String> {
     log::info!("[Terminal] cmd::pty_kill session_id={} source=webview-invoke", session_id);
-    state.kill(session_id, "webview-invoke")
+    // taskkill /F /T は数秒かかることがあるため spawn_blocking で実行
+    let manager = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || manager.kill(session_id, "webview-invoke"))
+        .await
+        .map_err(|e| format!("spawn_blocking join error: {}", e))?
 }
 
 #[tauri::command]
@@ -1268,6 +1284,67 @@ pub fn run() {
                                 log::error!("[heartbeat] ping emit failed: {}", e);
                                 ping_pending_since = None;
                                 unresponsive_logged_until_secs = 0;
+                            }
+                        }
+                    }
+                });
+            }
+
+            // メインスレッド watchdog: run_on_main_thread に投げた閉包の実行遅延を計測し、
+            // tao メインスレッド (= WebView2 への emit/IPC 配送を担う UI スレッド) の
+            // ブロックを検出する。heartbeat の「webview unresponsive」だけでは
+            // 「JS 側フリーズ」と「Rust メインスレッドブロック」を区別できないため、
+            // ハング時にどちらかをログから切り分けられるようにする診断機構。
+            {
+                use std::sync::Arc;
+                use std::sync::atomic::{AtomicU64, Ordering};
+                use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+                fn epoch_ms() -> u64 {
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64
+                }
+
+                let main_ack_ms = Arc::new(AtomicU64::new(0));
+                let watchdog_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let mut blocked_since: Option<u64> = None;
+                    let mut last_blocked_log_ms: u64 = 0;
+                    loop {
+                        tokio::time::sleep(Duration::from_secs(15)).await;
+                        let sent = epoch_ms();
+                        let ack = main_ack_ms.clone();
+                        if watchdog_handle
+                            .run_on_main_thread(move || {
+                                ack.store(epoch_ms(), Ordering::Relaxed);
+                            })
+                            .is_err()
+                        {
+                            // アプリ終了中など。次周期で再試行する。
+                            continue;
+                        }
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        let acked = main_ack_ms.load(Ordering::Relaxed);
+                        if acked >= sent {
+                            if let Some(since) = blocked_since.take() {
+                                log::warn!(
+                                    "[main-thread-watchdog] main thread recovered after {}s",
+                                    epoch_ms().saturating_sub(since) / 1000
+                                );
+                            }
+                            last_blocked_log_ms = 0;
+                        } else {
+                            let since = *blocked_since.get_or_insert(sent);
+                            let blocked_secs = epoch_ms().saturating_sub(since) / 1000;
+                            // 継続ブロック中の連続出力は 55 秒に 1 回へ抑制（初回は即時）
+                            if epoch_ms().saturating_sub(last_blocked_log_ms) >= 55_000 {
+                                last_blocked_log_ms = epoch_ms();
+                                log::error!(
+                                    "[main-thread-watchdog] tao main thread blocked for {}s (run_on_main_thread closure not executed within 5s)",
+                                    blocked_secs
+                                );
                             }
                         }
                     }

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1260,7 +1260,7 @@ impl NotifyService {
     }
 
     #[tool(description = "指定 PTY セッションを停止する。oretachi_list_terminals で取得した session_id を渡す。UI のタブは pty-exit イベント経由で自動的に消える")]
-    fn oretachi_kill_terminal(
+    async fn oretachi_kill_terminal(
         &self,
         Parameters(KillTerminalParams { session_id }): Parameters<KillTerminalParams>,
     ) -> Result<CallToolResult, McpError> {
@@ -1271,7 +1271,11 @@ impl NotifyService {
                 None,
             ));
         }
-        pty.kill(session_id, "mcp-kill-terminal")
+        // taskkill 最大10秒 + watcher join を含むため tokio ワーカーを塞がないよう spawn_blocking
+        let manager = pty.inner().clone();
+        tauri::async_runtime::spawn_blocking(move || manager.kill(session_id, "mcp-kill-terminal"))
+            .await
+            .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {}", e), None))?
             .map_err(|e| McpError::internal_error(e, None))?;
         log::info!("[mcp] oretachi_kill_terminal: session_id={}", session_id);
         Ok(CallToolResult::success(vec![Content::text("killed")]))

--- a/src-tauri/src/process_utils.rs
+++ b/src-tauri/src/process_utils.rs
@@ -183,12 +183,49 @@ fn merge_paths(base: &str, additions: &str) -> String {
 }
 
 /// プロセスツリーを強制終了する
+///
+/// Windows: `taskkill /F /T` は通常数秒以内に終わるが、システム高負荷や対象プロセスの
+/// 異常状態では応答しないことがある。`.output()` の無期限待ちは呼び出しスレッドを
+/// 永久ブロックしうるため、タイムアウト付きで待機し、超過時は taskkill 自体を kill する。
 pub fn kill_process_tree(pid: u32) {
     #[cfg(target_os = "windows")]
     {
-        let _ = make_command("taskkill")
+        const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        let child = make_command("taskkill")
             .args(["/F", "/T", "/PID", &pid.to_string()])
-            .output();
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        let mut child = match child {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("[Terminal] kill_process_tree: taskkill spawn failed pid={}: {}", pid, e);
+                return;
+            }
+        };
+        let deadline = std::time::Instant::now() + TIMEOUT;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        log::warn!(
+                            "[Terminal] kill_process_tree: taskkill timed out after {:?} pid={}",
+                            TIMEOUT,
+                            pid
+                        );
+                        // taskkill 自体を kill して待ちを打ち切る。kill 失敗時は wait しない
+                        // （永久ブロック回避のためデタッチ）。
+                        if child.kill().is_ok() {
+                            let _ = child.wait();
+                        }
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(_) => break,
+            }
+        }
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -21,7 +21,8 @@ struct PtySession {
     /// ConPTY の入力パイプへの write は子プロセスが stdin を読まないと無期限に
     /// ブロックしうるため、Tauri コマンド（メインスレッド）からは enqueue のみ行い、
     /// 実 I/O をメインスレッドから隔離する。全 Sender drop で writer スレッドは終了する。
-    input_tx: std::sync::mpsc::Sender<Vec<u8>>,
+    /// 有界 (INPUT_QUEUE_MAX_CHUNKS) で、満杯時の write() は即時エラーになる。
+    input_tx: std::sync::mpsc::SyncSender<Vec<u8>>,
     master: Arc<Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>>,
     child_killer: Box<dyn portable_pty::ChildKiller + Send + Sync>,
     child_pid: Option<u32>,
@@ -64,6 +65,12 @@ const MAX_FLUSH_BYTES: usize = 256 * 1024;
 /// メモリを食い潰すため、上限超過時は最古を捨てる。直近の出力は `output_history`（64KB）が
 /// 別途保持するため MCP の差分読みには影響しない（極端な過負荷時に画面表示の取りこぼしに留まる）。
 const MAX_PENDING_BYTES: usize = 8 * 1024 * 1024;
+
+/// PTY 入力キュー（writer スレッドへの sync_channel）の最大チャンク数。
+/// 子プロセスが stdin を読まない場合の無制限なメモリ蓄積を防ぐ。
+/// 満杯時は write() が即時エラーを返す（旧実装の write ブロックに相当する
+/// バックプレッシャをエラーとして可視化する）。
+const INPUT_QUEUE_MAX_CHUNKS: usize = 1024;
 
 /// セッションの保留バッファを最大 `MAX_FLUSH_BYTES` drain し、base64 エンコードして
 /// `pty-output` を 1 回 emit する。保留が空なら何もしない。
@@ -793,7 +800,7 @@ impl PtyManagerCore {
         // ブロックするのはこのスレッドだけで、enqueue 側 (Tauri コマンド) は影響を受けない。
         // kill 時は session drop で全 Sender が消え recv が Err になりスレッドが終了する。
         // ブロック中でも kill が master を drop → ConPTY 破棄で write がエラーになり解ける。
-        let (input_tx, input_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+        let (input_tx, input_rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(INPUT_QUEUE_MAX_CHUNKS);
         std::thread::spawn(move || {
             let mut writer = writer;
             while let Ok(data) = input_rx.recv() {
@@ -834,7 +841,8 @@ impl PtyManagerCore {
     /// PTY への入力をセッションの writer スレッドへ enqueue する（非ブロッキング）。
     /// 実 I/O は writer スレッドが行うため、本関数は ConPTY 入力パイプの状態に
     /// かかわらず即座に返る。I/O エラーは writer スレッド側でログされ、以降の
-    /// send が "input channel closed" で失敗するようになる。
+    /// send が "input channel closed" で失敗するようになる。キューが満杯
+    /// （子プロセスが stdin を読まず writer がブロック中）の場合も即時エラーを返す。
     pub fn write(&self, session_id: u32, data: Vec<u8>) -> Result<(), String> {
         let tx = {
             let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
@@ -845,8 +853,15 @@ impl PtyManagerCore {
             session.input_tx.clone()
         };
 
-        tx.send(data)
-            .map_err(|_| format!("Write error: input channel closed (session {})", session_id))
+        tx.try_send(data).map_err(|e| match e {
+            std::sync::mpsc::TrySendError::Full(_) => format!(
+                "Write error: input queue full (session {}; child process not reading stdin?)",
+                session_id
+            ),
+            std::sync::mpsc::TrySendError::Disconnected(_) => {
+                format!("Write error: input channel closed (session {})", session_id)
+            }
+        })
     }
 
     /// 指定セッションの出力履歴を取得する。
@@ -954,25 +969,28 @@ impl PtyManagerCore {
                     Ok(mut alive) => *alive = false,
                     Err(e) => *e.into_inner() = false,
                 }
-                // master を取り出して reader に EOF を送る準備。
+                // master の take は sessions ロック解放後に行う。resize() が master ロックを
+                // 保持したまま ConPTY RPC でハングしている場合、ここで master.lock() を待つと
+                // sessions ロックを保持し続け、メインスレッド上の pty_write (sessions.lock())
+                // まで巻き込んでフリーズするため、Arc ごと持ち出してロック外で take する。
                 // session の残りフィールド (input_tx 含む) はこのスコープ末尾で drop され、
                 // input_tx の drop により writer スレッドの recv が解けてスレッドが終了する。
-                let master = session.master.lock().ok().and_then(|mut g| g.take());
-                Some((session.child_pid, session.child_killer, master, session.watcher_handle))
+                Some((session.child_pid, session.child_killer, session.master.clone(), session.watcher_handle))
             } else {
                 None
             }
         }; // ← sessions ロック解放
 
-        if let Some((child_pid, mut child_killer, master, watcher_handle)) = removed {
+        if let Some((child_pid, mut child_killer, master_arc, watcher_handle)) = removed {
             // ロック外でプロセスkill（taskkillが遅くても他の操作をブロックしない）
             if let Some(pid) = child_pid {
                 crate::process_utils::kill_process_tree(pid);
             }
             // child_killer でバックアップ kill（child が監視スレッドに渡済みでも動作）
             let _ = child_killer.kill();
-            // master を drop して ConPTY を破棄し、reader に EOF を送る
+            // master を取り出して drop し ConPTY を破棄、reader に EOF を送る
             // （入力パイプも閉じられ、writer スレッドがブロック中でも write エラーで解ける）
+            let master = master_arc.lock().unwrap_or_else(|e| e.into_inner()).take();
             drop(master);
             // watcher スレッドの終了を待つ（alive=false を検知して必ず終了する）
             if let Some(handle) = watcher_handle {

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -17,7 +17,11 @@ const OUTPUT_HISTORY_BYTES: usize = 65_536;
 const EXITED_SESSION_TTL: Duration = Duration::from_secs(30);
 
 struct PtySession {
-    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    /// PTY 入力の送信キュー。書き込み本体はセッション毎の writer スレッドが行う。
+    /// ConPTY の入力パイプへの write は子プロセスが stdin を読まないと無期限に
+    /// ブロックしうるため、Tauri コマンド（メインスレッド）からは enqueue のみ行い、
+    /// 実 I/O をメインスレッドから隔離する。全 Sender drop で writer スレッドは終了する。
+    input_tx: std::sync::mpsc::Sender<Vec<u8>>,
     master: Arc<Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>>,
     child_killer: Box<dyn portable_pty::ChildKiller + Send + Sync>,
     child_pid: Option<u32>,
@@ -105,10 +109,35 @@ pub struct ReadHistoryResult {
     pub lost_bytes: u64,
 }
 
-pub struct PtyManager {
+/// PtyManager の実体。Drop 時に kill_all を行うため、Clone される外殻 (`PtyManager`)
+/// とは分離し、最後の参照が消えたときだけ一度 Drop が走るようにする。
+pub struct PtyManagerCore {
     sessions: Arc<Mutex<HashMap<u32, PtySession>>>,
     next_id: Mutex<u32>,
     polling_alive: Arc<Mutex<bool>>,
+}
+
+/// Tauri の State として管理する PTY マネージャ。
+/// `Arc` の newtype なので clone が安価で、async コマンドから
+/// `tauri::async_runtime::spawn_blocking` へ move して使える ('static 化)。
+#[derive(Clone)]
+pub struct PtyManager(Arc<PtyManagerCore>);
+
+impl PtyManager {
+    pub fn new() -> Self {
+        PtyManager(Arc::new(PtyManagerCore {
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Mutex::new(1),
+            polling_alive: Arc::new(Mutex::new(true)),
+        }))
+    }
+}
+
+impl std::ops::Deref for PtyManager {
+    type Target = PtyManagerCore;
+    fn deref(&self) -> &PtyManagerCore {
+        &self.0
+    }
 }
 
 #[derive(serde::Serialize, Clone)]
@@ -314,15 +343,7 @@ fn get_claude_session_id_by_pid(pid: u32) -> Option<String> {
     v.get("sessionId")?.as_str().map(|s| s.to_string())
 }
 
-impl PtyManager {
-    pub fn new() -> Self {
-        PtyManager {
-            sessions: Arc::new(Mutex::new(HashMap::new())),
-            next_id: Mutex::new(1),
-            polling_alive: Arc::new(Mutex::new(true)),
-        }
-    }
-
+impl PtyManagerCore {
     /// AIエージェントフラグを明示的にセットする（executeAgentWorktree 用）
     pub fn set_ai_agent(&self, session_id: u32, is_agent: bool) -> Result<(), String> {
         let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
@@ -767,10 +788,28 @@ impl PtyManager {
             let _ = app_handle_reader.emit("pty-exit", PtyExitPayload { session_id });
         });
 
-        let writer = Arc::new(Mutex::new(writer));
+        // writer スレッド: 入力キューを順番に ConPTY 入力パイプへ書き込む。
+        // 子プロセスが stdin を読まずパイプが満杯のときは write_all がブロックするが、
+        // ブロックするのはこのスレッドだけで、enqueue 側 (Tauri コマンド) は影響を受けない。
+        // kill 時は session drop で全 Sender が消え recv が Err になりスレッドが終了する。
+        // ブロック中でも kill が master を drop → ConPTY 破棄で write がエラーになり解ける。
+        let (input_tx, input_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+        std::thread::spawn(move || {
+            let mut writer = writer;
+            while let Ok(data) = input_rx.recv() {
+                if let Err(e) = writer.write_all(&data).and_then(|_| writer.flush()) {
+                    log::warn!(
+                        "[Terminal] writer thread exiting on write error session_id={}: {}",
+                        session_id,
+                        e
+                    );
+                    return;
+                }
+            }
+        });
 
         let session = PtySession {
-            writer,
+            input_tx,
             master: master_arc,
             child_killer,
             child_pid,
@@ -792,21 +831,22 @@ impl PtyManager {
         Ok(session_id)
     }
 
+    /// PTY への入力をセッションの writer スレッドへ enqueue する（非ブロッキング）。
+    /// 実 I/O は writer スレッドが行うため、本関数は ConPTY 入力パイプの状態に
+    /// かかわらず即座に返る。I/O エラーは writer スレッド側でログされ、以降の
+    /// send が "input channel closed" で失敗するようになる。
     pub fn write(&self, session_id: u32, data: Vec<u8>) -> Result<(), String> {
-        // sessions ロックは Arc 取得のみ（瞬時）→ I/O 中は他セッション操作をブロックしない
-        let writer_arc = {
+        let tx = {
             let mut sessions = self.sessions.lock().map_err(|e| format!("lock error: {}", e))?;
             sweep_exited(&mut sessions);
             let session = sessions
                 .get(&session_id)
                 .ok_or_else(|| format!("Session {} not found", session_id))?;
-            session.writer.clone()
+            session.input_tx.clone()
         };
 
-        let mut writer = writer_arc.lock().map_err(|e| format!("writer lock error: {}", e))?;
-        writer.write_all(&data).map_err(|e| format!("Write error: {}", e))?;
-        writer.flush().map_err(|e| format!("Flush error: {}", e))?;
-        Ok(())
+        tx.send(data)
+            .map_err(|_| format!("Write error: input channel closed (session {})", session_id))
     }
 
     /// 指定セッションの出力履歴を取得する。
@@ -914,24 +954,26 @@ impl PtyManager {
                     Ok(mut alive) => *alive = false,
                     Err(e) => *e.into_inner() = false,
                 }
-                // master を取り出して reader に EOF を送る準備
+                // master を取り出して reader に EOF を送る準備。
+                // session の残りフィールド (input_tx 含む) はこのスコープ末尾で drop され、
+                // input_tx の drop により writer スレッドの recv が解けてスレッドが終了する。
                 let master = session.master.lock().ok().and_then(|mut g| g.take());
-                Some((session.child_pid, session.child_killer, master, session.writer, session.watcher_handle))
+                Some((session.child_pid, session.child_killer, master, session.watcher_handle))
             } else {
                 None
             }
         }; // ← sessions ロック解放
 
-        if let Some((child_pid, mut child_killer, master, writer, watcher_handle)) = removed {
+        if let Some((child_pid, mut child_killer, master, watcher_handle)) = removed {
             // ロック外でプロセスkill（taskkillが遅くても他の操作をブロックしない）
             if let Some(pid) = child_pid {
                 crate::process_utils::kill_process_tree(pid);
             }
             // child_killer でバックアップ kill（child が監視スレッドに渡済みでも動作）
             let _ = child_killer.kill();
-            // master / writer を drop して reader に EOF を送る
+            // master を drop して ConPTY を破棄し、reader に EOF を送る
+            // （入力パイプも閉じられ、writer スレッドがブロック中でも write エラーで解ける）
             drop(master);
-            drop(writer);
             // watcher スレッドの終了を待つ（alive=false を検知して必ず終了する）
             if let Some(handle) = watcher_handle {
                 let _ = handle.join();
@@ -1002,7 +1044,7 @@ impl PtyManager {
     }
 }
 
-impl Drop for PtyManager {
+impl Drop for PtyManagerCore {
     fn drop(&mut self) {
         match self.polling_alive.lock() {
             Ok(mut alive) => *alive = false,

--- a/src/composables/usePty.ts
+++ b/src/composables/usePty.ts
@@ -58,28 +58,41 @@ export function usePty() {
     });
   }
 
+  // pty_resize は async コマンド (spawn_blocking) のため、並行 invoke では適用順が
+  // 逆転しうる。直列化して「最後に要求したサイズが最後に適用される」ことを保証する。
+  let resizeChain: Promise<void> = Promise.resolve();
+
   async function resize(rows: number, cols: number): Promise<void> {
     if (sessionId.value === null) return;
-    await invoke("pty_resize", {
-      sessionId: sessionId.value,
-      rows,
-      cols,
+    const next = resizeChain.then(async () => {
+      if (sessionId.value === null) return;
+      await invoke("pty_resize", {
+        sessionId: sessionId.value,
+        rows,
+        cols,
+      });
     });
+    resizeChain = next.catch(() => {});
+    return next;
   }
 
   // kill の invoke 解決前に onUnmounted が再入すると sessionId がまだ非 null のため
-  // pty_kill が二重発行される (ログ上 2 連発が観測されている)。killing フラグで抑止する。
-  let killing = false;
+  // pty_kill が二重発行される (ログ上 2 連発が観測されている)。in-flight の Promise を
+  // 共有することで二重発行を抑止しつつ、再入側も kill 完了を待てるようにする。
+  let killPromise: Promise<void> | null = null;
 
-  async function kill(): Promise<void> {
-    if (sessionId.value === null || killing) return;
-    killing = true;
-    try {
-      await invoke("pty_kill", { sessionId: sessionId.value });
-      await cleanup();
-    } finally {
-      killing = false;
-    }
+  function kill(): Promise<void> {
+    if (sessionId.value === null) return Promise.resolve();
+    if (killPromise) return killPromise;
+    killPromise = (async () => {
+      try {
+        await invoke("pty_kill", { sessionId: sessionId.value });
+        await cleanup();
+      } finally {
+        killPromise = null;
+      }
+    })();
+    return killPromise;
   }
 
   async function attachToSession(
@@ -124,7 +137,10 @@ export function usePty() {
 
   onUnmounted(() => {
     if (!detached.value) {
-      kill();
+      // fire-and-forget: 失敗は unhandled rejection にせずログに残す
+      kill().catch((e) => {
+        console.error("[Terminal] kill on unmount failed:", e);
+      });
     }
   });
 

--- a/src/composables/usePty.ts
+++ b/src/composables/usePty.ts
@@ -67,10 +67,19 @@ export function usePty() {
     });
   }
 
+  // kill の invoke 解決前に onUnmounted が再入すると sessionId がまだ非 null のため
+  // pty_kill が二重発行される (ログ上 2 連発が観測されている)。killing フラグで抑止する。
+  let killing = false;
+
   async function kill(): Promise<void> {
-    if (sessionId.value === null) return;
-    await invoke("pty_kill", { sessionId: sessionId.value });
-    await cleanup();
+    if (sessionId.value === null || killing) return;
+    killing = true;
+    try {
+      await invoke("pty_kill", { sessionId: sessionId.value });
+      await cleanup();
+    } finally {
+      killing = false;
+    }
   }
 
   async function attachToSession(


### PR DESCRIPTION
## 背景

2026-06-10 のメインウィンドウ WebView 恒久フリーズ (`oretachi.log.20260610hng`) を受けた机上検証 (artifact: `webview-hang-desk-verification-20260611`) で、#66 で修正したオクルージョンバッファ問題とは別に、**async でない `#[tauri::command]` が tao メインスレッド (WebView2 への emit/IPC 配送を担う UI スレッド) で実行される**ことに起因する恒久フリーズ経路が残存していることを確認した。メインスレッドがブロックすると heartbeat ping の配送も invoke 応答も全て停止し、ログ無痕跡のフリーズになる (4月以降ほぼ毎日発生していたハングと同一シグネチャ)。

## 変更内容

### メインスレッドからのブロッキング I/O 隔離 (9211257)
- **pty_write**: セッション毎の writer スレッド + mpsc キューに置換。コマンドは enqueue のみの非ブロッキングになり、ConPTY 入力パイプ満杯 (子プロセスが stdin を読まない) でブロックするのは専用スレッドだけになる。同期コマンドのまま維持し、キー入力順序 (メインスレッド実行順 = FIFO) を保証。
- **pty_spawn / pty_resize / pty_kill**: async + `spawn_blocking` 化。`PtyManager` を `Arc<PtyManagerCore>` の newtype + `Deref` に再構成 (clone で Drop の kill_all が誤発火しない構造)。
- **kill_process_tree**: `taskkill /F /T` の無期限待ちを 10 秒タイムアウト付きに変更。
- **usePty.ts**: onUnmounted 再入による pty_kill 二重発行 (ログで毎回 2 連発を観測) を抑止。
- **メインスレッド watchdog**: `run_on_main_thread` の応答遅延を計測し、次回ハング時に「Rust メインスレッドブロック」と「JS フリーズ」をログから切り分け可能にする。

### バグレビュー指摘の修正 (72380c5)
bug-review + bug-review-deep による検証で確認された妥当な指摘を修正:
- kill() の master take を sessions ロック解放後へ移動 (resize ハング時に pty_write を巻き込む残存フリーズパスの遮断)
- 入力キューを `sync_channel(1024)` + `try_send` に有界化 (無制限メモリ蓄積の防止 + バックプレッシャのエラー可視化)
- usePty.kill を in-flight Promise 共有に変更 (再入側も完了を待てる) + onUnmounted の unhandled rejection 解消
- usePty.resize を直列化 (async 化による適用順逆転の防止)
- `git_worktree_remove` / `oretachi_kill_terminal` の kill を spawn_blocking 化 (tokio ワーカー占有の解消)
- watchdog の時刻基準を SystemTime → Instant (時計巻き戻りによる誤検知排除)

## 検証

- `cargo check` 警告ゼロ / `cargo test` 48 件パス
- `pnpm run type-check` エラーなし / `pnpm test` 17 件パス
- セキュリティレビュー (/security-review): 新規脆弱性なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)