### PR TITLE
feat(settings): タスク追加時のブランチ名パターンをリポジトリ単位で設定可能に

### DIFF
--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -920,17 +920,25 @@ impl NotifyService {
     ) -> Result<CallToolResult, McpError> {
         let settings_manager = self.app_handle.state::<SettingsManager>();
         let settings = settings_manager.get();
-        let paths: Vec<(String, String)> = settings
+        let paths: Vec<(String, String, Option<String>)> = settings
             .repositories
             .iter()
-            .map(|repo| (repo.name.clone(), repo.path.clone()))
+            .map(|repo| {
+                let pattern = repo
+                    .branch_name_pattern
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|p| !p.is_empty())
+                    .map(str::to_string);
+                (repo.name.clone(), repo.path.clone(), pattern)
+            })
             .collect();
         let repos: Vec<serde_json::Value> = tokio::task::spawn_blocking(move || {
             paths
                 .iter()
-                .map(|(name, path)| {
+                .map(|(name, path, pattern)| {
                     let remotes = get_git_remotes(path);
-                    serde_json::json!({ "name": name, "remotes": remotes })
+                    serde_json::json!({ "name": name, "remotes": remotes, "branchNamePattern": pattern })
                 })
                 .collect()
         })

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -27,6 +27,8 @@ pub struct Repository {
     pub notification_hooks: Option<Vec<NotificationHookEntry>>,
     #[serde(default, rename = "pullBeforeAdd")]
     pub pull_before_add: Option<bool>,
+    #[serde(default, rename = "branchNamePattern")]
+    pub branch_name_pattern: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/task_executor.rs
+++ b/src-tauri/src/task_executor.rs
@@ -75,7 +75,15 @@ request and repositories, and perform appropriate worktree operations.
 - agent_worktree: Launch an AI agent on the worktree's terminal with the given prompt. The worktree must already exist (either pre-existing or created via add_worktree).
 - When you want to add a NEW worktree and launch an agent, output BOTH add_worktree and agent_worktree as separate entries in the code array, in order.
 - When targeting an EXISTING worktree, output only agent_worktree (no add_worktree needed).
-- When no specific branch name is provided, branch names for new worktrees should follow the pattern "worktree/{descriptive-name}".
+- When no specific branch name is provided by the user, generate the branch name from the
+  target repository's branch name pattern:
+  - Each repository in the repository list may include a "branch pattern" (shown as
+    "(branch pattern: ...)" in the embedded list, or the "branchNamePattern" field from
+    oretachi_list_repository). Use the pattern of the repository the task is assigned to.
+  - In the pattern, replace the "<task>" placeholder with a short descriptive name for the task.
+  - "{a|b|c}" means choose exactly ONE of the listed options that best fits the task
+    (e.g. for "{feature|fix}/<task>", use "fix/..." for a bug fix and "feature/..." for a new feature).
+  - If the target repository has NO branch pattern, default to "worktree/<descriptive-name>".
 - Repository names must match exactly what is in the repository list.
 
 ## User Request
@@ -117,10 +125,19 @@ fn build_repo_list_text(settings: &crate::settings::AppSettings) -> String {
                     Some(format!("{}={}", name, url))
                 })
                 .collect();
+            let pattern_suffix = match repo.branch_name_pattern.as_deref() {
+                Some(p) if !p.trim().is_empty() => format!(" (branch pattern: {})", p.trim()),
+                _ => String::new(),
+            };
             if remote_strs.is_empty() {
-                format!("- {} (no remotes)", repo.name)
+                format!("- {} (no remotes){}", repo.name, pattern_suffix)
             } else {
-                format!("- {} (remotes: {})", repo.name, remote_strs.join(", "))
+                format!(
+                    "- {} (remotes: {}){}",
+                    repo.name,
+                    remote_strs.join(", "),
+                    pattern_suffix
+                )
             }
         })
         .collect();

--- a/src/components/PostAddSettingsDialog.vue
+++ b/src/components/PostAddSettingsDialog.vue
@@ -30,6 +30,11 @@ const pmArgs = ref<string>(props.currentPackageManagerArgs ?? "");
 const pullBeforeAdd = ref<boolean>(props.currentPullBeforeAdd ?? false);
 const branchNamePattern = ref<string>(props.currentBranchNamePattern ?? "");
 
+// ブランチ名パターンの構文例。i18n メッセージに含めると <task> が HTML、{...} が
+// vue-i18n の補間として解釈されてしまうため、静的なバインド文字列として表示する。
+const BRANCH_PATTERN_PLACEHOLDER = "worktree/<task>";
+const BRANCH_PATTERN_EXAMPLES = ["worktree/<task>", "{feature|fix}/<task>"];
+
 const ALL_PMS = ["npm", "pnpm", "yarn", "bun"];
 
 const HOOK_EVENTS = ["Stop", "Notification", "SubagentStop", "PreToolUse", "PostToolUse", "PermissionRequest"] as const;
@@ -123,9 +128,14 @@ function onConfirm() {
             class="branch-pattern-input"
             type="text"
             v-model="branchNamePattern"
-            :placeholder="t('addOptions.branchPatternPlaceholder')"
+            :placeholder="BRANCH_PATTERN_PLACEHOLDER"
           />
-          <p class="section-description">{{ t("addOptions.branchPatternHint") }}</p>
+          <p class="section-description">
+            {{ t("addOptions.branchPatternHint") }}
+            <span class="branch-pattern-examples">
+              <code v-for="ex in BRANCH_PATTERN_EXAMPLES" :key="ex">{{ ex }}</code>
+            </span>
+          </p>
         </div>
       </div>
 
@@ -365,6 +375,23 @@ function onConfirm() {
   border-color: #cba6f7;
 }
 
+.branch-pattern-examples {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-left: 4px;
+}
+
+.branch-pattern-examples code {
+  background: #313244;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 11px;
+  font-family: monospace;
+  color: #cdd6f4;
+}
+
 .list-header {
   display: flex;
   gap: 8px;
@@ -534,8 +561,7 @@ function onConfirm() {
       "sectionLabel": "Add options",
       "pullBeforeAdd": "Run git pull (or fetch) before adding worktree",
       "branchPatternLabel": "Branch name pattern",
-      "branchPatternPlaceholder": "worktree/<task>",
-      "branchPatternHint": "Pattern used when adding a task. <task> is replaced with a descriptive name; {a|b} lets the AI pick the best fit (e.g. {feature|fix}/<task>). Leave empty for worktree/<task>."
+      "branchPatternHint": "Pattern for the branch name created when adding a task. The task placeholder is replaced with a descriptive name, and a choice group lets the AI pick the best fit. Leave empty to use the default. Examples:"
     },
     "pkgManager": {
       "sectionLabel": "Package install",
@@ -566,8 +592,7 @@ function onConfirm() {
       "sectionLabel": "追加オプション",
       "pullBeforeAdd": "ワークツリー追加前に git pull / fetch を実行する",
       "branchPatternLabel": "ブランチ名パターン",
-      "branchPatternPlaceholder": "worktree/<task>",
-      "branchPatternHint": "タスク追加時に使うブランチ名パターン。<task> は説明的な名前に置換され、{a|b} は AI がタスク内容に応じて最適な方を選びます（例: {feature|fix}/<task>）。未記入なら worktree/<task> になります。"
+      "branchPatternHint": "タスク追加時に作成されるブランチ名のパターン。タスクのプレースホルダは説明的な名前に置換され、選択肢グループは AI がタスク内容に応じて最適な方を選びます。未記入なら既定値を使います。例:"
     },
     "pkgManager": {
       "sectionLabel": "パッケージインストール",

--- a/src/components/PostAddSettingsDialog.vue
+++ b/src/components/PostAddSettingsDialog.vue
@@ -11,10 +11,11 @@ const props = defineProps<{
   currentPackageManagerArgs?: string;
   currentNotificationHooks?: NotificationHookEntry[];
   currentPullBeforeAdd?: boolean;
+  currentBranchNamePattern?: string;
 }>();
 
 const emit = defineEmits<{
-  confirm: [targets: string[], packageManager: string | undefined, packageManagerArgs: string | undefined, notificationHooks: NotificationHookEntry[], pullBeforeAdd: boolean];
+  confirm: [targets: string[], packageManager: string | undefined, packageManagerArgs: string | undefined, notificationHooks: NotificationHookEntry[], pullBeforeAdd: boolean, branchNamePattern: string | undefined];
   cancel: [];
 }>();
 
@@ -27,6 +28,7 @@ const detectedPMs = ref<string[]>([]);
 const selectedPM = ref<string | undefined>(props.currentPackageManager);
 const pmArgs = ref<string>(props.currentPackageManagerArgs ?? "");
 const pullBeforeAdd = ref<boolean>(props.currentPullBeforeAdd ?? false);
+const branchNamePattern = ref<string>(props.currentBranchNamePattern ?? "");
 
 const ALL_PMS = ["npm", "pnpm", "yarn", "bun"];
 
@@ -99,7 +101,7 @@ function onConfirm() {
       hooks.push({ event: ev as NotificationHookEntry["event"], kind: state.kind as NotificationHookEntry["kind"] });
     }
   }
-  emit("confirm", Array.from(selected.value), selectedPM.value || undefined, pmArgs.value.trim() || undefined, hooks, pullBeforeAdd.value);
+  emit("confirm", Array.from(selected.value), selectedPM.value || undefined, pmArgs.value.trim() || undefined, hooks, pullBeforeAdd.value, branchNamePattern.value.trim() || undefined);
 }
 </script>
 
@@ -115,6 +117,16 @@ function onConfirm() {
           <input type="checkbox" v-model="pullBeforeAdd" />
           <span class="entry-text">{{ t("addOptions.pullBeforeAdd") }}</span>
         </label>
+        <div class="branch-pattern-row">
+          <span class="branch-pattern-label">{{ t("addOptions.branchPatternLabel") }}</span>
+          <input
+            class="branch-pattern-input"
+            type="text"
+            v-model="branchNamePattern"
+            :placeholder="t('addOptions.branchPatternPlaceholder')"
+          />
+          <p class="section-description">{{ t("addOptions.branchPatternHint") }}</p>
+        </div>
       </div>
 
       <!-- パッケージマネージャーセクション -->
@@ -326,6 +338,33 @@ function onConfirm() {
   border-color: #cba6f7;
 }
 
+.branch-pattern-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.branch-pattern-label {
+  font-size: 11px;
+  color: #6c7086;
+}
+
+.branch-pattern-input {
+  background: #313244;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 12px;
+  color: #cdd6f4;
+  outline: none;
+  font-family: monospace;
+}
+
+.branch-pattern-input:focus {
+  border-color: #cba6f7;
+}
+
 .list-header {
   display: flex;
   gap: 8px;
@@ -493,7 +532,10 @@ function onConfirm() {
     "title": "Worktree settings",
     "addOptions": {
       "sectionLabel": "Add options",
-      "pullBeforeAdd": "Run git pull (or fetch) before adding worktree"
+      "pullBeforeAdd": "Run git pull (or fetch) before adding worktree",
+      "branchPatternLabel": "Branch name pattern",
+      "branchPatternPlaceholder": "worktree/<task>",
+      "branchPatternHint": "Pattern used when adding a task. <task> is replaced with a descriptive name; {a|b} lets the AI pick the best fit (e.g. {feature|fix}/<task>). Leave empty for worktree/<task>."
     },
     "pkgManager": {
       "sectionLabel": "Package install",
@@ -522,7 +564,10 @@ function onConfirm() {
     "title": "追加設定",
     "addOptions": {
       "sectionLabel": "追加オプション",
-      "pullBeforeAdd": "ワークツリー追加前に git pull / fetch を実行する"
+      "pullBeforeAdd": "ワークツリー追加前に git pull / fetch を実行する",
+      "branchPatternLabel": "ブランチ名パターン",
+      "branchPatternPlaceholder": "worktree/<task>",
+      "branchPatternHint": "タスク追加時に使うブランチ名パターン。<task> は説明的な名前に置換され、{a|b} は AI がタスク内容に応じて最適な方を選びます（例: {feature|fix}/<task>）。未記入なら worktree/<task> になります。"
     },
     "pkgManager": {
       "sectionLabel": "パッケージインストール",

--- a/src/components/settings/SettingsRepositoriesSection.vue
+++ b/src/components/settings/SettingsRepositoriesSection.vue
@@ -16,6 +16,7 @@ const {
   copyDialogCurrentPMArgs,
   copyDialogCurrentHooks,
   copyDialogCurrentPullBeforeAdd,
+  copyDialogCurrentBranchNamePattern,
   openCopyDialog,
   onDialogConfirm,
 } = usePostAddSettings();
@@ -148,6 +149,7 @@ function clearExecScript(repoId: string) {
     :current-package-manager-args="copyDialogCurrentPMArgs"
     :current-notification-hooks="copyDialogCurrentHooks"
     :current-pull-before-add="copyDialogCurrentPullBeforeAdd"
+    :current-branch-name-pattern="copyDialogCurrentBranchNamePattern"
     @confirm="onDialogConfirm"
     @cancel="showCopyDialog = false"
   />

--- a/src/composables/usePostAddSettings.ts
+++ b/src/composables/usePostAddSettings.ts
@@ -13,6 +13,7 @@ export function usePostAddSettings() {
   const copyDialogCurrentPMArgs = ref<string | undefined>(undefined);
   const copyDialogCurrentHooks = ref<NotificationHookEntry[]>([]);
   const copyDialogCurrentPullBeforeAdd = ref<boolean>(false);
+  const copyDialogCurrentBranchNamePattern = ref<string | undefined>(undefined);
 
   function openCopyDialog(repoId: string) {
     const repo = settings.value.repositories.find((r) => r.id === repoId);
@@ -24,6 +25,7 @@ export function usePostAddSettings() {
     copyDialogCurrentPMArgs.value = repo.packageManagerArgs;
     copyDialogCurrentHooks.value = repo.notificationHooks ?? [];
     copyDialogCurrentPullBeforeAdd.value = repo.pullBeforeAdd ?? false;
+    copyDialogCurrentBranchNamePattern.value = repo.branchNamePattern;
     showCopyDialog.value = true;
   }
 
@@ -33,6 +35,7 @@ export function usePostAddSettings() {
     packageManagerArgs: string | undefined,
     notificationHooks: NotificationHookEntry[],
     pullBeforeAdd: boolean,
+    branchNamePattern: string | undefined,
   ) {
     const repo = settings.value.repositories.find((r) => r.id === copyDialogRepoId.value);
     if (!repo) return;
@@ -41,6 +44,7 @@ export function usePostAddSettings() {
     repo.packageManagerArgs = packageManagerArgs || undefined;
     repo.notificationHooks = notificationHooks.length > 0 ? notificationHooks : undefined;
     repo.pullBeforeAdd = pullBeforeAdd || undefined;
+    repo.branchNamePattern = branchNamePattern || undefined;
     scheduleSave();
     showCopyDialog.value = false;
   }
@@ -60,6 +64,7 @@ export function usePostAddSettings() {
     copyDialogCurrentPMArgs,
     copyDialogCurrentHooks,
     copyDialogCurrentPullBeforeAdd,
+    copyDialogCurrentBranchNamePattern,
     openCopyDialog,
     onDialogConfirm,
     clearCopyTargets,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -13,6 +13,7 @@ export interface Repository {
   packageManagerArgs?: string; // install コマンドに追加する引数 (例: --config.node-linker=hoisted)
   notificationHooks?: NotificationHookEntry[]; // Claude Code通知フック設定
   pullBeforeAdd?: boolean; // ワークツリー追加前に git pull を実行するか
+  branchNamePattern?: string; // タスク追加時のブランチ名パターン (例: "{feature|fix}/<task>"、未記入なら "worktree/<task>")
 }
 
 export interface WorktreeEntry {


### PR DESCRIPTION
## 概要

「タスクを追加」からワークツリーを作成する際の新規ブランチ名のパターンを、リポジトリごとに設定可能にしました。設定タブのリポジトリ設定ダイアログ（追加設定）に「ブランチ名パターン」入力欄を追加しています。

## 仕様

- デフォルト（未記入）は従来どおり `worktree/<task>`
- `<task>` は AI が生成する説明的な名前のプレースホルダ
- `{feature|fix}/<task>` のような「選択肢」記法を許可し、AI がタスク内容（バグ修正 / 新機能など）に応じて最適な接頭辞を選択する
- ユーザーがプロンプトで明示的にブランチ名を指定した場合は、従来どおりその名前を優先

## 設計

ブランチ名は元々 AI エージェント（task_executor）がシステムプロンプトのルールに従って生成しているため、パターンをクライアントでテンプレート展開せず、リポジトリ情報と一緒に AI に渡して解釈させる方式を採用しました。

- データモデル: `Repository.branchNamePattern`（TS / Rust 構造体、serde rename）
- 設定 UI: `PostAddSettingsDialog.vue` に入力欄・i18n(en/ja) を追加
- AI への伝達（2 経路）:
  - 非 MCP: `build_repo_list_text` でリポジトリ行に ` (branch pattern: ...)` を付記
  - MCP: `oretachi_list_repository` の JSON に `branchNamePattern` を追加
  - システムプロンプトに `<task>` 置換・`{a|b}` 選択・未設定時 `worktree/<task>` のルールを追記

## 後方互換

`#[serde(default)]` により、既存 `settings.json`（フィールド欠落）は `None` でデシリアライズされます。パターン未設定リポジトリは従来どおり `worktree/<task>`。

## 確認

- `cd src-tauri && cargo check`：通過
- `pnpm run type-check`：通過
- セルフレビュー（security-review / bug-review）：critical / warning なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)