### PR TITLE
fix(windows): RedirectionGuard 継承検出時に explorer.exe 経由でセルフリローンチ

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,9 @@ mod terminal_session;
 #[cfg(target_os = "windows")]
 mod acrylic;
 
+#[cfg(target_os = "windows")]
+mod redirection_guard;
+
 use fs_watcher::FsWatcherManager;
 use process_utils::WorktreeRemoveManager;
 use pty_manager::{AiAgentChangedPayload, PtyManager};
@@ -703,6 +706,12 @@ fn get_debug_mode() -> bool {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Windows: インストーラ起動由来の RedirectionGuard 緩和策 (Enforce=1) を検出したら
+    // explorer.exe 経由でセルフリローンチする (Issue #70)。リローンチ時は exit(0) して戻らない。
+    // この時点ではロガー未初期化のため、結果は setup() に持ち越して記録する。
+    #[cfg(target_os = "windows")]
+    let redirection_guard_outcome = redirection_guard::relaunch_if_guarded();
+
     // Windows: tauri-plugin-notification はパスが \target\release で終わる場合に
     // AUMID を設定しないため、PowerShell として通知が表示される問題を回避する。
     #[cfg(target_os = "windows")]
@@ -895,6 +904,26 @@ pub fn run() {
             // settings.debug_mode は後で読み込まれるため、env var のみで先行設定する。
             if !env_debug {
                 log::set_max_level(log::LevelFilter::Info);
+            }
+
+            #[cfg(target_os = "windows")]
+            match &redirection_guard_outcome {
+                redirection_guard::GuardOutcome::NotGuarded => {}
+                redirection_guard::GuardOutcome::RelaunchedPreviously => {
+                    log::info!(
+                        "[RedirectionGuard] 緩和策 (Enforce=1) を検出したため explorer.exe 経由で再起動した"
+                    );
+                }
+                redirection_guard::GuardOutcome::StillGuarded => {
+                    log::warn!(
+                        "[RedirectionGuard] リローンチ後も緩和策 (Enforce=1) が残っている。ターミナル内のジャンクション操作 (pnpm install 等) が失敗する可能性がある"
+                    );
+                }
+                redirection_guard::GuardOutcome::RelaunchSkipped(reason) => {
+                    log::warn!(
+                        "[RedirectionGuard] 緩和策 (Enforce=1) を検出したが起動を継続: {reason}。ターミナル内のジャンクション操作 (pnpm install 等) が失敗する可能性がある"
+                    );
+                }
             }
 
             // レポート DB を同期的に初期化（ファイル接続のみで高速、起動前に完了させる）

--- a/src-tauri/src/redirection_guard.rs
+++ b/src-tauri/src/redirection_guard.rs
@@ -1,0 +1,170 @@
+//! Windows RedirectionGuard (PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY) 対策。
+//!
+//! インストーラ/アップデータの「完了後に起動」で立ち上がった oretachi.exe は、
+//! 起動チェーンから RedirectionGuard 緩和策 (Enforce=1) を継承することがある。
+//! 緩和策は子プロセスに遺伝するため、ターミナル内の pnpm 等で NTFS ジャンクションの
+//! トラバースが「信頼されていないマウントポイント」エラーになる (Issue #70)。
+//!
+//! 起動時に自プロセスのポリシーを照会し、Enforce=1 なら explorer.exe (Enforce=0) 経由で
+//! セルフリローンチしてクリーンな親から起動し直す。
+//!
+//! 検証済みの挙動 (2026-06-11 実機確認):
+//! - 親が SetProcessMitigationPolicy で自己設定した Enforce=1 は子プロセスに継承される
+//! - Enforce=1 を自プロセスから解除しようとすると ERROR_ACCESS_DENIED で拒否される
+//!   (片方向 API のためリローンチ以外に回復手段がない)
+//! - Enforce=1 のプロセスから explorer.exe 経由で起動した子は Enforce=0 になる
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+/// 起動ガードの判定結果。tauri-plugin-log の初期化前に実行されるため、
+/// ログ出力は setup() に持ち越して行う。
+pub enum GuardOutcome {
+    /// Enforce=0 の通常起動
+    NotGuarded,
+    /// リローンチ直後の起動 (Enforce=0 + 直近マーカー有り)
+    RelaunchedPreviously,
+    /// リローンチ後もなお Enforce=1 (ループ防止のためそのまま起動継続)
+    StillGuarded,
+    /// Enforce=1 だがリローンチを行わず起動継続 (デバッグビルド / リローンチ失敗)
+    RelaunchSkipped(String),
+}
+
+/// RedirectionGuard (Enforce=1) を検出した場合、explorer.exe 経由でセルフリローンチする。
+/// リローンチする場合は内部で `exit(0)` するため戻らない。
+pub fn relaunch_if_guarded() -> GuardOutcome {
+    let marker_was_fresh = consume_marker();
+
+    if !redirection_trust_enforced() {
+        return if marker_was_fresh {
+            GuardOutcome::RelaunchedPreviously
+        } else {
+            GuardOutcome::NotGuarded
+        };
+    }
+
+    if marker_was_fresh {
+        // 直近にリローンチ済みなのに Enforce=1 のまま (親の explorer 自体が
+        // 緩和策持ち等)。再試行しても結果は変わらないため起動を継続する。
+        return GuardOutcome::StillGuarded;
+    }
+
+    if cfg!(debug_assertions) {
+        // `pnpm run tauri dev` 中に exit すると tauri CLI が dev server を落とし、
+        // リローンチ後のプロセスが孤立するため、開発時は検出のみ行う。
+        return GuardOutcome::RelaunchSkipped(
+            "デバッグビルドのためリローンチをスキップ".to_string(),
+        );
+    }
+
+    match write_marker_and_relaunch() {
+        Ok(()) => std::process::exit(0),
+        Err(reason) => GuardOutcome::RelaunchSkipped(reason),
+    }
+}
+
+/// 自プロセスの RedirectionTrust ポリシーで EnforceRedirectionTrust (bit0) が
+/// 立っているかを照会する。
+fn redirection_trust_enforced() -> bool {
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentProcess, GetProcessMitigationPolicy, ProcessRedirectionTrustPolicy,
+    };
+
+    // PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY は DWORD ビットフィールドの
+    // union (4 bytes) のため u32 で照会する (windows-sys 0.59 に構造体定義が無い)。
+    let mut flags: u32 = 0;
+    let ok = unsafe {
+        GetProcessMitigationPolicy(
+            GetCurrentProcess(),
+            ProcessRedirectionTrustPolicy,
+            &mut flags as *mut u32 as *mut _,
+            std::mem::size_of::<u32>(),
+        )
+    };
+    // ポリシー未サポートの OS (Win11 22H2 未満など) では API が失敗する = 緩和策なし
+    ok != 0 && (flags & 1) != 0
+}
+
+/// ループ防止マーカーのパス。explorer.exe 経由の起動では引数も環境変数も
+/// 新プロセスへ渡せないため、一時ファイルで「リローンチ直後」を伝搬する。
+fn marker_path() -> PathBuf {
+    std::env::temp_dir().join("oretachi-redirection-guard-relaunch")
+}
+
+const MARKER_TTL: Duration = Duration::from_secs(60);
+
+/// マーカーの mtime から「リローンチ直後」かどうかを判定する。
+/// mtime が未来 (時計巻き戻し等) の場合はループ抑止を優先して fresh 扱いにする。
+fn marker_is_fresh(mtime: SystemTime, now: SystemTime) -> bool {
+    match now.duration_since(mtime) {
+        Ok(elapsed) => elapsed <= MARKER_TTL,
+        Err(_) => true,
+    }
+}
+
+/// マーカーを読み取って削除し、fresh だったかを返す。
+/// stale マーカーを残すと TTL 経過まで手動再起動でのリトライが効かなくなるため、
+/// 結果によらず必ず削除する。
+fn consume_marker() -> bool {
+    let path = marker_path();
+    let Ok(meta) = std::fs::metadata(&path) else {
+        return false;
+    };
+    let fresh = meta
+        .modified()
+        .map(|mtime| marker_is_fresh(mtime, SystemTime::now()))
+        .unwrap_or(true);
+    let _ = std::fs::remove_file(&path);
+    fresh
+}
+
+/// マーカーを書き込み、explorer.exe 経由で自 exe を起動する。
+/// explorer は exe パス以外の引数を新プロセスへ渡せないため、コマンドライン引数は
+/// 失われる (現状引数は未使用。deep link 等を導入する場合はここの再設計が必要)。
+fn write_marker_and_relaunch() -> Result<(), String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("自 exe パスの取得に失敗したためリローンチを中止: {e}"))?;
+
+    std::fs::write(marker_path(), b"relaunch")
+        .map_err(|e| format!("ループ防止マーカーの書き込みに失敗したためリローンチを中止: {e}"))?;
+
+    // PATH 探索に依存しないよう %SystemRoot% からの絶対パスで起動する。
+    // explorer は成功時にも終了コード 1 を返すことがあるため exit code は見ない。
+    let explorer = std::env::var_os("SystemRoot")
+        .map(|root| PathBuf::from(root).join("explorer.exe"))
+        .unwrap_or_else(|| PathBuf::from("explorer.exe"));
+
+    match std::process::Command::new(explorer).arg(&exe).spawn() {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(marker_path());
+            Err(format!("explorer.exe 経由のリローンチ起動に失敗: {e}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_within_ttl_is_fresh() {
+        let now = SystemTime::now();
+        let mtime = now - Duration::from_secs(30);
+        assert!(marker_is_fresh(mtime, now));
+    }
+
+    #[test]
+    fn marker_past_ttl_is_stale() {
+        let now = SystemTime::now();
+        let mtime = now - Duration::from_secs(61);
+        assert!(!marker_is_fresh(mtime, now));
+    }
+
+    #[test]
+    fn marker_with_future_mtime_is_fresh() {
+        let now = SystemTime::now();
+        let mtime = now + Duration::from_secs(300);
+        assert!(marker_is_fresh(mtime, now));
+    }
+}


### PR DESCRIPTION
## 背景

インストーラ/アップデータの「完了後に起動」や自動更新後の再起動で立ち上がった oretachi.exe は、起動チェーンから Windows の RedirectionGuard 緩和策 (`PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY`, Enforce=1) を継承することがある。緩和策は子プロセスに遺伝するため、oretachi 内の全ターミナルで NTFS ジャンクションのトラバースがブロックされ、`pnpm install` / `pnpm test` / Claude Code などが軒並み失敗する (2026-06-11 に実環境で確認)。

緩和策は実行中プロセスから除去できない (`ERROR_ACCESS_DENIED` を実測) ため、起動最初期に検出して explorer.exe (Enforce=0) 経由でセルフリローンチし、クリーンな親から起動し直す。

Closes #70

## 実装

新規 `src-tauri/src/redirection_guard.rs` (Windows 専用):

- 起動時に自プロセスの RedirectionTrust ポリシー (policy=16) を照会し、EnforceRedirectionTrust (bit0) が立っていたら `%SystemRoot%\explorer.exe <自exe>` 経由でセルフリローンチして `exit(0)`
- 一時ファイルマーカー (TTL 60秒、mtime ベース、読み取り後は全パスで削除) でリローンチの無限ループを防止
- リローンチ起動に失敗した場合は exit せず通常起動を継続 (「起動消失」を回避)
- デバッグビルドは検出+警告ログのみ (`tauri dev` のプロセス管理を壊さないため)

`src-tauri/src/lib.rs`:

- `run()` の最初 (AUMID 設定より前) でガードを呼び出し、結果を `setup()` に持ち越して tauri-plugin-log 初期化後にログ記録

NSIS updater の自動再起動 (`useUpdater.ts` → `relaunch()`) も同一の汚染経路であり、本ガードがそのまま救済する。

## 実機検証で確定した挙動 (2026-06-11)

プローブプログラムで以下を実証:

- 親が `SetProcessMitigationPolicy` で設定した Enforce=1 は**子プロセスに継承される**
- Enforce=1 の**自己解除は `ERROR_ACCESS_DENIED` で不可** (片方向 API)
- Enforce=1 のプロセスから **explorer.exe 経由で起動した子は Enforce=0** になる

## テスト

- `cargo check`: 警告・エラーなし
- `cargo test --lib`: 51 件全パス (マーカー TTL の unit test 3 件を含む)
- Cargo.toml の変更は不要 (必要な windows-sys feature は既存)

## 残課題

- リリースビルドでのエンドツーエンド確認 (インストーラの「完了後に起動」→ 自動再起動 1 回 → ログ記録 → ジャンクション操作成功)
- アップデート→自動再起動の一連の実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)