### PR TITLE
fix(wizard): ORETACHI_FORCE_WIZARD が .env.development.local で効かない問題を修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -727,9 +727,10 @@ fn get_debug_mode() -> bool {
     log::max_level() >= log::LevelFilter::Debug
 }
 
-/// 動作確認用: 初回起動ウィザードを毎回表示するか (.env の ORETACHI_FORCE_WIZARD)。
-/// dotenvy は run() 冒頭でカレントディレクトリの .env を読むだけのため、
-/// インストール済みアプリでは実質常に false になる。
+/// 動作確認用: 初回起動ウィザードを毎回表示するか (ORETACHI_FORCE_WIZARD)。
+/// run() 冒頭で .env* 一式 (Vite 規約準拠、.env.development.local が最優先) を読むため、
+/// dev では .env.development.local 等で true にすると毎回表示される。
+/// インストール済みアプリでは .env* が存在しないため実質常に false になる。
 #[tauri::command]
 fn get_force_wizard() -> bool {
     std::env::var("ORETACHI_FORCE_WIZARD")
@@ -756,11 +757,16 @@ pub fn run() {
         }
     }
 
-    // .env 読み込み（Vite の .env 規約に準拠）
-    // builder チェーンより前に読み込む必要があるためここで実施
-    let _ = dotenvy::from_filename(".env");
+    // .env 読み込み（Vite の .env 規約に準拠: 優先度 .{mode}.local > .{mode} > .local > base）
+    // builder チェーンより前に読み込む必要があるためここで実施。
+    // 読み込み順は「低優先 → 高優先」で、後勝ち（override）になるよう並べる。
+    // from_filename(_override) は cwd とその親を探索するため、cwd が src-tauri でも
+    // リポジトリルートの .env* 一式を解決する。
+    let _ = dotenvy::from_filename(".env"); // base（既存のシェル環境変数は上書きしない）
+    let _ = dotenvy::from_filename_override(".env.local"); // 全モード共通のローカル上書き
     if cfg!(debug_assertions) {
         let _ = dotenvy::from_filename_override(".env.development");
+        let _ = dotenvy::from_filename_override(".env.development.local");
     }
 
     // ORETACHI_DEBUG 環境変数でデバッグモードを判定（起動時点で確定）


### PR DESCRIPTION
## 概要

`ORETACHI_FORCE_WIZARD=true` を `.env.development.local` に設定しても初回起動ウィザードが表示されない問題を修正します。

## 原因

`src-tauri/src/lib.rs` の `.env` 読み込みは「Vite の .env 規約に準拠」と謳いながら、実際には `.env` と `.env.development` の2ファイルしか読んでおらず、Vite で最優先となる `.env.development.local`（および `.env.local`）を読み込んでいませんでした。

Vite の優先順位（高→低）:
1. `.env.{mode}.local` ← **未読込（ユーザーが設定するファイル）**
2. `.env.{mode}`（= `.env.development`）
3. `.env.local` ← **未読込**
4. `.env`

このため `get_force_wizard()` は `.env.development` の `ORETACHI_FORCE_WIZARD=false` を読み続け、`forceWizard` が常に `false` になっていました。

## 変更内容

- dotenvy の読み込みを Vite の優先順位（`.{mode}.local` > `.{mode}` > `.local` > base）に従う cascade に拡張
- `get_force_wizard()` のドキュメントコメントを実態に合わせて更新

```rust
let _ = dotenvy::from_filename(".env");                          // base
let _ = dotenvy::from_filename_override(".env.local");           // 全モード共通
if cfg!(debug_assertions) {
    let _ = dotenvy::from_filename_override(".env.development");
    let _ = dotenvy::from_filename_override(".env.development.local"); // 最優先
}
```

`.env*` ファイル自体は変更していません（ローカル設定を尊重）。`from_filename(_override)` は cwd とその親を探索するため、dev 時の cwd が `src-tauri` でもリポジトリルートの `.env*` を解決します。

## 検証

- `cd src-tauri && cargo check` 通過
- `.env.development.local` に `ORETACHI_FORCE_WIZARD=true` を設定 → `pnpm run tauri dev` でウィザードが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)