### PR TITLE
fix(home): ワークツリーカードの列ズレ/gap を修正

### DIFF
--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -60,13 +60,17 @@ function animateFlip(oldPositions: Map<string, DOMRect>) {
     el.style.transition = 'transform 0.3s ease';
     el.style.transform = '';
 
-    // transition 完了時に inline style を消す。中断されなければここで残留 transform が確実に除去される
+    // transition 完了時に inline style を消す。中断されなければここで残留 transform が確実に除去される。
+    // transitioncancel（後続アニメーションによる中断）時はリスナー解除のみ行い、
+    // style は後続アニメーションに委ねる（ここで消すと進行中の transform を壊すため）。
     const onEnd = (e: TransitionEvent) => {
       if (e.propertyName !== 'transform') return;
       el.removeEventListener('transitionend', onEnd);
-      clearCardInlineTransform(el);
+      el.removeEventListener('transitioncancel', onEnd);
+      if (e.type === 'transitionend') clearCardInlineTransform(el);
     };
     el.addEventListener('transitionend', onEnd);
+    el.addEventListener('transitioncancel', onEnd);
   }
 }
 
@@ -306,8 +310,10 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
 // FLIP / auto-animate がリサイズ等の列間 DOM 移動で transform を残すと、
 // カードが論理列スロットからずれて描画され gap が生じるのを防ぐ self-healing。
 function resetAllCardTransforms() {
+  // transform が残留している要素のみ掃除する。transform が空で transition のみ残る要素は
+  // FLIP アニメーション進行中（最終値 '' へ遷移中）なので touch せず animateFlip の onEnd に委ねる。
   for (const el of cardElements.values()) {
-    if (el.style.transform || el.style.transition) clearCardInlineTransform(el);
+    if (el.style.transform) clearCardInlineTransform(el);
   }
 }
 

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -39,6 +39,11 @@ function capturePositions(): Map<string, DOMRect> {
   return positions;
 }
 
+function clearCardInlineTransform(el: HTMLElement) {
+  el.style.transform = '';
+  el.style.transition = '';
+}
+
 function animateFlip(oldPositions: Map<string, DOMRect>) {
   for (const [id, el] of cardElements) {
     const oldRect = oldPositions.get(id);
@@ -54,6 +59,14 @@ function animateFlip(oldPositions: Map<string, DOMRect>) {
     el.offsetHeight;
     el.style.transition = 'transform 0.3s ease';
     el.style.transform = '';
+
+    // transition 完了時に inline style を消す。中断されなければここで残留 transform が確実に除去される
+    const onEnd = (e: TransitionEvent) => {
+      if (e.propertyName !== 'transform') return;
+      el.removeEventListener('transitionend', onEnd);
+      clearCardInlineTransform(el);
+    };
+    el.addEventListener('transitionend', onEnd);
   }
 }
 
@@ -122,6 +135,8 @@ watch(draggingId, (id) => {
     if (id) ctrl.disable();
     else ctrl.enable();
   }
+  // ドラッグ完了直後に残留 transform を掃除する
+  if (!id) nextTick(resetAllCardTransforms);
 });
 
 function onCardDragStart(worktreeId: string, event: DragEvent) {
@@ -286,6 +301,26 @@ const TASK_CARD_WIDTH = ref(260);
 
 const { containerRef, columns } = useMasonryLayout(worktreesRef, { minColumnWidth: naturalCardWidth, gap: 12 });
 const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayout(tasksRef, { minColumnWidth: TASK_CARD_WIDTH, gap: 12 });
+
+// 中断されたアニメーションが残した inline transform を一括除去する。
+// FLIP / auto-animate がリサイズ等の列間 DOM 移動で transform を残すと、
+// カードが論理列スロットからずれて描画され gap が生じるのを防ぐ self-healing。
+function resetAllCardTransforms() {
+  for (const el of cardElements.values()) {
+    if (el.style.transform || el.style.transition) clearCardInlineTransform(el);
+  }
+}
+
+// 列構成（順序変化・列数変化のいずれも）が変わったら残留 transform を掃除する。
+// ドラッグ中 / 削除 FLIP 中は transform を意図的に使用中なので除外する。
+watch(
+  () => columns.value.map((c) => c.map((w) => w.id).join(",")).join("|"),
+  () => {
+    if (draggingId.value) return;
+    if (autoAnimateDisableDepth > 0) return;
+    nextTick(resetAllCardTransforms);
+  }
+);
 
 </script>
 


### PR DESCRIPTION
## 概要
ホームタブのワークツリーカード一覧で、使い続けると並び順・列の詰め方がおかしくなる問題を修正します。報告例「8個で3列目に不自然な空白(gap)」「7個で3-3-1（期待3-2-2）」。

## 原因
- マソンリーのラウンドロビン分配（`useMasonryLayout.ts`）自体は正しい。
- カスタム FLIP アニメーション `animateFlip` が inline の `transform`/`transition` を確実にクリーンアップしないため、アニメーション中断時に残留 transform がカードに張り付き、論理列スロットと描画位置がズレて gap が生じる。
- ウィンドウリサイズで列数が変わるとカードが別の列 `<div>`（別親）へ DOM 移動し、その際に残留が消えないまま新しい列で描画される（`:key` で DOM 要素が再利用されるため残留が生き残る）間欠症状。

## 修正内容（`src/components/HomeView.vue` のみ）
- `animateFlip` に `transitionend`/`transitioncancel` クリーンアップを追加し、完了時に inline style を確実に除去（cancel 時はリスナー解除のみ、style は後続アニメに委譲）。
- `resetAllCardTransforms()` + `columns` シグネチャ監視の self-healing watch を追加。順序変化・列数変化の両方で発火し、ドラッグ中 / 削除 FLIP 中以外で残留 transform を一括除去。判定は `transform` 残留時のみに限定し、進行中 FLIP は touch しない。
- `watch(draggingId)` の enable 分岐でドラッグ完了直後にも残留 transform を掃除。

他ファイル（`useMasonryLayout.ts` / `useWorktrees.ts` / `useWorktreeRemove.ts` / `WorktreeCard.vue`）は無改修。

## 検証
- `pnpm run type-check` 通過。
- 手動: ワークツリー8個でホームを開き、ウィンドウ幅を 3列⇔2列⇔1列で往復 → 末尾カード上の gap / 列ズレが出ないこと。ドラッグ並べ替え・カード削除後の整列、DevTools で `.card-drop-target` に残留 `transform` が無いこと。

## レビュー
- security-review: 指摘なし（純粋なクライアント側のアニメ state 衛生、攻撃面の追加なし）。
- bug-review: Critical/Warning 0件。SUGGESTION 2件（FLIP クリーンアップの堅牢化）は本PRで対応済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)