### PR TITLE
feat(settings): UIスケール設定 (通常/大/特大) を追加

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:webview:allow-create-webview-window",
+    "core:webview:allow-set-webview-zoom",
     "core:window:allow-create",
     "core:window:allow-set-focus",
     "core:window:allow-set-always-on-top",

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -231,11 +231,13 @@ pub struct AppearanceSettings {
     pub enable_gaming_border: bool,
     #[serde(default, rename = "gamingBorderTheme")]
     pub gaming_border_theme: Option<String>,
+    #[serde(default, rename = "uiScale")]
+    pub ui_scale: Option<String>,
 }
 
 impl Default for AppearanceSettings {
     fn default() -> Self {
-        AppearanceSettings { enable_acrylic: true, acrylic_opacity: None, acrylic_color: None, enable_gaming_border: false, gaming_border_theme: None }
+        AppearanceSettings { enable_acrylic: true, acrylic_opacity: None, acrylic_color: None, enable_gaming_border: false, gaming_border_theme: None, ui_scale: None }
     }
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,8 @@ import { useSubWindowEvents } from "./composables/useSubWindowEvents";
 import { useShutdownGuard } from "./composables/useShutdownGuard";
 import type { ArchiveRow } from "./types/archive";
 import { logDebug } from "./utils/log";
-import { uiZoomFactor, cssPxToLogical } from "./utils/uiScale";
+import { cssPxToLogical } from "./utils/uiScale";
+import { useUiZoom } from "./composables/useUiZoom";
 import { consumeMaxBlockedMs, startEventLoopMonitor } from "./utils/eventLoopMonitor";
 import { terminalMountCount, terminalUnmountCount, terminalActiveCount } from "./components/TerminalView.vue";
 import { ask } from "@tauri-apps/plugin-dialog";
@@ -68,6 +69,7 @@ const { checkForUpdate, downloadAndInstall } = useUpdater();
 type ViewMode = "home" | "settings" | "terminal";
 
 const { settings, loadSettings, scheduleSave } = useSettings();
+const { appliedZoom } = useUiZoom();
 const { worktrees, loadWorktreesFromSettings, addWorktreePlaceholder, invokeWorktreeAdd, commitWorktree, rollbackWorktree, reorderWorktree, saveWorktreeOrder, restoreWorktreeOrder, addTerminal, removeTerminal, updateTerminalTitle, saveTerminalSession, loadTerminalSession } = useWorktrees();
 const { detachedWorktrees, isDetached, moveToSubWindow, moveToMainWindow, focusSubWindow, unregisterSubWindow, getPendingInitData, clearPendingInitData, getDetachedSessionId, registerTerminalSession, closeAllSubWindows } = useSubWindows();
 const { autoApprovalPromptMap, lastJudgedCommandMap, showAutoApprovalPromptDialog, autoApprovalPromptTargetId, restoreFromSettings: restoreAutoApprovalPrompts, onClickAutoApproval, onSaveAutoApprovalPrompt } = useAutoApprovalPrompt(settings, scheduleSave, isDetached);
@@ -901,8 +903,8 @@ async function onTrayButtonClick() {
       let mainWindowSize: { width: number; height: number } | undefined;
       // sizeFromContainer: 親コンテナからのフォールバックサイズを使ったかどうか
       let sizeFromContainer = false;
-      // gBCR は CSS px。windowSize は常に論理px (DIP) で渡す契約のためズーム換算する
-      const zoom = uiZoomFactor(settings.value);
+      // gBCR は CSS px。windowSize は常に論理px (DIP) で渡す契約のため実適用ズームで換算する
+      const zoom = appliedZoom.value;
       if (rect && rect.width > 0 && rect.height > 0) {
         mainWindowSize = { width: cssPxToLogical(rect.width, zoom), height: cssPxToLogical(rect.height, zoom) };
       } else {

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,6 +48,7 @@ import { useSubWindowEvents } from "./composables/useSubWindowEvents";
 import { useShutdownGuard } from "./composables/useShutdownGuard";
 import type { ArchiveRow } from "./types/archive";
 import { logDebug } from "./utils/log";
+import { uiZoomFactor, cssPxToLogical } from "./utils/uiScale";
 import { consumeMaxBlockedMs, startEventLoopMonitor } from "./utils/eventLoopMonitor";
 import { terminalMountCount, terminalUnmountCount, terminalActiveCount } from "./components/TerminalView.vue";
 import { ask } from "@tauri-apps/plugin-dialog";
@@ -900,14 +901,16 @@ async function onTrayButtonClick() {
       let mainWindowSize: { width: number; height: number } | undefined;
       // sizeFromContainer: 親コンテナからのフォールバックサイズを使ったかどうか
       let sizeFromContainer = false;
+      // gBCR は CSS px。windowSize は常に論理px (DIP) で渡す契約のためズーム換算する
+      const zoom = uiZoomFactor(settings.value);
       if (rect && rect.width > 0 && rect.height > 0) {
-        mainWindowSize = { width: Math.round(rect.width), height: Math.round(rect.height) };
+        mainWindowSize = { width: cssPxToLogical(rect.width, zoom), height: cssPxToLogical(rect.height, zoom) };
       } else {
         // activeWorktreeId が null（ホーム/設定画面）の場合:
         // メインコンテンツ領域を計測（= WorktreeHeader + フレーム領域と同サイズ）
         const containerRect = mainContentAreaRef.value?.getBoundingClientRect();
         if (containerRect && containerRect.width > 0 && containerRect.height > 0) {
-          mainWindowSize = { width: Math.round(containerRect.width), height: Math.round(containerRect.height) };
+          mainWindowSize = { width: cssPxToLogical(containerRect.width, zoom), height: cssPxToLogical(containerRect.height, zoom) };
           sizeFromContainer = true;
         }
       }

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -16,7 +16,8 @@ import { useWorktreeTaskMap } from "./composables/useWorktreeTaskMap";
 import type { FrameNode } from "./types/frame";
 import type { TrayTerminalEntry } from "./types/terminal";
 import { useI18n } from "vue-i18n";
-import { uiZoomFactor, cssPxToLogical } from "./utils/uiScale";
+import { cssPxToLogical } from "./utils/uiScale";
+import { useUiZoom, applyUiZoom } from "./composables/useUiZoom";
 import MacTrafficLights from "./components/MacTrafficLights.vue";
 import { isMac } from "./composables/usePlatform";
 
@@ -87,21 +88,25 @@ const showAutoApprovalPromptDialog = ref(false);
 // 現在ワークツリーの表示
 // ────────────────────────────────────────────────
 
-async function showWorktree(data: TrayWorktreeData) {
-  terminalEntries.clear();
-  terminalRefs.clear();
-
-  // ウィンドウサイズをサブウィンドウに合わせる
-  // isDetached=true: windowSize はサブウィンドウ全体のサイズ → フッターのみ加算
-  // isDetached=false: windowSize はメインウィンドウのフレーム領域 → ヘッダー + フッター加算
-  // windowSize は常に論理px (DIP)。offsetHeight は CSS px のためズーム換算してから加算
+// ウィンドウサイズをサブウィンドウに合わせる
+// isDetached=true: windowSize はサブウィンドウ全体のサイズ → フッターのみ加算
+// isDetached=false: windowSize はメインウィンドウのフレーム領域 → ヘッダー + フッター加算
+// windowSize は常に論理px (DIP)。offsetHeight は CSS px のため実適用ズームで換算してから加算
+async function applyWindowSize(data: TrayWorktreeData) {
   const win = getCurrentWindow();
-  const zoom = uiZoomFactor(settings.value);
+  const zoom = appliedZoom.value;
   const footerH = cssPxToLogical(footerRef.value?.offsetHeight ?? 0, zoom);
   const headerH = data.isDetached ? 0 : cssPxToLogical(headerRef.value?.offsetHeight ?? 0, zoom);
   const width = data.windowSize?.width ?? 900;
   const height = (data.windowSize?.height ?? 600) + footerH + headerH;
   await win.setSize(new LogicalSize(width, height));
+}
+
+async function showWorktree(data: TrayWorktreeData) {
+  terminalEntries.clear();
+  terminalRefs.clear();
+
+  await applyWindowSize(data);
 
   for (const t of data.terminals) {
     terminalEntries.set(t.id, { ...t });
@@ -270,6 +275,7 @@ async function onCancelAiJudging() {
 // ────────────────────────────────────────────────
 
 const { settings, loadSettings } = useSettings();
+const { appliedZoom } = useUiZoom();
 
 // TrayPopup のホットキーリスナー
 useHotkeyListener(() => {
@@ -301,6 +307,14 @@ onMounted(async () => {
   // トレイ表示中の uiScale / ターミナル設定変更に追従
   unlistenSettings = await listen("settings-changed", async () => {
     await loadSettings();
+    // main.ts のリスナーと順不同でも冪等なズーム適用で appliedZoom を最新化し、
+    // 表示中ワークツリーのウィンドウサイズを新ズームで再計算する
+    await applyUiZoom(settings.value);
+    const wt = currentWorktree.value;
+    if (initialized.value && wt) {
+      await nextTick();
+      await applyWindowSize(wt);
+    }
   });
 
   const appWindow = getCurrentWindow();

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, onMounted, onUnmounted, nextTick, computed } from "vue";
-import { emitTo, type UnlistenFn } from "@tauri-apps/api/event";
+import { emitTo, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 import TerminalView from "./components/TerminalView.vue";
 import FrameContainer from "./components/FrameContainer.vue";
@@ -16,6 +16,7 @@ import { useWorktreeTaskMap } from "./composables/useWorktreeTaskMap";
 import type { FrameNode } from "./types/frame";
 import type { TrayTerminalEntry } from "./types/terminal";
 import { useI18n } from "vue-i18n";
+import { uiZoomFactor, cssPxToLogical } from "./utils/uiScale";
 import MacTrafficLights from "./components/MacTrafficLights.vue";
 import { isMac } from "./composables/usePlatform";
 
@@ -93,9 +94,11 @@ async function showWorktree(data: TrayWorktreeData) {
   // ウィンドウサイズをサブウィンドウに合わせる
   // isDetached=true: windowSize はサブウィンドウ全体のサイズ → フッターのみ加算
   // isDetached=false: windowSize はメインウィンドウのフレーム領域 → ヘッダー + フッター加算
+  // windowSize は常に論理px (DIP)。offsetHeight は CSS px のためズーム換算してから加算
   const win = getCurrentWindow();
-  const footerH = footerRef.value?.offsetHeight ?? 0;
-  const headerH = data.isDetached ? 0 : (headerRef.value?.offsetHeight ?? 0);
+  const zoom = uiZoomFactor(settings.value);
+  const footerH = cssPxToLogical(footerRef.value?.offsetHeight ?? 0, zoom);
+  const headerH = data.isDetached ? 0 : cssPxToLogical(headerRef.value?.offsetHeight ?? 0, zoom);
   const width = data.windowSize?.width ?? 900;
   const height = (data.windowSize?.height ?? 600) + footerH + headerH;
   await win.setSize(new LogicalSize(width, height));
@@ -290,9 +293,15 @@ useHotkeyListener(() => {
 });
 
 let unlistenInit: UnlistenFn | null = null;
+let unlistenSettings: UnlistenFn | null = null;
 
 onMounted(async () => {
   await loadSettings();
+
+  // トレイ表示中の uiScale / ターミナル設定変更に追従
+  unlistenSettings = await listen("settings-changed", async () => {
+    await loadSettings();
+  });
 
   const appWindow = getCurrentWindow();
 
@@ -315,6 +324,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   unlistenInit?.();
+  unlistenSettings?.();
 });
 </script>
 

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -2,7 +2,6 @@
 import { ref, onMounted } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { open, ask, message } from "@tauri-apps/plugin-dialog";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useSettings } from "../composables/useSettings";
@@ -14,7 +13,7 @@ import { useI18n } from "vue-i18n";
 import { setLocale } from "../i18n";
 import { useToast } from "primevue/usetoast";
 import { playNotificationSound } from "../utils/notificationSound";
-import { uiZoomFactor } from "../utils/uiScale";
+import { applyUiZoom } from "../composables/useUiZoom";
 import type { NotificationKind } from "../composables/useNotifications";
 import SettingsHotkeySection from "./settings/SettingsHotkeySection.vue";
 import SettingsRepositoriesSection from "./settings/SettingsRepositoriesSection.vue";
@@ -38,11 +37,7 @@ async function onUiScaleChange(value: string) {
   scheduleSave();
   // scheduleSave は 500ms デバウンスのため、自ウィンドウは即時反映する
   // (他ウィンドウは settings-changed 経由で main.ts のリスナーが追従)
-  try {
-    await getCurrentWebview().setZoom(uiZoomFactor(settings.value));
-  } catch {
-    // setZoom 失敗時は保存後の settings-changed 再適用に任せる
-  }
+  await applyUiZoom(settings.value);
 }
 
 async function onCheckUpdate() {

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { open, ask, message } from "@tauri-apps/plugin-dialog";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useSettings } from "../composables/useSettings";
@@ -13,6 +14,7 @@ import { useI18n } from "vue-i18n";
 import { setLocale } from "../i18n";
 import { useToast } from "primevue/usetoast";
 import { playNotificationSound } from "../utils/notificationSound";
+import { uiZoomFactor } from "../utils/uiScale";
 import type { NotificationKind } from "../composables/useNotifications";
 import SettingsHotkeySection from "./settings/SettingsHotkeySection.vue";
 import SettingsRepositoriesSection from "./settings/SettingsRepositoriesSection.vue";
@@ -28,6 +30,19 @@ const appVersion = ref("");
 
 async function onDebugModeChange(enabled: boolean) {
   await invoke("set_debug_mode", { enabled });
+}
+
+async function onUiScaleChange(value: string) {
+  if (!settings.value.appearance) settings.value.appearance = {};
+  settings.value.appearance.uiScale = value === "large" || value === "xlarge" ? value : "normal";
+  scheduleSave();
+  // scheduleSave は 500ms デバウンスのため、自ウィンドウは即時反映する
+  // (他ウィンドウは settings-changed 経由で main.ts のリスナーが追従)
+  try {
+    await getCurrentWebview().setZoom(uiZoomFactor(settings.value));
+  } catch {
+    // setZoom 失敗時は保存後の settings-changed 再適用に任せる
+  }
 }
 
 async function onCheckUpdate() {
@@ -669,6 +684,18 @@ function getSoundLabel(sound: string | null | undefined): string {
           <option v-for="theme in gamingBorderThemes" :key="theme.value" :value="theme.value">{{ t(theme.labelKey) }}</option>
         </select>
       </div>
+      <div class="row-input mt-8">
+        <label class="row-label">{{ t('appearance.uiScale') }}</label>
+        <select
+          class="text-input select-input"
+          :value="settings.appearance?.uiScale ?? 'normal'"
+          @change="(e) => onUiScaleChange((e.target as HTMLSelectElement).value)"
+        >
+          <option value="normal">{{ t('appearance.uiScaleNormal') }}</option>
+          <option value="large">{{ t('appearance.uiScaleLarge') }}</option>
+          <option value="xlarge">{{ t('appearance.uiScaleXLarge') }}</option>
+        </select>
+      </div>
     </div>
 
     <!-- ターミナル猫 -->
@@ -1205,7 +1232,11 @@ function getSoundLabel(sound: string | null | undefined): string {
       },
       "restartNote": "Enabling/disabling the effect requires restarting the app.",
       "opacity": "Opacity",
-      "color": "Tint color"
+      "color": "Tint color",
+      "uiScale": "UI scale",
+      "uiScaleNormal": "Normal",
+      "uiScaleLarge": "Large",
+      "uiScaleXLarge": "Extra Large"
     },
     "notificationSound": {
       "label": "Notification Sound",
@@ -1308,7 +1339,11 @@ function getSoundLabel(sound: string | null | undefined): string {
       },
       "restartNote": "エフェクトの有効/無効はアプリ再起動後に反映されます。",
       "opacity": "不透明度",
-      "color": "背景色"
+      "color": "背景色",
+      "uiScale": "UIスケール",
+      "uiScaleNormal": "通常",
+      "uiScaleLarge": "大",
+      "uiScaleXLarge": "特大"
     },
     "notificationSound": {
       "label": "通知音",

--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -18,7 +18,7 @@ import { matchesHotkey } from "../composables/useHotkeys";
 import { useTerminalSearch } from "../composables/useTerminalSearch";
 import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useI18n } from "vue-i18n";
-import { uiZoomFactor } from "../utils/uiScale";
+import { useUiZoom } from "../composables/useUiZoom";
 import { logDebug } from "../utils/log";
 
 const { t } = useI18n();
@@ -65,9 +65,11 @@ const batcher = usePtyWriteBatcher(() => terminal);
 const { settings } = useSettings();
 
 // UIスケール (webview ズーム) 下でもターミナルの物理グリフサイズを不変に保つため、
-// xterm には設定値 / ズーム倍率 を渡す (CSS px × ズーム = 物理相当サイズ)
+// xterm には設定値 / ズーム倍率 を渡す (CSS px × ズーム = 物理相当サイズ)。
+// setZoom 失敗時に過縮小しないよう、設定値でなく実適用ズームで割る
+const { appliedZoom } = useUiZoom();
 const effectiveFontSize = computed(
-  () => Math.round((settings.value.terminal.fontSize / uiZoomFactor(settings.value)) * 100) / 100
+  () => Math.round((settings.value.terminal.fontSize / appliedZoom.value) * 100) / 100
 );
 
 async function handlePaste() {

--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -6,7 +6,7 @@ export let terminalActiveCount = 0;
 </script>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
@@ -18,6 +18,7 @@ import { matchesHotkey } from "../composables/useHotkeys";
 import { useTerminalSearch } from "../composables/useTerminalSearch";
 import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useI18n } from "vue-i18n";
+import { uiZoomFactor } from "../utils/uiScale";
 import { logDebug } from "../utils/log";
 
 const { t } = useI18n();
@@ -63,6 +64,12 @@ const { sessionId, spawn, attachToSession, write, resize, kill, isRunning, detac
 const batcher = usePtyWriteBatcher(() => terminal);
 const { settings } = useSettings();
 
+// UIスケール (webview ズーム) 下でもターミナルの物理グリフサイズを不変に保つため、
+// xterm には設定値 / ズーム倍率 を渡す (CSS px × ズーム = 物理相当サイズ)
+const effectiveFontSize = computed(
+  () => Math.round((settings.value.terminal.fontSize / uiZoomFactor(settings.value)) * 100) / 100
+);
+
 async function handlePaste() {
   try {
     const text = await readText();
@@ -94,7 +101,7 @@ function initTerminal() {
     ...(props.initialCols != null && { cols: props.initialCols }),
     ...(props.initialRows != null && { rows: props.initialRows }),
     fontFamily: '"Cascadia Code", Consolas, Menlo, "SF Mono", Monaco, monospace',
-    fontSize: settings.value.terminal.fontSize,
+    fontSize: effectiveFontSize.value,
     theme: {
       background: isTransparent ? "#1e1e2e00" : "#1e1e2e",
       foreground: "#cdd6f4",
@@ -358,7 +365,7 @@ function waitForReady(): Promise<void> {
 }
 
 watch(
-  () => settings.value.terminal.fontSize,
+  effectiveFontSize,
   (newSize) => {
     if (terminal) {
       terminal.options.fontSize = newSize;

--- a/src/composables/useTrayPopup.ts
+++ b/src/composables/useTrayPopup.ts
@@ -17,7 +17,7 @@ export interface TrayWorktreeData {
   isDetached: boolean;
   layout: FrameNode | null;
   terminals: TrayTerminalData[];
-  windowSize?: { width: number; height: number };
+  windowSize?: { width: number; height: number }; // 論理px (DIP)。CSS px 計測値はプロデューサ側でズーム換算済み
   branchName: string;
   repositoryName: string;
   hotkeyChar?: string;

--- a/src/composables/useUiZoom.ts
+++ b/src/composables/useUiZoom.ts
@@ -1,0 +1,27 @@
+import { ref, readonly } from "vue";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { uiZoomFactor } from "../utils/uiScale";
+
+// このウィンドウの webview に実際に適用されたズーム倍率。
+// setZoom 失敗時 (例: 旧macOS) は設定値と乖離するため、フォント補正や
+// CSS px→論理px 換算は設定値でなく必ずこちらを参照する。
+const appliedZoom = ref(1.0);
+
+/**
+ * uiScale 設定をこのウィンドウの webview ズームに適用する (冪等)。
+ * 成功時のみ appliedZoom を更新する。
+ */
+export async function applyUiZoom(settings: { appearance?: { uiScale?: string | null } | null }): Promise<void> {
+  const zoom = uiZoomFactor(settings);
+  if (zoom === appliedZoom.value) return;
+  try {
+    await getCurrentWebview().setZoom(zoom);
+    appliedZoom.value = zoom;
+  } catch (e) {
+    console.warn("Failed to set webview zoom:", e);
+  }
+}
+
+export function useUiZoom() {
+  return { appliedZoom: readonly(appliedZoom) };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,26 +7,13 @@ import Aura from "@primeuix/themes/aura";
 import { attachConsole } from "@tauri-apps/plugin-log";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { platform } from "@tauri-apps/plugin-os";
 import { i18n, setLocale } from "./i18n";
-import { uiZoomFactor } from "./utils/uiScale";
+import { applyUiZoom } from "./composables/useUiZoom";
 import type { AppSettings } from "./types/settings";
 
 const params = new URLSearchParams(window.location.search);
 const mode = params.get("mode");
-
-let appliedZoom = 1.0;
-async function applyUiScale(settings: AppSettings) {
-  const zoom = uiZoomFactor(settings);
-  if (zoom === appliedZoom) return;
-  try {
-    await getCurrentWebview().setZoom(zoom);
-    appliedZoom = zoom;
-  } catch (e) {
-    console.warn("Failed to set webview zoom:", e);
-  }
-}
 
 async function mountApp() {
   document.addEventListener("contextmenu", (e) => e.preventDefault());
@@ -45,7 +32,7 @@ async function mountApp() {
     if (loaded.appearance?.enableAcrylic !== false && platform() !== "macos") {
       document.documentElement.classList.add("transparent-mode");
     }
-    await applyUiScale(loaded);
+    await applyUiZoom(loaded);
   } catch {
     // settings 読み込み失敗時はデフォルト (enableAcrylic=true) として透明モードに
     if (platform() !== "macos") {
@@ -57,7 +44,7 @@ async function mountApp() {
   listen("settings-changed", async () => {
     try {
       const s = await invoke<AppSettings>("get_settings");
-      await applyUiScale(s);
+      await applyUiZoom(s);
     } catch {
       // 取得失敗時は現状のズームを維持
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,27 @@ import Tooltip from "primevue/tooltip";
 import Aura from "@primeuix/themes/aura";
 import { attachConsole } from "@tauri-apps/plugin-log";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { platform } from "@tauri-apps/plugin-os";
 import { i18n, setLocale } from "./i18n";
+import { uiZoomFactor } from "./utils/uiScale";
 import type { AppSettings } from "./types/settings";
 
 const params = new URLSearchParams(window.location.search);
 const mode = params.get("mode");
+
+let appliedZoom = 1.0;
+async function applyUiScale(settings: AppSettings) {
+  const zoom = uiZoomFactor(settings);
+  if (zoom === appliedZoom) return;
+  try {
+    await getCurrentWebview().setZoom(zoom);
+    appliedZoom = zoom;
+  } catch (e) {
+    console.warn("Failed to set webview zoom:", e);
+  }
+}
 
 async function mountApp() {
   document.addEventListener("contextmenu", (e) => e.preventDefault());
@@ -30,12 +45,23 @@ async function mountApp() {
     if (loaded.appearance?.enableAcrylic !== false && platform() !== "macos") {
       document.documentElement.classList.add("transparent-mode");
     }
+    await applyUiScale(loaded);
   } catch {
     // settings 読み込み失敗時はデフォルト (enableAcrylic=true) として透明モードに
     if (platform() !== "macos") {
       document.documentElement.classList.add("transparent-mode");
     }
   }
+
+  // UIスケール変更を全ウィンドウモード共通で追従 (emit はグローバルブロードキャスト)
+  listen("settings-changed", async () => {
+    try {
+      const s = await invoke<AppSettings>("get_settings");
+      await applyUiScale(s);
+    } catch {
+      // 取得失敗時は現状のズームを維持
+    }
+  });
 
   let rootComponent;
   if (mode === "subwindow") {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -84,6 +84,7 @@ export interface AppearanceSettings {
   acrylicColor?: string;   // "#RRGGBB", デフォルト: "#121212"
   enableGamingBorder?: boolean; // デフォルト: false
   gamingBorderTheme?: string;   // デフォルト: 'gaming'
+  uiScale?: 'normal' | 'large' | 'xlarge'; // デフォルト: 'normal'
 }
 
 export interface NotificationSoundSettings {

--- a/src/utils/uiScale.ts
+++ b/src/utils/uiScale.ts
@@ -1,0 +1,29 @@
+/**
+ * UIスケール設定 (appearance.uiScale) のズーム換算ユーティリティ。
+ *
+ * 適用機構は webview ズーム (getCurrentWebview().setZoom) で、ブラウザズームと
+ * 同じセマンティクス。ズーム Z 下では CSS px × Z = 論理px (DIP/LogicalSize)。
+ */
+
+/** 'large' 選択時のズーム倍率 (VSCode のズーム1段階相当) */
+export const UI_SCALE_LARGE = 1.2;
+
+/** 'xlarge' 選択時のズーム倍率 (VSCode のズーム2段階相当 = 1.2^2) */
+export const UI_SCALE_XLARGE = 1.44;
+
+/** uiScale 設定値からズーム倍率を返す (未知の値はすべて 1.0) */
+export function uiZoomFactor(settings: { appearance?: { uiScale?: string | null } | null }): number {
+  switch (settings.appearance?.uiScale) {
+    case "large":
+      return UI_SCALE_LARGE;
+    case "xlarge":
+      return UI_SCALE_XLARGE;
+    default:
+      return 1.0;
+  }
+}
+
+/** webview 内の CSS px 計測値を LogicalSize 用の論理pxに換算する */
+export function cssPxToLogical(px: number, zoom: number): number {
+  return Math.round(px * zoom);
+}


### PR DESCRIPTION
## 概要

VSCode の拡大縮小のように、**ターミナル内テキスト以外**の全UIサイズを調整可能にする設定を追加します。設定タブの外観セクションにセレクトボックス (通常=1.0 / 大=1.2 / 特大=1.44) を追加しました。

## 実装方式

Tauri の webview ズーム (`getCurrentWebview().setZoom()`) を採用。ブラウザズームと同じセマンティクスのため CSS 無変更で、Monaco (CodeViewer)・PrimeVue・アーティファクトの iframe を含む全UIが一貫して拡大されます。

- **全ウィンドウ対応**: 全5ウィンドウモード (メイン/サブ/トレイ/CodeViewer/アーティファクト) は単一の `main.ts` から起動されるため、起動時適用 + `settings-changed` リスナーをそこに一本化
- **ターミナル除外**: xterm の fontSize を `設定値 ÷ ズーム倍率` に補正し、物理グリフサイズを不変に維持 (FitAddon が cols/rows を自動再計算)
- **実適用ズームの共有**: `useUiZoom` composable の `appliedZoom` (setZoom 成功時のみ更新) を全消費側が参照し、setZoom 失敗環境でのターミナル縮小・トレイ過大サイズを防止
- **トレイの整合性**: ウィンドウ間で受け渡す `windowSize` を「常に論理px (DIP)」に統一 (gBCR/offsetHeight の CSS px 計測値はプロデューサ側でズーム換算)。トレイ表示中の設定変更時もウィンドウサイズを再計算

## 整合性確認

- サブウィンドウの `innerSize()/scaleFactor()` は論理px 直接取得のため換算不要
- FramePane のD&D・HomeView の FLIP 等はウィンドウ内完結の CSS px 計算でズーム影響なし
- 設定未定義時は「通常」(後方互換)。Rust 側は `Option<String>` で素通し
- bug-review 実施済み: Critical 0件、Warning 1件 + Suggestion 1件は対応済み (d182b11)、Suggestion 1件 (settings-changed 連続発火時の世代トークン) はレアケースかつ自己修復するため未対応

## 検証

- [x] `pnpm run type-check` / `cargo check` パス
- [ ] 手動確認: 「大/特大」切替で全UIが拡大・ターミナル文字サイズ不変・cols/rows 減少
- [ ] 再起動後の適用、サブ/CodeViewer/アーティファクトウィンドウへの反映
- [ ] トレイポップアップ (非デタッチ/デタッチ/ホーム画面中) のサイズ整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)