### PR TITLE
fix(terminal): ホーム画面からのターミナル追加の孤児化・タブ不整合・背景ペイン混入を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -504,7 +504,7 @@ function getOrCreateBackgroundLeafId(bundle: WorktreeFrameBundle): string {
 function addTerminalToFrameBundle(bundle: WorktreeFrameBundle, terminalId: number, background: boolean): string {
   const targetLeafId = background
     ? getOrCreateBackgroundLeafId(bundle)
-    : bundle.frame.resolveLeafId(bundle.frame.lastFocusedLeafId.value);
+    : bundle.frame.resolveLeafId(bundle.frame.lastFocusedLeafId.value, { foregroundOnly: true });
 
   if (targetLeafId) {
     bundle.frame.returnAllToOffscreen();

--- a/src/App.vue
+++ b/src/App.vue
@@ -407,7 +407,20 @@ async function switchToTerminal(terminalId: number) {
 
   const bundle = worktreeFrameBundles.get(worktreeId);
   if (bundle) {
-    const leaf = bundle.frame.getAllLeafs().find((l) => l.terminalIds.includes(terminalId));
+    const terminal = worktrees.value
+      .find((w) => w.id === worktreeId)
+      ?.terminals.find((t) => t.id === terminalId);
+    if (terminal && !bundle.terminalEntries.has(terminalId)) {
+      bundle.terminalEntries.set(terminalId, { id: terminal.id, title: terminal.title, sessionId: 0, snapshot: "" });
+    }
+
+    let leaf = bundle.frame.getAllLeafs().find((l) => l.terminalIds.includes(terminalId));
+    if (!leaf && terminal) {
+      const recoveredLeafId = addTerminalToFrameBundle(bundle, terminalId, false);
+      leaf = bundle.frame.getAllLeafs().find((l) => l.id === recoveredLeafId);
+      logDebug(`[Terminal] switchToTerminal recovered missing leaf terminalId=${terminalId} leafId=${recoveredLeafId || "null"}`);
+    }
+
     if (leaf) {
       bundle.frame.setActiveTerminal(leaf.id, terminalId);
       bundle.frame.lastFocusedLeafId.value = leaf.id;
@@ -488,6 +501,27 @@ function getOrCreateBackgroundLeafId(bundle: WorktreeFrameBundle): string {
   return newLeaf.id;
 }
 
+function addTerminalToFrameBundle(bundle: WorktreeFrameBundle, terminalId: number, background: boolean): string {
+  const targetLeafId = background
+    ? getOrCreateBackgroundLeafId(bundle)
+    : bundle.frame.resolveLeafId(bundle.frame.lastFocusedLeafId.value);
+
+  if (targetLeafId) {
+    bundle.frame.returnAllToOffscreen();
+    bundle.frame.addTerminalToLeaf(targetLeafId, terminalId);
+    if (!background) {
+      bundle.frame.lastFocusedLeafId.value = targetLeafId;
+    }
+  } else {
+    bundle.frame.initLayout([terminalId]);
+    const createdLeafId = bundle.frame.getAllLeafs()[0]?.id ?? "";
+    bundle.frame.lastFocusedLeafId.value = createdLeafId;
+    return createdLeafId;
+  }
+
+  return targetLeafId;
+}
+
 async function onAddTerminal(
   worktreeId: string,
   options?: { background?: boolean; pendingCommand?: string },
@@ -518,20 +552,8 @@ async function onAddTerminal(
   const bundle = worktreeFrameBundles.get(worktreeId)!;
   bundle.terminalEntries.set(terminal.id, { id: terminal.id, title: terminal.title, sessionId: 0, snapshot: "" });
 
-  const targetLeafId = background
-    ? getOrCreateBackgroundLeafId(bundle)
-    : (bundle.frame.lastFocusedLeafId.value || bundle.frame.getAllLeafs()[0]?.id);
+  const targetLeafId = addTerminalToFrameBundle(bundle, terminal.id, background);
   logDebug(`[Terminal] onAddTerminal leafId=${targetLeafId ?? "null"} terminalId=${terminal.id}`);
-  if (targetLeafId) {
-    bundle.frame.returnAllToOffscreen();
-    bundle.frame.addTerminalToLeaf(targetLeafId, terminal.id);
-    if (!background) {
-      bundle.frame.lastFocusedLeafId.value = targetLeafId;
-    }
-  } else {
-    bundle.frame.initLayout([terminal.id]);
-    bundle.frame.lastFocusedLeafId.value = bundle.frame.getAllLeafs()[0]?.id ?? "";
-  }
 
   if (!background) {
     viewMode.value = "terminal";

--- a/src/SubWindowApp.vue
+++ b/src/SubWindowApp.vue
@@ -119,6 +119,7 @@ const {
   closeActiveTerminal,
   closeTerminal,
   handleTerminalExit,
+  resolveLeafId,
   onSplitRequest,
   onTabDrop,
   onTabEdgeDrop,
@@ -345,7 +346,7 @@ onMounted(async () => {
       terminalEntries.set(terminalId, { id: terminalId, title, sessionId, snapshot: "" });
 
       // lastFocusedLeafId のリーフに追加（なければ root リーフに）
-      const targetLeafId = lastFocusedLeafId.value || getFirstLeafId();
+      const targetLeafId = resolveLeafId(lastFocusedLeafId.value) || getFirstLeafId();
       addTerminalToLeaf(targetLeafId, terminalId);
       lastFocusedLeafId.value = targetLeafId;
 

--- a/src/composables/useWorktreeFrame.ts
+++ b/src/composables/useWorktreeFrame.ts
@@ -44,8 +44,13 @@ export function useWorktreeFrame(options: {
     return getAllLeafs().filter((l) => l.terminalIds.length > 0);
   }
 
-  function resolveLeafId(preferredLeafId?: string | null): string {
-    const leafs = getAllLeafs();
+  function resolveLeafId(
+    preferredLeafId?: string | null,
+    options?: { foregroundOnly?: boolean }
+  ): string {
+    const leafs = options?.foregroundOnly
+      ? getAllLeafs().filter((l) => !l.isBackground)
+      : getAllLeafs();
     if (preferredLeafId && leafs.some((l) => l.id === preferredLeafId)) {
       return preferredLeafId;
     }

--- a/src/composables/useWorktreeFrame.ts
+++ b/src/composables/useWorktreeFrame.ts
@@ -44,6 +44,20 @@ export function useWorktreeFrame(options: {
     return getAllLeafs().filter((l) => l.terminalIds.length > 0);
   }
 
+  function resolveLeafId(preferredLeafId?: string | null): string {
+    const leafs = getAllLeafs();
+    if (preferredLeafId && leafs.some((l) => l.id === preferredLeafId)) {
+      return preferredLeafId;
+    }
+    return leafs[0]?.id ?? "";
+  }
+
+  function normalizeLastFocusedLeaf(): string {
+    const leafId = resolveLeafId(lastFocusedLeafId.value);
+    lastFocusedLeafId.value = leafId;
+    return leafId;
+  }
+
   async function switchTerminal(leafId: string, terminalId: number) {
     setActiveTerminal(leafId, terminalId);
     lastFocusedLeafId.value = leafId;
@@ -75,6 +89,7 @@ export function useWorktreeFrame(options: {
     terminalEntries.delete(terminalId);
     removeTerminalFromLeaf(leafId, terminalId);
     pruneTree();
+    normalizeLastFocusedLeaf();
 
     if (onTerminalClosed) {
       await onTerminalClosed(terminalId);
@@ -122,7 +137,7 @@ export function useWorktreeFrame(options: {
    * lastFocusedLeafId を更新せずフォアグラウンドのフォーカスを維持する。
    */
   function addBackgroundLeaf(direction: "left" | "right" | "top" | "bottom"): FrameLeaf {
-    const targetLeafId = lastFocusedLeafId.value || getAllLeafs()[0]?.id || "";
+    const targetLeafId = normalizeLastFocusedLeaf();
     return splitLeaf(targetLeafId, direction, [], true);
   }
 
@@ -182,7 +197,7 @@ export function useWorktreeFrame(options: {
   }
 
   function switchNextTerminal() {
-    const leafId = lastFocusedLeafId.value;
+    const leafId = normalizeLastFocusedLeaf();
     if (!leafId) return;
     const leaf = getLeafsWithTerminals().find((l) => l.id === leafId);
     if (!leaf || leaf.terminalIds.length === 0) return;
@@ -192,7 +207,7 @@ export function useWorktreeFrame(options: {
   }
 
   function switchPrevTerminal() {
-    const leafId = lastFocusedLeafId.value;
+    const leafId = normalizeLastFocusedLeaf();
     if (!leafId) return;
     const leaf = getLeafsWithTerminals().find((l) => l.id === leafId);
     if (!leaf || leaf.terminalIds.length === 0) return;
@@ -202,7 +217,7 @@ export function useWorktreeFrame(options: {
   }
 
   function closeActiveTerminal() {
-    const leafId = lastFocusedLeafId.value;
+    const leafId = normalizeLastFocusedLeaf();
     if (!leafId) return;
     const leaf = getLeafsWithTerminals().find((l) => l.id === leafId);
     if (leaf?.activeTerminalId != null) {
@@ -216,6 +231,8 @@ export function useWorktreeFrame(options: {
     addTerminalToLeaf,
     setActiveTerminal,
     lastFocusedLeafId,
+    resolveLeafId,
+    normalizeLastFocusedLeaf,
     setTerminalRef,
     returnAllToOffscreen,
     mountTerminalsToHosts,

--- a/src/composables/useWorktreeFrameBundles.ts
+++ b/src/composables/useWorktreeFrameBundles.ts
@@ -89,7 +89,7 @@ export function useWorktreeFrameBundles(options: {
       const existingLeaf = bundle.frame.getAllLeafs().find((l) => l.terminalIds.includes(terminal.id));
       if (existingLeaf) continue;
 
-      const targetLeafId = bundle.frame.resolveLeafId(bundle.frame.lastFocusedLeafId.value);
+      const targetLeafId = bundle.frame.resolveLeafId(bundle.frame.lastFocusedLeafId.value, { foregroundOnly: true });
       if (targetLeafId) {
         bundle.frame.addTerminalToLeaf(targetLeafId, terminal.id);
         bundle.frame.lastFocusedLeafId.value = targetLeafId;

--- a/src/composables/useWorktreeFrameBundles.ts
+++ b/src/composables/useWorktreeFrameBundles.ts
@@ -76,6 +76,30 @@ export function useWorktreeFrameBundles(options: {
     bundles.set(worktreeId, { frame, terminalEntries: entries, terminalRefs: refs });
   }
 
+  function syncWorktreeTerminalsToFrame(worktreeId: string, bundle: WorktreeFrameBundle) {
+    const wt = worktrees.value.find((w) => w.id === worktreeId);
+    if (!wt) return;
+
+    for (const terminal of wt.terminals) {
+      terminalWorktreeMap.set(terminal.id, worktreeId);
+      if (!bundle.terminalEntries.has(terminal.id)) {
+        bundle.terminalEntries.set(terminal.id, { id: terminal.id, title: terminal.title, sessionId: 0, snapshot: "" });
+      }
+
+      const existingLeaf = bundle.frame.getAllLeafs().find((l) => l.terminalIds.includes(terminal.id));
+      if (existingLeaf) continue;
+
+      const targetLeafId = bundle.frame.resolveLeafId(bundle.frame.lastFocusedLeafId.value);
+      if (targetLeafId) {
+        bundle.frame.addTerminalToLeaf(targetLeafId, terminal.id);
+        bundle.frame.lastFocusedLeafId.value = targetLeafId;
+      } else {
+        bundle.frame.initLayout([terminal.id]);
+        bundle.frame.lastFocusedLeafId.value = bundle.frame.getAllLeafs()[0]?.id ?? "";
+      }
+    }
+  }
+
   function getTerminalRef(terminalId: number): InstanceType<typeof TerminalView> | undefined {
     const wid = terminalWorktreeMap.get(terminalId);
     if (!wid) return undefined;
@@ -89,6 +113,8 @@ export function useWorktreeFrameBundles(options: {
     await nextTick();
     const bundle = bundles.get(worktreeId);
     if (bundle) {
+      syncWorktreeTerminalsToFrame(worktreeId, bundle);
+      await nextTick();
       bundle.frame.mountTerminalsToHosts();
       const leafs = bundle.frame.getLeafsWithTerminals();
       if (leafs.length > 0) {


### PR DESCRIPTION
## 概要

ホーム画面の「ターミナル追加」ボタンから追加したターミナルが、ワークツリータブに表示されず・アクセスできなくなる不具合を修正します。あわせてレビューで見つかった隣接する背景ペイン混入バグも修正します。

## 不具合

ホーム画面で追加 → ワークツリータブに遷移するもターミナルが表示されない／タブも出ない。ホーム画面ではターミナルは追加済み扱い（カウント増加）だが、アクセス手段がない。その後ワークツリータブ側の追加ボタンでは正常に追加でき、結果ホーム2個・タブ1個というカウント不整合が起きていた。

### 根本原因

`lastFocusedLeafId` がターミナルクローズ後の `pruneTree()` 等で**実在しないリーフID（stale）**を保持していると、旧コードの `lastFocusedLeafId.value || getAllLeafs()[0]?.id` は空文字でないためフォールバックせず、`addTerminalToLeaf(staleId, ...)` がツリー上に該当リーフを見つけられず黙って失敗していた。結果 `terminalEntries`（ホームのカウント源）には登録されるがフレームツリーには入らず、孤児ターミナルが発生していた。

## 修正内容

- `resolveLeafId` / `normalizeLastFocusedLeaf` を追加し、stale な leaf ID を実在リーフへフォールバック（追加・close・切替の各経路に適用）
- `switchToTerminal` にリーフ欠落ターミナルの再アタッチ復旧を追加し、既存の孤児にもアクセス可能化
- `switchToWorktree` で `syncWorktreeTerminalsToFrame` を実行し、モデル上のターミナルをフレームへ照合・再アタッチしてカウント不整合を解消
- `addTerminalToFrameBundle` の `initLayout` 分岐で実際に生成した leaf ID を返すよう修正
- `resolveLeafId` に `foregroundOnly` オプションを追加し、フォアグラウンド追加時は `isBackground` リーフを候補から除外（background spawn で唯一のリーフが背景化された後、通常タブが背景ペインに紛れ込む既存バグの修正）

## 確認

- `pnpm run type-check`（vue-tsc）クリーン通過
- bug-review 実施済み: Critical 0件。検出された Warning（背景ペイン混入）は本PRで修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)