### PR TITLE
fix(shutdown): 終了処理を確実化し MCP 固定ポート掴みっぱなし/孤児 WebView2 を防止

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,6 @@ winreg = "0.52"
 # wry 0.54 / tauri 2.10 が使う版に合わせる (windows 0.61 系・PlatformWebview の controller()/environment() と同一型)。
 webview2-com = "0.38"
 windows = { version = "0.58", features = ["Win32_UI_Shell", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp"] }
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm", "Win32_System_Environment", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug", "Win32_Storage_FileSystem", "Win32_System_Kernel", "Win32_System_Memory"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm", "Win32_System_Environment", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug", "Win32_Storage_FileSystem", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_JobObjects", "Win32_Security"] }
 windows-version = "0.1"
 

--- a/src-tauri/src/job_object.rs
+++ b/src-tauri/src/job_object.rs
@@ -1,0 +1,73 @@
+//! Windows Job Object によるプロセス終了時の子プロセス巻き込み終了。
+//!
+//! 起動時に `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` を設定した Job を作り、自プロセスを
+//! 割り当てる。子プロセス（WebView2 の `msedgewebview2.exe` 等）は既定で親の Job を継承する
+//! ため、親プロセスが終了（正常/異常/クラッシュ/強制終了問わず）して最後の Job ハンドルが
+//! 閉じられると、OS が Job 内の全プロセスを終了させる。
+//!
+//! これは `RunEvent::Exit` 経由のクリーンアップ（通常終了）が走らないケース
+//! （クラッシュ・タスクマネージャからの強制終了）でも効く、OS レベルのセーフティネット。
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use std::sync::OnceLock;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
+        JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    /// 割当済みフラグ兼ハンドル記録。
+    /// このハンドルは **決して CloseHandle しない**（最後のハンドルを閉じると
+    /// KILL_ON_JOB_CLOSE により自プロセスごと即終了してしまうため）。プロセス終了時に
+    /// OS が暗黙クローズするのに委ねる。
+    static JOB: OnceLock<usize> = OnceLock::new();
+
+    pub fn assign_current_process_to_job() {
+        if JOB.get().is_some() {
+            return;
+        }
+        unsafe {
+            let job: HANDLE = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job.is_null() {
+                log::warn!("[job] CreateJobObjectW failed; child processes may be orphaned on exit");
+                return;
+            }
+
+            // UI limits は設定しない（設定すると nested job への割当が失敗する）。
+            // KILL_ON_JOB_CLOSE のみ設定する。SILENT_BREAKAWAY も設定しない（孤児化を招くため）。
+            let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            let ok = SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            );
+            if ok == 0 {
+                log::warn!("[job] SetInformationJobObject failed; child processes may be orphaned on exit");
+                return;
+            }
+
+            // 既に別 Job（UI limits 付き等）配下だと失敗し得る。致命にせず従来挙動へ degrade。
+            let ok = AssignProcessToJobObject(job, GetCurrentProcess());
+            if ok == 0 {
+                log::warn!("[job] AssignProcessToJobObject failed; child processes may be orphaned on exit");
+                return;
+            }
+
+            let _ = JOB.set(job as usize);
+            log::info!("[job] assigned current process to kill-on-close job object");
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub use imp::assign_current_process_to_job;
+
+/// 非 Windows では no-op。
+#[cfg(not(target_os = "windows"))]
+pub fn assign_current_process_to_job() {}

--- a/src-tauri/src/job_object.rs
+++ b/src-tauri/src/job_object.rs
@@ -11,7 +11,7 @@
 #[cfg(target_os = "windows")]
 mod imp {
     use std::sync::OnceLock;
-    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
     use windows_sys::Win32::System::JobObjects::{
         AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
         JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
@@ -49,6 +49,8 @@ mod imp {
             );
             if ok == 0 {
                 log::warn!("[job] SetInformationJobObject failed; child processes may be orphaned on exit");
+                // 割当前なので Job ハンドルを閉じてもプロセスには影響しない（KILL_ON_JOB_CLOSE 未割当）。
+                CloseHandle(job);
                 return;
             }
 
@@ -56,6 +58,8 @@ mod imp {
             let ok = AssignProcessToJobObject(job, GetCurrentProcess());
             if ok == 0 {
                 log::warn!("[job] AssignProcessToJobObject failed; child processes may be orphaned on exit");
+                // 割当に失敗したので Job は空。ここで閉じても自プロセスは巻き込まれない。
+                CloseHandle(job);
                 return;
             }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod claude_plugin_skills;
 mod fs_watcher;
 mod git_worktree;
 mod ide_launcher;
+mod job_object;
 mod main_thread_watch;
 pub mod mcp_server;
 mod process_utils;
@@ -1030,6 +1031,11 @@ pub fn run() {
                 log::set_max_level(log::LevelFilter::Info);
             }
 
+            // 子プロセス（WebView2 等）を Job Object に取り込み、親終了時に OS レベルで
+            // 巻き込み終了させる。MCP サーバ spawn や window.show() より前に割り当てて
+            // 以降生成される全子プロセスを確実に Job 配下に入れる。
+            job_object::assign_current_process_to_job();
+
             #[cfg(target_os = "windows")]
             match &redirection_guard_outcome {
                 redirection_guard::GuardOutcome::NotGuarded => {}
@@ -1575,13 +1581,27 @@ pub fn run() {
         }
 
         if let tauri::RunEvent::Exit = event {
-            let pty_manager = app_handle.state::<PtyManager>();
-            pty_manager.kill_all("app-exit");
-            let mcp_manager = app_handle.state::<mcp_server::McpServerManager>();
-            mcp_manager.stop();
+            // ① MCP を最優先で停止し、ポート解放を有界に待つ。
+            //    stop_and_wait は serve future 完了（= TcpListener drop = ポート解放）まで待つ。
+            //    PTY kill が長引いてもポートは先に確実に解放されるため、再起動時の
+            //    「固定ポートが掴まれたまま bind 失敗 → 停止中」を防ぐ。
+            //    Exit 時点で tokio ランタイムは生存しており block_on は安全（有界 timeout で必ず復帰）。
             if mcp_enabled {
+                let mcp_manager = app_handle.state::<mcp_server::McpServerManager>();
+                let released = tauri::async_runtime::block_on(
+                    mcp_manager.stop_and_wait(std::time::Duration::from_millis(1500)),
+                );
+                if !released {
+                    log::warn!("[exit] MCP stop_and_wait timed out; port may still be held");
+                }
                 mcp_server::cleanup_port_file(app_handle);
             }
+
+            // ② PTY セッションを終了時専用の高速経路で kill（並列 + 有界 deadline）。
+            let pty_manager = app_handle.state::<PtyManager>();
+            pty_manager.kill_all_fast("app-exit");
+
+            // ③ ファイルシステムウォッチャーを停止。
             let fs_watcher = app_handle.state::<FsWatcherManager>();
             fs_watcher.stop_all();
         }

--- a/src-tauri/src/process_utils.rs
+++ b/src-tauri/src/process_utils.rs
@@ -182,15 +182,27 @@ fn merge_paths(base: &str, additions: &str) -> String {
     result.join(":")
 }
 
-/// プロセスツリーを強制終了する
+/// 通常経路（Tauri コマンド等）から使うプロセスツリーの強制終了。
+/// `taskkill /F /T` の待機上限は 10 秒。
+pub fn kill_process_tree(pid: u32) {
+    kill_process_tree_with_timeout(pid, std::time::Duration::from_secs(10));
+}
+
+/// アプリ終了経路から使う高速版。`taskkill /F /T` の待機上限を 1.5 秒に短縮し、
+/// 多数セッションを並列 kill しても UI スレッドのブロックを有界に抑える。
+/// 超過時は taskkill 自体を kill してデタッチする（孤児プロセスは Job Object が回収）。
+pub fn kill_process_tree_exit(pid: u32) {
+    kill_process_tree_with_timeout(pid, std::time::Duration::from_millis(1500));
+}
+
+/// プロセスツリーを強制終了する（待機上限を引数で指定）。
 ///
 /// Windows: `taskkill /F /T` は通常数秒以内に終わるが、システム高負荷や対象プロセスの
 /// 異常状態では応答しないことがある。`.output()` の無期限待ちは呼び出しスレッドを
-/// 永久ブロックしうるため、タイムアウト付きで待機し、超過時は taskkill 自体を kill する。
-pub fn kill_process_tree(pid: u32) {
+/// 永久ブロックしうるため、`timeout` 付きで待機し、超過時は taskkill 自体を kill する。
+pub fn kill_process_tree_with_timeout(pid: u32, timeout: std::time::Duration) {
     #[cfg(target_os = "windows")]
     {
-        const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
         let child = make_command("taskkill")
             .args(["/F", "/T", "/PID", &pid.to_string()])
             .stdout(std::process::Stdio::null())
@@ -203,7 +215,7 @@ pub fn kill_process_tree(pid: u32) {
                 return;
             }
         };
-        let deadline = std::time::Instant::now() + TIMEOUT;
+        let deadline = std::time::Instant::now() + timeout;
         loop {
             match child.try_wait() {
                 Ok(Some(_)) => break,
@@ -211,7 +223,7 @@ pub fn kill_process_tree(pid: u32) {
                     if std::time::Instant::now() >= deadline {
                         log::warn!(
                             "[Terminal] kill_process_tree: taskkill timed out after {:?} pid={}",
-                            TIMEOUT,
+                            timeout,
                             pid
                         );
                         // taskkill 自体を kill して待ちを打ち切る。kill 失敗時は wait しない
@@ -230,6 +242,7 @@ pub fn kill_process_tree(pid: u32) {
 
     #[cfg(not(target_os = "windows"))]
     {
+        let _ = timeout;
         unsafe {
             libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
         }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1012,6 +1012,90 @@ impl PtyManagerCore {
         }
     }
 
+    /// アプリ終了経路専用の高速 kill_all。
+    ///
+    /// 逐次 `kill`（各セッション taskkill 最大10秒 + 無期限 `watcher_handle.join()`）は
+    /// N セッションで最悪 N×10秒 UI スレッドをブロックし、ユーザーの強制終了 → 孤児
+    /// WebView2 / ポート保持を招く。本関数は次の最適化で終了時間を有界化する:
+    /// 1. sessions ロックを最小スコープで全 drain し、ロック外で並列に kill する。
+    /// 2. taskkill は `kill_process_tree_exit`（1.5秒上限）を使う。
+    /// 3. `watcher_handle.join()` は無期限に待たず、合計 deadline まで有界に待つだけ。
+    ///    （プロセス終了時にスレッドも消えるため未 join でも問題ない。取りこぼした
+    ///     子プロセスは起動時に設定する Job Object が OS レベルで回収する。）
+    pub fn kill_all_fast(&self, source: &str) {
+        // (child_pid, child_killer, master(Arc), watcher_handle) を持ち出す。
+        // session 本体（input_tx 含む）はこのスコープ末尾で drop され、writer スレッドが終了する。
+        type Drained = (
+            Option<u32>,
+            Box<dyn portable_pty::ChildKiller + Send + Sync>,
+            Arc<Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>>,
+            Option<std::thread::JoinHandle<()>>,
+        );
+        let drained: Vec<Drained> = {
+            let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+            sweep_exited(&mut sessions);
+            let ids: Vec<u32> = sessions.keys().cloned().collect();
+            let mut out: Vec<Drained> = Vec::with_capacity(ids.len());
+            for id in ids {
+                if let Some(session) = sessions.remove(&id) {
+                    // ウォッチャースレッド停止のため alive=false を確実にセット（poison でも）。
+                    match session.alive.lock() {
+                        Ok(mut alive) => *alive = false,
+                        Err(e) => *e.into_inner() = false,
+                    }
+                    out.push((
+                        session.child_pid,
+                        session.child_killer,
+                        session.master.clone(),
+                        session.watcher_handle,
+                    ));
+                    // session（残りフィールド: input_tx 等）はここで drop される。
+                }
+            }
+            out
+        }; // ← sessions ロック解放
+
+        let count = drained.len();
+        log::info!("[Terminal] pty_manager::kill_all_fast source={} count={}", source, count);
+        if count == 0 {
+            return;
+        }
+
+        // 各セッションを並列スレッドで kill。1 スレッドが master.lock() でハングしても
+        // 他スレッドと UI スレッドを巻き込まないよう、スレッド内で master take を行う。
+        let remaining = Arc::new(std::sync::atomic::AtomicUsize::new(count));
+        for (child_pid, mut child_killer, master_arc, watcher_handle) in drained {
+            let remaining = remaining.clone();
+            std::thread::spawn(move || {
+                // child_killer でバックアップ kill（即時）
+                let _ = child_killer.kill();
+                // master を take して drop し ConPTY を破棄、reader に EOF を送る
+                let master = master_arc.lock().unwrap_or_else(|e| e.into_inner()).take();
+                drop(master);
+                // プロセスツリーを 1.5 秒上限で kill
+                if let Some(pid) = child_pid {
+                    crate::process_utils::kill_process_tree_exit(pid);
+                }
+                // watcher_handle は join せず drop（detach）。alive=false で自然終了する。
+                drop(watcher_handle);
+                remaining.fetch_sub(1, Ordering::SeqCst);
+            });
+        }
+
+        // 合計 deadline（2秒）まで有界に待つ。超過してもブロックを打ち切って終了を進める。
+        let deadline = Instant::now() + Duration::from_millis(2000);
+        while remaining.load(Ordering::SeqCst) > 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let left = remaining.load(Ordering::SeqCst);
+        if left > 0 {
+            log::warn!(
+                "[Terminal] kill_all_fast: {} session(s) not confirmed within deadline (detached)",
+                left
+            );
+        }
+    }
+
     /// 指定ディレクトリ以下をcwdとして持つ全PTYセッションをkillする。
     /// ワークツリー削除前にそのディレクトリを掴んでいる子プロセスを解放するために使用。
     /// 返り値: killしたセッション数（> 0 なら呼び出し側でプロセス終了待機が必要）


### PR DESCRIPTION
## 背景 (#81)

別PCで、固定ポートの MCP サーバが oretachi 再起動後に「停止中」のまま回復せず、oretachi のウィンドウが無いのに `msedgewebview2` プロセスが大量残存する事象が発生。

**根本原因**: 前回プロセスがクリーンに終了しきれず固定ポートを掴んだままになり、新プロセスの `TcpListener::bind` が `AddrInUse` で失敗 → 「停止中」になる（自動ポートなら起きないため固定ポート時のみ顕在化）。終了経路の弱点:
1. `mcp_manager.stop()` が投げっぱなしで、ポート解放を待たない（しかも `kill_all` が先）
2. `kill_all` が逐次 + 各 kill が taskkill 最大10秒 + 無期限 `watcher_handle.join()` → N セッションで最悪 N×10秒ハング → 強制終了 → 孤児 WebView2 + ポート保持
3. Job Object 未使用のため強制終了/クラッシュで WebView2 子が孤児化

## 変更内容

スコープは **終了処理の確実化のみ**。A/B = 通常終了の確実化、C = 異常終了の OS レベルセーフティネット の二層構成。

- **`lib.rs` Exit**: 順序を入れ替え、MCP を最優先で `block_on(stop_and_wait(1500ms))` → TcpListener drop（ポート解放）を有界に待ってから `cleanup_port_file` → `kill_all_fast` → `fs_watcher`
- **`pty_manager.rs`**: 終了専用 `kill_all_fast` を追加。全 drain 後に並列スレッドで kill（master take もスレッド内）し合計2秒 deadline で有界待機。watcher は join せず detach
- **`process_utils.rs`**: `kill_process_tree` を `_with_timeout` に共通化し、終了経路用 `kill_process_tree_exit`（1.5秒上限）を追加。通常経路は従来10秒のまま
- **`job_object.rs`（新規）**: 起動時に `KILL_ON_JOB_CLOSE` の Job へ自プロセスを割当。クラッシュ/強制終了でも WebView2 子を OS が巻き込み終了させる。割当失敗系では Job ハンドルを CloseHandle
- **`Cargo.toml`**: windows-sys に `Win32_System_JobObjects` / `Win32_Security` を追加

## 確認状況

- ✅ `cargo check` 通過
- ✅ security-review: 指摘なし
- ✅ bug-review: critical/warning なし（指摘 #1 の Job ハンドルリークは対応済み）
- ⏳ 実機 E2E（Windows）未実施:
  1. 複数ターミナル+MCP接続中に通常終了 → `netstat -ano | findstr :<固定ポート>` で LISTEN 消失 → 即再起動で「停止中」にならず bind 成功
  2. 終了後 `tasklist | findstr msedgewebview2` 残存ゼロ。タスクマネージャから `oretachi.exe` を End task しても Job により消える
  3. ターミナル多数(5+)での終了が ~3秒以内に収束

🤖 Generated with [Claude Code](https://claude.com/claude-code)