### PR TITLE
feat(diagnostics): メインスレッドハングの真因捕捉計装

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3586,6 +3586,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "webview2-com",
  "windows 0.58.0",
  "windows-sys 0.59.0",
  "windows-version",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,10 @@ libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
+# WebView2 ネイティブ診断イベント (ProcessFailed / NewBrowserVersionAvailable) 購読用。
+# wry 0.54 / tauri 2.9 が使う版に合わせる (windows 0.61 系・PlatformWebview の controller()/environment() と同一型)。
+webview2-com = "0.38"
 windows = { version = "0.58", features = ["Win32_UI_Shell", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp"] }
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm", "Win32_System_Environment", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm", "Win32_System_Environment", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug", "Win32_Storage_FileSystem", "Win32_System_Kernel", "Win32_System_Memory"] }
 windows-version = "0.1"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
 # WebView2 ネイティブ診断イベント (ProcessFailed / NewBrowserVersionAvailable) 購読用。
-# wry 0.54 / tauri 2.9 が使う版に合わせる (windows 0.61 系・PlatformWebview の controller()/environment() と同一型)。
+# wry 0.54 / tauri 2.10 が使う版に合わせる (windows 0.61 系・PlatformWebview の controller()/environment() と同一型)。
 webview2-com = "0.38"
 windows = { version = "0.58", features = ["Win32_UI_Shell", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp"] }
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm", "Win32_System_Environment", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug", "Win32_Storage_FileSystem", "Win32_System_Kernel", "Win32_System_Memory"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod claude_plugin_skills;
 mod fs_watcher;
 mod git_worktree;
 mod ide_launcher;
+mod main_thread_watch;
 pub mod mcp_server;
 mod process_utils;
 mod pty_manager;
@@ -76,6 +77,7 @@ async fn pty_spawn(
 // キー入力の順序が保証される (async 化すると並列実行で順序が壊れうる)。
 #[tauri::command]
 fn pty_write(state: State<PtyManager>, session_id: u32, data: Vec<u8>) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::PtyWrite);
     state.write(session_id, data)
 }
 
@@ -106,6 +108,7 @@ fn pty_set_ai_agent(
     session_id: u32,
     is_agent: bool,
 ) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::PtySetAiAgent);
     state.set_ai_agent(session_id, is_agent)?;
     let mut sessions = std::collections::HashMap::new();
     sessions.insert(session_id, pty_manager::AiAgentInfo {
@@ -119,6 +122,7 @@ fn pty_set_ai_agent(
 
 #[tauri::command]
 fn pty_is_ai_agent(state: State<PtyManager>, session_id: u32) -> Result<bool, String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::PtyIsAiAgent);
     state.is_ai_agent(session_id)
 }
 
@@ -126,16 +130,19 @@ fn pty_is_ai_agent(state: State<PtyManager>, session_id: u32) -> Result<bool, St
 
 #[tauri::command]
 fn get_settings(state: State<SettingsManager>) -> AppSettings {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::GetSettings);
     state.get()
 }
 
 #[tauri::command]
 fn save_settings(state: State<SettingsManager>, settings: AppSettings) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::SaveSettings);
     state.save(settings)
 }
 
 #[tauri::command]
 fn apply_acrylic_effect(app_handle: tauri::AppHandle, r: u8, g: u8, b: u8, a: u8) {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::ApplyAcrylic);
     #[cfg(target_os = "windows")]
     {
         for (_, window) in app_handle.webview_windows() {
@@ -426,16 +433,19 @@ async fn git_commit(repo_path: String, message: String) -> Result<String, String
 
 #[tauri::command]
 fn detect_ides() -> Vec<ide_launcher::IdeInfo> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::DetectIdes);
     ide_launcher::detect_ides()
 }
 
 #[tauri::command]
 fn detect_ai_agents() -> Vec<ai_provider::AiAgentInfo> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::DetectAiAgents);
     ai_provider::detect_ai_agents()
 }
 
 #[tauri::command]
 fn open_in_ide(command: String, path: String) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::OpenInIde);
     ide_launcher::open_in_ide(&command, &path)
 }
 
@@ -443,6 +453,7 @@ fn open_in_ide(command: String, path: String) -> Result<(), String> {
 
 #[tauri::command]
 fn regenerate_mcp_api_key(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::RegenerateMcpApiKey);
     let settings_manager = app_handle.state::<SettingsManager>();
     let mut settings = settings_manager.get();
     settings.mcp_api_key = settings::generate_api_key();
@@ -453,6 +464,7 @@ fn regenerate_mcp_api_key(app_handle: tauri::AppHandle) -> Result<String, String
 
 #[tauri::command]
 fn get_mcp_status(state: State<mcp_server::McpServerManager>) -> mcp_server::McpStatus {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::GetMcpStatus);
     state.get_status()
 }
 
@@ -617,6 +629,7 @@ async fn delete_task(
 
 #[tauri::command]
 fn path_exists(path: String) -> bool {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::PathExists);
     std::path::Path::new(&path).exists()
 }
 
@@ -642,6 +655,7 @@ fn notify_worktree_archived(
     name: String,
     branch_name: String,
 ) {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::NotifyWorktreeArchived);
     let _ = app_handle.emit("worktree-archived", serde_json::json!({
         "id": id,
         "name": name,
@@ -658,6 +672,7 @@ fn notify_worktree_added(
     name: String,
     branch_name: String,
 ) {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::NotifyWorktreeAdded);
     let _ = app_handle.emit("worktree-added", serde_json::json!({
         "id": id,
         "name": name,
@@ -698,11 +713,13 @@ fn start_fs_watch(
     worktree_id: String,
     worktree_path: String,
 ) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::StartFsWatch);
     state.start_watching(app_handle, worktree_id, worktree_path)
 }
 
 #[tauri::command]
 fn stop_fs_watch(state: State<FsWatcherManager>, worktree_id: String) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::StopFsWatch);
     state.stop_watching(&worktree_id)
 }
 
@@ -714,6 +731,7 @@ fn is_mcp_enabled() -> bool {
 
 #[tauri::command]
 fn set_debug_mode(enabled: bool) {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::SetDebugMode);
     if enabled {
         log::set_max_level(log::LevelFilter::Debug);
     } else {
@@ -724,6 +742,7 @@ fn set_debug_mode(enabled: bool) {
 
 #[tauri::command]
 fn get_debug_mode() -> bool {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::GetDebugMode);
     log::max_level() >= log::LevelFilter::Debug
 }
 
@@ -733,9 +752,69 @@ fn get_debug_mode() -> bool {
 /// インストール済みアプリでは .env* が存在しないため実質常に false になる。
 #[tauri::command]
 fn get_force_wizard() -> bool {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::GetForceWizard);
     std::env::var("ORETACHI_FORCE_WIZARD")
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false)
+}
+
+/// メインウィンドウの WebView2 にネイティブ診断イベントを登録する (Windows 限定)。
+///
+/// - `ProcessFailed`: browser/renderer プロセス破綻を ERROR ログ。完全アイドル中のフリーズ
+///   (WebView2Feedback #4141: idle 時 browser プロセス破綻) を **アプリ側ログに初めて残す** 決定打。
+/// - `NewBrowserVersionAvailable`: WebView2 ランタイム自動更新検知を WARN ログ。更新→破綻仮説の裏付け/反証用。
+///
+/// 失敗してもアプリ動作には影響させない (ログのみ)。**回復処理は一切行わない** (記録に徹する)。
+#[cfg(target_os = "windows")]
+fn subscribe_webview2_diagnostics(window: &tauri::WebviewWindow) {
+    use webview2_com::Microsoft::Web::WebView2::Win32::{
+        ICoreWebView2ProcessFailedEventArgs, COREWEBVIEW2_PROCESS_FAILED_KIND,
+    };
+    use webview2_com::{NewBrowserVersionAvailableEventHandler, ProcessFailedEventHandler};
+
+    let result = window.with_webview(|webview| unsafe {
+        // ProcessFailed は ICoreWebView2 直下のイベント。
+        match webview.controller().CoreWebView2() {
+            Ok(core) => {
+                let handler = ProcessFailedEventHandler::create(Box::new(
+                    |_sender, args: Option<ICoreWebView2ProcessFailedEventArgs>| {
+                        let mut kind = COREWEBVIEW2_PROCESS_FAILED_KIND(-1);
+                        if let Some(a) = args.as_ref() {
+                            let _ = a.ProcessFailedKind(&mut kind);
+                        }
+                        log::error!(
+                            "[webview2] ProcessFailed kind={} (browser/renderer プロセス破綻; アイドル時フリーズの疑い WebView2Feedback#4141)",
+                            kind.0
+                        );
+                        Ok(())
+                    },
+                ));
+                let mut token: i64 = 0;
+                if let Err(e) = core.add_ProcessFailed(&handler, &mut token) {
+                    log::warn!("[webview2] add_ProcessFailed failed: {}", e);
+                } else {
+                    log::info!("[webview2] ProcessFailed ハンドラ登録完了");
+                }
+            }
+            Err(e) => log::warn!("[webview2] CoreWebView2() 取得失敗: {}", e),
+        }
+
+        // NewBrowserVersionAvailable は ICoreWebView2Environment のイベント。
+        let env = webview.environment();
+        let handler = NewBrowserVersionAvailableEventHandler::create(Box::new(|_env, _args| {
+            log::warn!(
+                "[webview2] NewBrowserVersionAvailable: WebView2 ランタイム自動更新を検知 (更新後のアイドル破綻に注意 WebView2Feedback#4141)"
+            );
+            Ok(())
+        }));
+        let mut token: i64 = 0;
+        if let Err(e) = env.add_NewBrowserVersionAvailable(&handler, &mut token) {
+            log::warn!("[webview2] add_NewBrowserVersionAvailable failed: {}", e);
+        }
+    });
+    if let Err(e) = result {
+        log::warn!("[webview2] with_webview failed (診断イベント未登録): {}", e);
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -756,6 +835,9 @@ pub fn run() {
             let _ = SetCurrentProcessExplicitAppUserModelID(&HSTRING::from("com.ia.oretachi"));
         }
     }
+
+    // メインスレッド・ブレッドクラムの単調時計を初期化する (以降の enter() より前に必須)。
+    main_thread_watch::init();
 
     // .env 読み込み（Vite の .env 規約に準拠: 優先度 .{mode}.local > .{mode} > .local > base）
     // builder チェーンより前に読み込む必要があるためここで実施。
@@ -794,6 +876,7 @@ pub fn run() {
             builder = builder.plugin(
                 tauri::plugin::Builder::<tauri::Wry>::new("acrylic-effect")
                     .on_window_ready(move |window| {
+                        let _bc = main_thread_watch::enter(main_thread_watch::Activity::WindowReady);
                         if let Ok(hwnd) = window.hwnd() {
                             acrylic::setup(hwnd.0, r, g, b, a);
                         }
@@ -1378,6 +1461,9 @@ pub fn run() {
                         let ack = main_ack_ms.clone();
                         if watchdog_handle
                             .run_on_main_thread(move || {
+                                let _bc = main_thread_watch::enter(
+                                    main_thread_watch::Activity::WatchdogProbe,
+                                );
                                 ack.store(elapsed_ms(), Ordering::Relaxed);
                             })
                             .is_err()
@@ -1396,14 +1482,35 @@ pub fn run() {
                             }
                             last_blocked_log_ms = 0;
                         } else {
+                            let first_detection = blocked_since.is_none();
                             let since = *blocked_since.get_or_insert(sent);
                             let blocked_secs = elapsed_ms().saturating_sub(since) / 1000;
+                            // ブロック初検知時のみ: UI スレッド ID をログし、プロセス全体の minidump を
+                            // 1 回だけ書き出す。停止中のネイティブスタック (WebView2/wry/tray) を後で解析できる。
+                            if first_detection {
+                                #[cfg(target_os = "windows")]
+                                {
+                                    log::error!(
+                                        "[main-thread-watchdog] UI thread id={} (minidump 内でこのスレッドのスタックを参照)",
+                                        main_thread_watch::ui_thread_id()
+                                    );
+                                    if let Ok(dir) = watchdog_handle.path().app_log_dir() {
+                                        let _ = std::fs::create_dir_all(&dir);
+                                        let path = dir.join(format!("oretachi-hang-{}.dmp", since));
+                                        main_thread_watch::write_hang_minidump_once(path);
+                                    }
+                                }
+                            }
                             // 継続ブロック中の連続出力は 55 秒に 1 回へ抑制（初回は即時）
                             if elapsed_ms().saturating_sub(last_blocked_log_ms) >= 55_000 {
                                 last_blocked_log_ms = elapsed_ms();
+                                // ブロック中の UI スレッドの「最後のブレッドクラム」を併記する。
+                                // label=="idle" なら停止はネイティブ event loop 側 (WebView2/wry/tray)、
+                                // それ以外なら当該同期コマンド内での停止と切り分けられる。
+                                let bc = main_thread_watch::snapshot();
                                 log::error!(
-                                    "[main-thread-watchdog] tao main thread blocked for {}s (run_on_main_thread closure not executed within 5s)",
-                                    blocked_secs
+                                    "[main-thread-watchdog] tao main thread blocked for {}s; last main-thread activity: {} (running {}ms) (run_on_main_thread closure not executed within 5s)",
+                                    blocked_secs, bc.label, bc.age_ms
                                 );
                             }
                         }
@@ -1421,6 +1528,9 @@ pub fn run() {
             }
 
             if let Some(window) = app.get_webview_window("main") {
+                // WebView2 ネイティブ診断イベント (ProcessFailed / NewBrowserVersionAvailable) を購読する。
+                #[cfg(target_os = "windows")]
+                subscribe_webview2_diagnostics(&window);
                 let _ = window.show();
             }
 
@@ -1430,6 +1540,39 @@ pub fn run() {
         .expect("error while building tauri application");
 
     app.run(move |app_handle, event| {
+        // RunEvent ハンドラは UI スレッドで走る。Guard の Drop で復元するため、ここを抜けると
+        // ブレッドクラムは直前 (通常 idle) に戻る。RunEvent ディスパッチ「中」に停止した場合のみ
+        // ブレッドクラムが run-event のまま残り、イベント待ち「中」の停止 (= idle) と区別できる。
+        let _bc = main_thread_watch::enter(main_thread_watch::Activity::RunEvent);
+
+        // UI スレッド起因のイベントを可視化する (フリーズ直前の操作を追える)。
+        // 高頻度イベント (Moved/Resized/CursorMoved/MainEventsCleared 等) は意図的に除外する:
+        // 無条件 DEBUG ログはログ肥大＋UI スレッドのログ I/O が新たなスタール要因になるため。
+        match &event {
+            tauri::RunEvent::Ready => log::debug!("[run-event] Ready"),
+            tauri::RunEvent::Resumed => log::debug!("[run-event] Resumed"),
+            tauri::RunEvent::ExitRequested { code, .. } => {
+                log::debug!("[run-event] ExitRequested code={:?}", code)
+            }
+            tauri::RunEvent::WindowEvent { label, event, .. } => match event {
+                tauri::WindowEvent::CloseRequested { .. } => {
+                    log::debug!("[run-event] WindowEvent[{}] CloseRequested", label)
+                }
+                tauri::WindowEvent::Destroyed => {
+                    log::debug!("[run-event] WindowEvent[{}] Destroyed", label)
+                }
+                tauri::WindowEvent::Focused(focused) => {
+                    log::debug!("[run-event] WindowEvent[{}] Focused={}", label, focused)
+                }
+                tauri::WindowEvent::ThemeChanged(theme) => {
+                    log::debug!("[run-event] WindowEvent[{}] ThemeChanged={:?}", label, theme)
+                }
+                // Moved/Resized/ScaleFactorChanged/CursorMoved 等の高頻度イベントは除外
+                _ => {}
+            },
+            _ => {}
+        }
+
         if let tauri::RunEvent::Exit = event {
             let pty_manager = app_handle.state::<PtyManager>();
             pty_manager.kill_all("app-exit");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -255,6 +255,7 @@ fn cancel_worktree_remove(
     remove_manager: State<'_, WorktreeRemoveManager>,
     worktree_path: String,
 ) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::CancelWorktreeRemove);
     if remove_manager.cancel(&worktree_path) {
         Ok(())
     } else {

--- a/src-tauri/src/main_thread_watch.rs
+++ b/src-tauri/src/main_thread_watch.rs
@@ -50,10 +50,11 @@ pub enum Activity {
     SetDebugMode,
     GetDebugMode,
     GetForceWizard,
+    CancelWorktreeRemove,
 }
 
 /// [`Activity`] の discriminant 順に並んだ表示ラベル。enum と順序を一致させること。
-const LABELS: [&str; 23] = [
+const LABELS: [&str; 24] = [
     "idle",
     "run-event",
     "watchdog-probe",
@@ -77,6 +78,7 @@ const LABELS: [&str; 23] = [
     "cmd:set_debug_mode",
     "cmd:get_debug_mode",
     "cmd:get_force_wizard",
+    "cmd:cancel_worktree_remove",
 ];
 
 /// discriminant から表示ラベルを引く。範囲外は `"?"`。
@@ -227,7 +229,7 @@ mod tests {
     #[test]
     fn labels_len_matches_max_discriminant() {
         // 最後の variant の discriminant + 1 が LABELS の長さと一致すること。
-        assert_eq!(LABELS.len(), Activity::GetForceWizard as usize + 1);
+        assert_eq!(LABELS.len(), Activity::CancelWorktreeRemove as usize + 1);
     }
 
     #[test]
@@ -238,6 +240,10 @@ mod tests {
         assert_eq!(name_for(Activity::PtyWrite as u8), "cmd:pty_write");
         assert_eq!(name_for(Activity::SaveSettings as u8), "cmd:save_settings");
         assert_eq!(name_for(Activity::GetForceWizard as u8), "cmd:get_force_wizard");
+        assert_eq!(
+            name_for(Activity::CancelWorktreeRemove as u8),
+            "cmd:cancel_worktree_remove"
+        );
     }
 
     #[test]

--- a/src-tauri/src/main_thread_watch.rs
+++ b/src-tauri/src/main_thread_watch.rs
@@ -1,0 +1,262 @@
+//! メインスレッド (tao/WebView2 UI スレッド) のブレッドクラム計装。
+//!
+//! UI スレッドで「最後に開始した処理」のラベルと開始時刻を、**ヒープ確保なし・ロックなし**の
+//! atomic だけで保持する。`watchdog` がブロックを検知したとき [`snapshot`] を読めば、
+//! 停止フレームが「同期 `#[tauri::command]` 内」か「ネイティブ event loop 側 (= Idle)」かを
+//! 切り分けられる。これがフリーズ調査の核心的な手がかりになる。
+//!
+//! - [`enter`] は **UI スレッドからのみ** 呼ぶ。返り値の [`Guard`] が drop されると直前の値へ
+//!   復元するため、入れ子で呼んでも整合する。
+//! - [`snapshot`] は別スレッド (watchdog) から読む。Relaxed atomic 越しの読み取りなので
+//!   ラベルと経過時間が一瞬ズレることはあるが、診断用途では問題ない (UB は発生しない)。
+//! - プラットフォーム非依存 (atomic のみ)。
+
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// 経過 ms を測る単調時計の起点。`run()` 冒頭で [`init`] が一度だけ設定する。
+static START: OnceLock<Instant> = OnceLock::new();
+/// 現在 UI スレッドで実行中の処理ラベル ([`Activity`] の discriminant)。
+static CUR_LABEL: AtomicU8 = AtomicU8::new(Activity::Idle as u8);
+/// 現在の処理を開始した時刻 (START からの経過 ms)。
+static CUR_SINCE_MS: AtomicU64 = AtomicU64::new(0);
+
+/// UI スレッドで起こりうる処理の種別。`#[repr(u8)]` の discriminant が [`LABELS`] の添字に対応する
+/// (順序を一致させること。テストで検証している)。
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum Activity {
+    Idle = 0,
+    RunEvent,
+    WatchdogProbe,
+    WindowReady,
+    PtyWrite,
+    PtySetAiAgent,
+    PtyIsAiAgent,
+    GetSettings,
+    SaveSettings,
+    ApplyAcrylic,
+    DetectIdes,
+    DetectAiAgents,
+    OpenInIde,
+    RegenerateMcpApiKey,
+    GetMcpStatus,
+    PathExists,
+    NotifyWorktreeArchived,
+    NotifyWorktreeAdded,
+    StartFsWatch,
+    StopFsWatch,
+    SetDebugMode,
+    GetDebugMode,
+    GetForceWizard,
+}
+
+/// [`Activity`] の discriminant 順に並んだ表示ラベル。enum と順序を一致させること。
+const LABELS: [&str; 23] = [
+    "idle",
+    "run-event",
+    "watchdog-probe",
+    "window-ready",
+    "cmd:pty_write",
+    "cmd:pty_set_ai_agent",
+    "cmd:pty_is_ai_agent",
+    "cmd:get_settings",
+    "cmd:save_settings",
+    "cmd:apply_acrylic_effect",
+    "cmd:detect_ides",
+    "cmd:detect_ai_agents",
+    "cmd:open_in_ide",
+    "cmd:regenerate_mcp_api_key",
+    "cmd:get_mcp_status",
+    "cmd:path_exists",
+    "cmd:notify_worktree_archived",
+    "cmd:notify_worktree_added",
+    "cmd:start_fs_watch",
+    "cmd:stop_fs_watch",
+    "cmd:set_debug_mode",
+    "cmd:get_debug_mode",
+    "cmd:get_force_wizard",
+];
+
+/// discriminant から表示ラベルを引く。範囲外は `"?"`。
+fn name_for(v: u8) -> &'static str {
+    LABELS.get(v as usize).copied().unwrap_or("?")
+}
+
+/// UI (tao/WebView2) スレッドの OS スレッド ID。`init()` が UI スレッドで記録する。
+/// minidump 解析時に「どのスレッドが UI スレッドか」を名指しするために使う。
+#[cfg(target_os = "windows")]
+static UI_THREAD_ID: AtomicU64 = AtomicU64::new(0);
+
+/// minidump を 1 回だけ書き出すためのガード。
+#[cfg(target_os = "windows")]
+static DUMP_WRITTEN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// 単調時計を初期化する。`run()` の冒頭 (= UI スレッド) で一度だけ呼ぶ。
+pub fn init() {
+    let _ = START.set(Instant::now());
+    #[cfg(target_os = "windows")]
+    unsafe {
+        UI_THREAD_ID.store(
+            windows_sys::Win32::System::Threading::GetCurrentThreadId() as u64,
+            Ordering::Relaxed,
+        );
+    }
+}
+
+/// 記録済みの UI スレッド ID (Windows)。未記録なら 0。
+#[cfg(target_os = "windows")]
+pub fn ui_thread_id() -> u64 {
+    UI_THREAD_ID.load(Ordering::Relaxed)
+}
+
+/// メインスレッドのハング初検知時に、プロセス全体のミニダンプを **1 回だけ** 書き出す (Windows 限定)。
+///
+/// `SuspendThread` + dbghelp `StackWalk64` の in-process シンボル化は、UI スレッドが
+/// heap/loader/dbghelp ロックを保持していると診断スレッド側で二重デッドロックを起こすため採用しない。
+/// 代わりにクラッシュダンプ用に設計された [`MiniDumpWriteDump`] でスナップショットをファイルに保存し、
+/// シンボル化はオフラインで行う。専用スレッドで実行して tokio ランタイムや watchdog を塞がず、
+/// 万一ダンプ自体がハングしても影響を 1 スレッドに限定する。`AtomicBool` で 1 回限りに制限する。
+///
+/// [`MiniDumpWriteDump`]: https://learn.microsoft.com/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
+#[cfg(target_os = "windows")]
+pub fn write_hang_minidump_once(dump_path: std::path::PathBuf) {
+    if DUMP_WRITTEN.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    std::thread::spawn(move || {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Foundation::HANDLE;
+        use windows_sys::Win32::System::Diagnostics::Debug::{
+            MiniDumpNormal, MiniDumpWithThreadInfo, MiniDumpWriteDump,
+        };
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetCurrentProcessId};
+
+        let file = match std::fs::File::create(&dump_path) {
+            Ok(f) => f,
+            Err(e) => {
+                log::error!(
+                    "[main-thread-watchdog] minidump ファイル作成失敗 {:?}: {}",
+                    dump_path,
+                    e
+                );
+                return;
+            }
+        };
+        let hfile = file.as_raw_handle() as HANDLE;
+        // スレッド情報付きの標準ダンプ。スタック歩行に必要な最小限のメモリを含む (シンボルは含まない)。
+        let dump_type = MiniDumpNormal | MiniDumpWithThreadInfo;
+        let ok = unsafe {
+            MiniDumpWriteDump(
+                GetCurrentProcess(),
+                GetCurrentProcessId(),
+                hfile,
+                dump_type,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        // file の HANDLE は MiniDumpWriteDump 完了まで生かす。
+        drop(file);
+        if ok != 0 {
+            log::error!(
+                "[main-thread-watchdog] minidump 書き出し完了: {:?} (windbg/VS で UI スレッドのスタックを解析)",
+                dump_path
+            );
+        } else {
+            log::error!(
+                "[main-thread-watchdog] MiniDumpWriteDump 失敗: {:?}",
+                dump_path
+            );
+        }
+    });
+}
+
+/// START からの経過 ms。未初期化なら 0。
+fn now_ms() -> u64 {
+    START.get().map(|s| s.elapsed().as_millis() as u64).unwrap_or(0)
+}
+
+/// 現在の UI スレッド処理を `a` に切り替える。返り値の [`Guard`] が drop されると直前の値へ復元する。
+/// **UI スレッドからのみ** 呼ぶこと。
+#[must_use = "Guard を drop すると直前のブレッドクラムへ復元される。即 drop すると計測されない"]
+pub fn enter(a: Activity) -> Guard {
+    let prev_label = CUR_LABEL.swap(a as u8, Ordering::Relaxed);
+    let prev_since = CUR_SINCE_MS.swap(now_ms(), Ordering::Relaxed);
+    Guard {
+        prev_label,
+        prev_since,
+    }
+}
+
+/// [`enter`] のスコープガード。drop 時に直前のブレッドクラムへ復元する。
+pub struct Guard {
+    prev_label: u8,
+    prev_since: u64,
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        CUR_SINCE_MS.store(self.prev_since, Ordering::Relaxed);
+        CUR_LABEL.store(self.prev_label, Ordering::Relaxed);
+    }
+}
+
+/// watchdog がブロック検知時に読むスナップショット。
+pub struct Snapshot {
+    /// 現在 UI スレッドで実行中の処理ラベル。`"idle"` ならネイティブ event loop 側で停止している。
+    pub label: &'static str,
+    /// その処理が開始してからの経過 ms。
+    pub age_ms: u64,
+}
+
+/// 現在のブレッドクラムを読み取る (別スレッドから呼んでよい)。
+pub fn snapshot() -> Snapshot {
+    let label = name_for(CUR_LABEL.load(Ordering::Relaxed));
+    let since = CUR_SINCE_MS.load(Ordering::Relaxed);
+    let age_ms = now_ms().saturating_sub(since);
+    Snapshot { label, age_ms }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_len_matches_max_discriminant() {
+        // 最後の variant の discriminant + 1 が LABELS の長さと一致すること。
+        assert_eq!(LABELS.len(), Activity::GetForceWizard as usize + 1);
+    }
+
+    #[test]
+    fn enum_discriminant_maps_to_label() {
+        // 代表的な variant が想定ラベルに対応すること (enum と LABELS の順序ズレ検出)。
+        assert_eq!(name_for(Activity::Idle as u8), "idle");
+        assert_eq!(name_for(Activity::RunEvent as u8), "run-event");
+        assert_eq!(name_for(Activity::PtyWrite as u8), "cmd:pty_write");
+        assert_eq!(name_for(Activity::SaveSettings as u8), "cmd:save_settings");
+        assert_eq!(name_for(Activity::GetForceWizard as u8), "cmd:get_force_wizard");
+    }
+
+    #[test]
+    fn name_for_out_of_range_is_question_mark() {
+        assert_eq!(name_for(254), "?");
+    }
+
+    #[test]
+    fn guard_restores_previous_breadcrumb() {
+        init();
+        // 入れ子: 外側 PtyWrite → 内側 SaveSettings → 内側 drop で PtyWrite へ復元
+        let _outer = enter(Activity::PtyWrite);
+        assert_eq!(snapshot().label, "cmd:pty_write");
+        {
+            let _inner = enter(Activity::SaveSettings);
+            assert_eq!(snapshot().label, "cmd:save_settings");
+        }
+        assert_eq!(snapshot().label, "cmd:pty_write");
+        drop(_outer);
+        assert_eq!(snapshot().label, "idle");
+    }
+}


### PR DESCRIPTION
## 背景

`oretachi.log.20260615hng` 末尾で、アプリが**復帰不能のフリーズ**を起こした (2026-06-15 20:48)。ログ調査の結果:

- 20:48:13 の正常 heartbeat 直後、**無ログのまま**フリーズ突入。
- 20:48:39 以降 `[main-thread-watchdog] tao main thread blocked` と `webview unresponsive` が**両方**発火 → **tao(WebView2 UI)メインスレッド自体が停止**し、5s→665s と単調増加して**回復せず**ログ終了（強制終了されたと推測）。
- フリーズ前18分は完全アイドル（sqlx/heartbeat/watchdog のみ）= **アイドル中の突然死**。

`pty_manager.rs` 等の自前ロックは机上検証で除外でき（`kill()` が taskkill 中に sessions ロックを保持しない設計等）、真因は **WebView2/wry ネイティブ層**（公式報告 WebView2Feedback #4141「idle 時 browser プロセス破綻」等）と推定。ただし**現状ログ外**にあるため、本 PR は**次回発生時に真因を確実にログ/ダンプへ捕捉する診断計装**に専念する（**回復処理はスコープ外** — 過去の自動回復が回復失敗時にアプリをクラッシュさせたため無効化済み）。

詳細: #78

## 変更内容（リスク段階順）

**段階1 — メインスレッド・ブレッドクラム（🟢 ロック/ヒープ確保なし）**
- 新規 `src-tauri/src/main_thread_watch.rs`: atomic だけで「UI スレッドで最後に開始した処理ラベル＋開始時刻」を保持（`enter()`/Drop guard で復元、入れ子対応）。
- 同期 `#[tauri::command]` **全20個**・`app.run` RunEvent・watchdog probe・acrylic `on_window_ready` に計装。
- watchdog のブロック検知ログに `last main-thread activity: <label> (running Nms)` を併記 → **`idle`=ネイティブ層 / コマンド名=その同期コマンド内** と一発で切り分け可能。

**段階2 — ネイティブイベント可視化（🟡 慎重実装）**
- WebView2 `ProcessFailed`(ERROR) / `NewBrowserVersionAvailable`(WARN) を購読（`with_webview`→COM、`webview2-com 0.38`＝wry/tauri と同一型）。#4141 のアイドル破綻を**アプリ側ログに初めて残す**。
- RunEvent は**低頻度イベントのみ**ログ化（`Moved`/`Resized`/`MainEventsCleared` 等の高頻度は除外＝ログ肥大・観測者効果を回避）。

**段階3 — ブロック初検知時の MiniDump（🔴 元案=危険 → 安全方式へ）**
- 危険な `SuspendThread`+dbghelp は不採用（UI スレッドのロック保持時に二重デッドロックの恐れ）。代わりに `MiniDumpWriteDump` でプロセス全体ダンプを `app_log_dir/oretachi-hang-<ms>.dmp` へ出力（専用スレッド・`AtomicBool` で1回限り）。UI スレッド ID もログ。

## 検証
- `cargo check` 通過、`cargo test --lib` **55 passed / 0 failed**（ブレッドクラムの順序整合・Drop復元・範囲外）
- セキュリティレビュー: 指摘なし
- bug-review: `cancel_worktree_remove` の計装漏れを修正済み（20/20 網羅）。Critical/Warning なし

## 残りの実機検証（Windows 実機）
実フリーズは WebView2 起因で稀なため、以下は実機確認が必要:
1. `pnpm run tauri dev` 起動 → `[webview2] ProcessFailed ハンドラ登録完了` と RunEvent ログ
2. 擬似ブロックで `last main-thread activity` 付き watchdog ログ＋`.dmp` 生成
3. 次回実発生時に `ProcessFailed`/`NewBrowserVersionAvailable`＋ダンプ＋ブレッドクラムで真因確定。恒久対処は真因確定後に別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
