### PR TITLE
feat(tray): トレイポップアップに description 情報バーを追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -869,6 +869,7 @@ async function onTrayButtonClick() {
         hotkeyChar: hotkeyChars.value.get(worktreeId),
         autoApproval: autoApprovalMap.get(worktreeId) ?? false,
         aiJudging: aiJudgingWorktrees.has(worktreeId),
+        description: worktree.description,
       });
     } else {
       // メインウィンドウのターミナル情報を収集
@@ -933,6 +934,7 @@ async function onTrayButtonClick() {
         aiJudging: aiJudgingWorktrees.has(worktreeId),
         autoApprovalPrompt: autoApprovalPromptMap.get(worktreeId) ?? '',
         lastJudgedCommand: lastJudgedCommandMap.get(worktreeId) ?? '',
+        description: worktree.description,
       });
     }
   }

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -142,6 +142,14 @@ async function showWorktree(data: TrayWorktreeData) {
       requestAnimationFrame(() => resolve());
     });
   });
+
+  // 情報バーの高さは横幅依存(line-clamp:2 + word-break)。117行目の初回計測は setSize 前の
+  // 旧横幅で行われるため、横幅が確定した今この時点で再計測して高さを補正する
+  // (新横幅で2行に折り返した場合のターミナルのクリップを防ぐ)。description がある時のみ。
+  if (data.description?.trim()) {
+    await applyWindowSize(data);
+  }
+
   mountTerminalsToHosts();
 
   // 全リーフのアクティブターミナルをリサイズ+リフレッシュ

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -28,6 +28,8 @@ const { getTooltipText: getWorktreeTaskTooltip } = useWorktreeTaskMap();
 const headerRef = ref<HTMLDivElement | null>(null);
 // フッター ref（ウィンドウサイズ補正用）
 const footerRef = ref<HTMLDivElement | null>(null);
+// description 情報バー ref（ウィンドウサイズ補正用）
+const descBarRef = ref<HTMLDivElement | null>(null);
 
 // 全ワークツリーデータ
 const allWorktrees = ref<TrayWorktreeData[]>([]);
@@ -97,8 +99,11 @@ async function applyWindowSize(data: TrayWorktreeData) {
   const zoom = appliedZoom.value;
   const footerH = cssPxToLogical(footerRef.value?.offsetHeight ?? 0, zoom);
   const headerH = data.isDetached ? 0 : cssPxToLogical(headerRef.value?.offsetHeight ?? 0, zoom);
+  // 情報バー(description)分の高さを加算する。トレイはターミナルを縮める権限が無い(no-resize)ため、
+  // コンテンツ領域を削らずウィンドウ外形を伸ばして確保する。description が無ければ 0。
+  const descH = cssPxToLogical(descBarRef.value?.offsetHeight ?? 0, zoom);
   const width = data.windowSize?.width ?? 900;
-  const height = (data.windowSize?.height ?? 600) + footerH + headerH;
+  const height = (data.windowSize?.height ?? 600) + footerH + headerH + descH;
   await win.setSize(new LogicalSize(width, height));
 }
 
@@ -106,6 +111,9 @@ async function showWorktree(data: TrayWorktreeData) {
   terminalEntries.clear();
   terminalRefs.clear();
 
+  // 情報バー(description)が現在の worktree の内容で描画されてから高さを計測する。
+  // currentWorktree (= allWorktrees[currentIndex]) は呼び出し側で更新済みのため nextTick で DOM 反映を待つ。
+  await nextTick();
   await applyWindowSize(data);
 
   for (const t of data.terminals) {
@@ -429,6 +437,18 @@ onUnmounted(() => {
       </div>
     </div>
 
+    <!-- description 情報バー: ある worktree のみ常時表示。高さは applyWindowSize に加算され、
+         ターミナル領域は削られない（トレイは no-resize でターミナルを縮める権限が無いため） -->
+    <div
+      v-if="currentWorktree?.description?.trim()"
+      ref="descBarRef"
+      class="shrink-0 px-4 py-1.5 border-b border-[#313244] text-[11px] leading-relaxed text-[#a6adc8] tray-desc-bar"
+      style="background-color: var(--bg-mantle-translucent)"
+      :title="currentWorktree.description"
+    >
+      {{ currentWorktree.description }}
+    </div>
+
     <!-- コンテンツ -->
     <div class="flex-1 min-h-0 overflow-hidden">
       <div v-if="!initialized" class="flex items-center justify-center h-full text-[#6c7086] text-sm">
@@ -543,3 +563,14 @@ onUnmounted(() => {
   }
 }
 </i18n>
+
+<style scoped>
+/* description 情報バー: 最大2行クランプ（WorktreeCard の .card-desc-inner に準拠） */
+.tray-desc-bar {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+</style>

--- a/src/composables/useTrayPopup.ts
+++ b/src/composables/useTrayPopup.ts
@@ -25,6 +25,7 @@ export interface TrayWorktreeData {
   aiJudging: boolean;
   autoApprovalPrompt?: string;
   lastJudgedCommand?: string;
+  description?: string; // ホーム画面と同じ AI 生成説明。トレイの情報バーに表示
 }
 
 let trayWindow: WebviewWindow | null = null;


### PR DESCRIPTION
## 概要
ホーム画面（WorktreeCard）で表示している AI 生成の worktree `description` を、トレイポップアップでも**操作不要で常時表示**する。ヘッダーとターミナルの間に、最大2行クランプの情報バーとして差し込む。

## 背景・設計判断
トレイは TerminalView を `:no-resize=true` で描画しており、ターミナルをソース（メイン/サブウィンドウ）の PTY の固定 cols/rows でミラーするだけで**サイズを変更する権限を持たない**。コンテンツ領域を情報バーで削るとターミナルがクリップされてしまう。

そこで情報バーの高さを `applyWindowSize` に加算し、**ウィンドウ外形を縦に伸ばして確保**する（ターミナル領域は不変）。`description` が無い worktree では情報バーは描画されず従来の高さを保つ。「次へ」で あり/なし を行き来するとその分だけ高さが変わるが、これは構造上不可避で許容済み（`setSize` は左上固定で下方向に伸縮）。

## 変更内容
- `useTrayPopup.ts`: `TrayWorktreeData` に `description?: string` を追加
- `App.vue`: トレイデータ生成2箇所（detached / main window）に `description` を渡す
- `TrayPopupApp.vue`:
  - ヘッダー直下に `v-if=currentWorktree?.description?.trim()` の情報バー（`{{ }}` でエスケープ表示・`:title` で全文・2行クランプ）
  - `applyWindowSize` に情報バー高さ `descH` を加算
  - 計測タイミング: `nextTick` 後に計測。さらに**横幅確定後に再計測して高さを補正**（line-clamp の高さは横幅依存のため、初回 900px 等の旧横幅で計測した値が折り返しでクリップを起こす問題を修正）

## レビュー
- セキュリティレビュー: 新規の脆弱性なし（`{{ }}` / 属性バインドで自動エスケープ、`v-html` 不使用）
- バグレビュー: 横幅確定前計測の Warning を検出 → コミット `69c9f64` で修正済み

## 確認方法
`pnpm run type-check` 通過。`pnpm run tauri dev` で description あり/なしの worktree を含む通知を出し、情報バー表示・ターミナル非クリップ・「次へ」遷移時の高さ変動を目視確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)