### PR TITLE
feat(workgroup): ワークグループ機能を追加

### DIFF
--- a/src-tauri/src/archive_db.rs
+++ b/src-tauri/src/archive_db.rs
@@ -16,6 +16,8 @@ pub struct ArchiveRow {
     pub archived_at: i64,
     #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
+    pub workgroup_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -46,13 +48,18 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             path            TEXT NOT NULL,
             branch_name     TEXT NOT NULL,
             archived_at     INTEGER NOT NULL,
-            description     TEXT
+            description     TEXT,
+            workgroup_id    TEXT
         )"#,
     )
     .execute(pool)
     .await?;
     // 既存 DB 向けマイグレーション: description カラムが無ければ追加（既にあればエラーを握りつぶす）
     let _ = sqlx::query("ALTER TABLE archives ADD COLUMN description TEXT")
+        .execute(pool)
+        .await;
+    // 既存 DB 向けマイグレーション: workgroup_id カラム（所属グループの記録・復元用）
+    let _ = sqlx::query("ALTER TABLE archives ADD COLUMN workgroup_id TEXT")
         .execute(pool)
         .await;
     sqlx::query(
@@ -70,7 +77,7 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 
 pub async fn save(pool: &SqlitePool, archive: &ArchiveRow) -> Result<(), String> {
     sqlx::query(
-        "INSERT OR REPLACE INTO archives (id, name, repository_id, repository_name, path, branch_name, archived_at, description) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO archives (id, name, repository_id, repository_name, path, branch_name, archived_at, description, workgroup_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&archive.id)
     .bind(&archive.name)
@@ -80,6 +87,7 @@ pub async fn save(pool: &SqlitePool, archive: &ArchiveRow) -> Result<(), String>
     .bind(&archive.branch_name)
     .bind(archive.archived_at)
     .bind(&archive.description)
+    .bind(&archive.workgroup_id)
     .execute(pool)
     .await
     .map_err(|e| e.to_string())?;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -52,6 +52,26 @@ pub struct WorktreeEntry {
     pub description: Option<String>,
     #[serde(default, rename = "descriptionOpen")]
     pub description_open: Option<bool>,
+    #[serde(default, rename = "workgroupId")]
+    pub workgroup_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Workgroup {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub color: Option<String>,
+    #[serde(default)]
+    pub auto_assign_hotkey: Option<bool>,
+    #[serde(default)]
+    pub task_add_agent: Option<AiAgentKind>,
+    #[serde(default)]
+    pub claude_code_mode: Option<String>,
+    #[serde(default)]
+    pub exec_prompt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -310,6 +330,10 @@ pub struct AppSettings {
     pub worktree_base_dir: String,
     pub worktrees: Vec<WorktreeEntry>,
     #[serde(default)]
+    pub workgroups: Vec<Workgroup>,
+    #[serde(default, rename = "activeWorkgroupId")]
+    pub active_workgroup_id: Option<String>,
+    #[serde(default)]
     pub terminal: TerminalSettings,
     #[serde(default)]
     pub hotkeys: HotkeySettings,
@@ -368,6 +392,8 @@ impl Default for AppSettings {
             repositories: Vec::new(),
             worktree_base_dir: String::new(),
             worktrees: Vec::new(),
+            workgroups: Vec::new(),
+            active_workgroup_id: None,
             terminal: TerminalSettings::default(),
             hotkeys: HotkeySettings::default(),
             always_on_top: false,

--- a/src/App.vue
+++ b/src/App.vue
@@ -370,6 +370,8 @@ const removeWorkgroupMembers = computed(() =>
 let removingWorkgroup = false;
 
 function onRemoveWorkgroup(groupId: string) {
+  // 最後の1グループは削除しない（常に1グループ以上を維持する）
+  if ((settings.value.workgroups?.length ?? 0) <= 1) return;
   removeWorkgroupId.value = groupId;
 }
 
@@ -679,6 +681,8 @@ async function onShowAddWorktreeDialog() {
 }
 
 async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string, sessionSourcePath?: string, copyWorkingChangesFrom?: string) {
+  // 現在表示中のワークグループに所属させる（仮追加の前に設定しないとランタイムコピーに反映されない）
+  if (activeWorkgroupId.value) entry.workgroupId = activeWorkgroupId.value;
   // ダイアログを即閉じ、一覧に仮エントリを表示
   showAddDialog.value = false;
   duplicateSourceData.value = null;
@@ -692,9 +696,6 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
     }
 
     const lfsSkipped = await invokeWorktreeAdd(entry, sourceBranch);
-
-    // 現在表示中のワークグループに所属させる
-    if (activeWorkgroupId.value) entry.workgroupId = activeWorkgroupId.value;
 
     // 成功時: 設定に永続化
     commitWorktree(entry);

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ import SettingsView from "./components/SettingsView.vue";
 import AddWorktreeDialog from "./components/AddWorktreeDialog.vue";
 import AddTaskDialog from "./components/AddTaskDialog.vue";
 import RemoveWorktreeDialog from "./components/RemoveWorktreeDialog.vue";
+import RemoveWorkgroupDialog from "./components/RemoveWorkgroupDialog.vue";
 import IdeSelectDialog from "./components/IdeSelectDialog.vue";
 import HotkeyCharDialog from "./components/HotkeyCharDialog.vue";
 import AutoApprovalPromptDialog from "./components/AutoApprovalPromptDialog.vue";
@@ -43,6 +44,7 @@ import { saveWindowState, StateFlags } from "@tauri-apps/plugin-window-state";
 import { useWorktreeRemove } from "./composables/useWorktreeRemove";
 import { useRemoveWorktreeDialog } from "./composables/useRemoveWorktreeDialog";
 import { useAutoHotkey } from "./composables/useAutoHotkey";
+import { useWorkgroups } from "./composables/useWorkgroups";
 import { useAppAutoApproval } from "./composables/useAppAutoApproval";
 import { useAppHotkeys } from "./composables/useAppHotkeys";
 import { useSubWindowEvents } from "./composables/useSubWindowEvents";
@@ -331,7 +333,7 @@ const worktreeRemoveCore = useWorktreeRemove({
   homeViewRef,
   t,
 });
-const { cancellableWorktrees, cancelWorktreeRemove, archiveWorktree } = worktreeRemoveCore;
+const { cancellableWorktrees, cancelWorktreeRemove, archiveWorktree, removeWorktreeNoArchive } = worktreeRemoveCore;
 
 // ワークツリー削除/アーカイブダイアログ
 const {
@@ -344,6 +346,63 @@ const {
   onArchiveWorktreeConfirm,
   dismissDialog: onRemoveWorktreeDismiss,
 } = useRemoveWorktreeDialog(worktreeRemoveCore);
+
+// ワークグループ
+const { activeWorkgroupId, resolvedGroupId, deleteWorkgroupRecord, displayName: workgroupDisplayName } = useWorkgroups();
+
+// タスク追加ダイアログ用: 現在表示中グループのタスク実行エージェント（リモート実行チェックボックスの出し分け）
+const activeTaskExecAgent = computed(() => {
+  const g = settings.value.workgroups?.find((w) => w.id === activeWorkgroupId.value);
+  return g?.taskAddAgent ?? settings.value.aiAgent?.taskAddAgent ?? settings.value.aiAgent?.approvalAgent;
+});
+
+// ワークグループ削除フロー
+const removeWorkgroupId = ref<string | null>(null);
+const removeWorkgroupName = computed(() => {
+  const g = settings.value.workgroups?.find((w) => w.id === removeWorkgroupId.value);
+  return g ? workgroupDisplayName(g) : "";
+});
+const removeWorkgroupMembers = computed(() =>
+  removeWorkgroupId.value
+    ? worktrees.value.filter((w) => resolvedGroupId(w.workgroupId) === removeWorkgroupId.value)
+    : [],
+);
+let removingWorkgroup = false;
+
+function onRemoveWorkgroup(groupId: string) {
+  removeWorkgroupId.value = groupId;
+}
+
+async function onRemoveWorkgroupConfirm(archive: boolean) {
+  const groupId = removeWorkgroupId.value;
+  if (!groupId || removingWorkgroup) return;
+  removingWorkgroup = true;
+  // 削除対象のスナップショット（削除中に worktrees が変化するため固定）
+  const members = worktrees.value
+    .filter((w) => resolvedGroupId(w.workgroupId) === groupId)
+    .map((w) => w.id);
+  const opts = { mergeTo: "", deleteBranch: true, forceBranch: true };
+  try {
+    for (const id of members) {
+      try {
+        if (archive) await archiveWorktree(id, opts);
+        else await removeWorktreeNoArchive(id, opts);
+      } catch (e) {
+        console.error("グループ内ワークツリー削除に失敗:", e);
+      }
+    }
+  } finally {
+    removingWorkgroup = false;
+    // 所属ワークツリーが残っていなければグループを削除
+    const remaining = worktrees.value.some((w) => resolvedGroupId(w.workgroupId) === groupId);
+    if (!remaining) deleteWorkgroupRecord(groupId);
+    removeWorkgroupId.value = null;
+  }
+}
+
+function onRemoveWorkgroupCancel() {
+  removeWorkgroupId.value = null;
+}
 
 // IDE 選択
 const { showIdeDialog, detectedIdes, openInIde, onIdeSelected } = useIdeSelect();
@@ -633,6 +692,9 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
     }
 
     const lfsSkipped = await invokeWorktreeAdd(entry, sourceBranch);
+
+    // 現在表示中のワークグループに所属させる
+    if (activeWorkgroupId.value) entry.workgroupId = activeWorkgroupId.value;
 
     // 成功時: 設定に永続化
     commitWorktree(entry);
@@ -1646,6 +1708,7 @@ onMounted(async () => {
         @add-task="showAddTaskDialog = true"
         @remove-task="removeTask"
         @rerun-task="rerunTaskId = $event"
+        @remove-workgroup="onRemoveWorkgroup"
       />
 
       <!-- 設定ビュー -->
@@ -1729,7 +1792,7 @@ onMounted(async () => {
       v-if="showAddTaskDialog || rerunTaskId"
       :initial-prompt="rerunTaskId ? rerunPrompt : ''"
       :mode="rerunTaskId ? 'rerun' : 'add'"
-      :show-remote-exec="(settings.aiAgent?.taskAddAgent ?? settings.aiAgent?.approvalAgent) === 'claudeCode'"
+      :show-remote-exec="activeTaskExecAgent === 'claudeCode'"
       :initial-remote-exec="settings.aiAgent?.remoteExec ?? false"
       @confirm="(prompt, remoteExec) => onAddTaskConfirm(prompt, remoteExec)"
       @cancel="onAddTaskCancel"
@@ -1758,6 +1821,15 @@ onMounted(async () => {
       @confirm="onRemoveWorktreeConfirm"
       @archive="onArchiveWorktreeConfirm"
       @cancel="onRemoveWorktreeDismiss"
+    />
+
+    <!-- ワークグループ削除ダイアログ -->
+    <RemoveWorkgroupDialog
+      v-if="removeWorkgroupId"
+      :group-name="removeWorkgroupName"
+      :members="removeWorkgroupMembers"
+      @confirm="onRemoveWorkgroupConfirm"
+      @cancel="onRemoveWorkgroupCancel"
     />
 
     <!-- IDE 選択ダイアログ -->

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -7,8 +7,10 @@ import WorktreeCard from "./WorktreeCard.vue";
 import TaskCard from "./TaskCard.vue";
 import ArchiveTable from "./ArchiveTable.vue";
 import HomeCatTerminal from "./HomeCatTerminal.vue";
+import WorkgroupBar from "./WorkgroupBar.vue";
 import { useMasonryLayout } from "../composables/useMasonryLayout";
 import { useSettings } from "../composables/useSettings";
+import { useWorkgroups } from "../composables/useWorkgroups";
 import { useTasks } from "../composables/useTasks";
 import { useTaskPersistence } from "../composables/useTaskPersistence";
 import { useTaskSearch } from "../composables/useTaskSearch";
@@ -205,6 +207,7 @@ const emit = defineEmits<{
   addTask: [];
   removeTask: [taskId: string];
   rerunTask: [taskId: string];
+  removeWorkgroup: [groupId: string];
 }>();
 
 type PanelMode = "worktree" | "task" | "archive";
@@ -261,8 +264,16 @@ watch(panelMode, async (mode, oldMode) => {
   }
 });
 
-const worktreesRef = computed(() => props.worktrees);
+// アクティブなワークグループでワークツリーをフィルタ
+const { activeWorkgroupId, resolvedGroupId, groups: workgroups, moveWorktreeToWorkgroup } = useWorkgroups();
+const worktreesRef = computed(() =>
+  props.worktrees.filter((w) => resolvedGroupId(w.workgroupId) === activeWorkgroupId.value),
+);
 const tasksRef = sortedTasks;
+
+function onMoveToWorkgroup(payload: { worktreeId: string; groupId: string }) {
+  moveWorktreeToWorkgroup(payload.worktreeId, payload.groupId);
+}
 
 // 各ワークツリーカードの自然幅（ターミナルサムネイル幅から計算）をもとに列幅を決定する
 const naturalCardWidth = computed(() => {
@@ -304,6 +315,11 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
         <option value="task">{{ t('taskTitle') }}</option>
         <option value="archive">{{ t('archiveTitle') }}</option>
       </select>
+      <WorkgroupBar
+        v-if="panelMode === 'worktree'"
+        class="header-workgroups"
+        @remove-workgroup="emit('removeWorkgroup', $event)"
+      />
       <div class="header-actions">
         <template v-if="panelMode === 'worktree'">
           <button
@@ -394,6 +410,9 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
               :ai-judging="aiJudgingWorktrees.has(worktree.id)"
               :tooltip="cardTooltips?.get(worktree.id)"
               :description-open="showAllDescriptions || (descriptionOpens?.get(worktree.id) ?? false)"
+              :workgroups="workgroups"
+              :current-workgroup-id="resolvedGroupId(worktree.workgroupId)"
+              @move-to-workgroup="onMoveToWorkgroup"
               @drag-start="onCardDragStart"
               @drag-end="onDragEnd"
               @select-terminal="emit('selectTerminal', $event)"
@@ -519,10 +538,15 @@ const { containerRef: taskContainerRef, columns: taskColumns } = useMasonryLayou
   font-weight: 600;
 }
 
+.header-workgroups {
+  margin: 0 12px;
+}
+
 .header-actions {
   display: flex;
   align-items: center;
   gap: 4px;
+  flex-shrink: 0;
 }
 
 .btn-icon-header {

--- a/src/components/RemoveWorkgroupDialog.vue
+++ b/src/components/RemoveWorkgroupDialog.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import type { Worktree } from "../types/worktree";
+
+const { t } = useI18n();
+
+defineProps<{
+  groupName: string;
+  members: Worktree[];
+}>();
+
+const emit = defineEmits<{
+  confirm: [archive: boolean];
+  cancel: [];
+}>();
+
+const archive = ref(true);
+</script>
+
+<template>
+  <div class="dialog-overlay" @click.self="emit('cancel')">
+    <div class="dialog">
+      <h3 class="dialog-title">{{ t('title', { name: groupName }) }}</h3>
+
+      <p class="warn">{{ t('warning', { count: members.length }) }}</p>
+
+      <div v-if="members.length > 0" class="member-list">
+        <div class="member-list-label">{{ t('membersLabel') }}</div>
+        <div v-for="m in members" :key="m.id" class="member-row">
+          <span class="member-name">{{ m.name }}</span>
+          <span class="member-branch">{{ m.branchName }}</span>
+        </div>
+      </div>
+
+      <div class="field checkbox-field">
+        <label class="checkbox-label">
+          <input v-model="archive" type="checkbox" />
+          {{ t('archiveOption') }}
+        </label>
+      </div>
+
+      <div class="dialog-actions">
+        <button class="btn-cancel" @click="emit('cancel')">{{ t('common.cancel') }}</button>
+        <button class="btn-danger" @click="emit('confirm', archive)">
+          {{ members.length > 0 ? t('confirmWithCount', { count: members.length }) : t('confirmEmpty') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 101;
+}
+
+.dialog {
+  background: #1e1e2e;
+  border: 1px solid #313244;
+  border-radius: 10px;
+  padding: 24px;
+  width: 440px;
+  max-width: 90vw;
+  max-height: 88vh;
+  overflow-y: auto;
+}
+
+.dialog-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #f38ba8;
+  margin: 0 0 16px;
+}
+
+.warn {
+  font-size: 13px;
+  color: #f9e2af;
+  line-height: 1.6;
+  margin: 0 0 16px;
+}
+
+.member-list {
+  background: #181825;
+  border: 1px solid #313244;
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.member-list-label {
+  font-size: 11px;
+  color: #6c7086;
+  margin-bottom: 8px;
+}
+
+.member-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 3px 0;
+}
+
+.member-name {
+  font-size: 13px;
+  color: #cdd6f4;
+  font-weight: 600;
+}
+
+.member-branch {
+  font-size: 11px;
+  color: #6c7086;
+  font-family: monospace;
+  word-break: break-all;
+}
+
+.checkbox-field {
+  margin-bottom: 20px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #cdd6f4;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+  cursor: pointer;
+  accent-color: #89b4fa;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.btn-cancel {
+  background: #313244;
+  color: #cdd6f4;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 7px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.btn-cancel:hover {
+  background: #45475a;
+}
+
+.btn-danger {
+  background: #f38ba8;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 4px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-danger:hover {
+  background: #eb6f8e;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Delete group \"{name}\"",
+    "warning": "All {count} worktree(s) in this group will be deleted, then the group will be removed. This cannot be undone.",
+    "membersLabel": "Worktrees to be deleted",
+    "archiveOption": "Archive before deleting (records the group for restore)",
+    "confirmWithCount": "Delete {count} worktree(s) and the group",
+    "confirmEmpty": "Delete group"
+  },
+  "ja": {
+    "title": "グループ「{name}」を削除",
+    "warning": "所属する {count} 件のワークツリーをすべて削除してから、グループを削除します。この操作は取り消せません。",
+    "membersLabel": "削除されるワークツリー",
+    "archiveOption": "削除前にアーカイブへ保存する（所属グループも記録）",
+    "confirmWithCount": "{count} 件を削除してグループを削除",
+    "confirmEmpty": "グループを削除"
+  }
+}
+</i18n>

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -432,27 +432,7 @@ function getSoundLabel(sound: string | null | undefined): string {
           >{{ AI_AGENT_LABELS[kind] }}{{ !isAgentDetected(kind) ? t('autoApproval.notDetected') : '' }}</option>
         </select>
       </div>
-      <div class="row-input row-input--inline mt-8">
-        <span class="inline-label">{{ t('autoApproval.taskAddAgent') }}</span>
-        <select
-          class="text-input select-input"
-          :value="settings.aiAgent?.taskAddAgent ?? ''"
-          @change="(e) => {
-            const v = (e.target as HTMLSelectElement).value;
-            if (!settings.aiAgent) settings.aiAgent = {};
-            settings.aiAgent.taskAddAgent = v ? (v as AiAgentKind) : undefined;
-            scheduleSave();
-          }"
-        >
-          <option value="">{{ t('autoApproval.notSet') }}</option>
-          <option
-            v-for="kind in ALL_AGENT_KINDS"
-            :key="kind"
-            :value="kind"
-            :disabled="!isAgentDetected(kind)"
-          >{{ AI_AGENT_LABELS[kind] }}{{ !isAgentDetected(kind) ? t('autoApproval.notDetected') : '' }}</option>
-        </select>
-      </div>
+      <!-- 「タスク実行エージェント」はワークグループ単位に移動 -->
       <div class="row-input row-input--inline mt-8">
         <span class="inline-label">{{ t('autoApproval.aiTimeout') }}</span>
         <input

--- a/src/components/WorkgroupBar.vue
+++ b/src/components/WorkgroupBar.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useWorkgroups } from "../composables/useWorkgroups";
+import WorkgroupEditDialog from "./WorkgroupEditDialog.vue";
+import type { Workgroup } from "../types/settings";
+
+const { t } = useI18n();
+
+const emit = defineEmits<{
+  removeWorkgroup: [groupId: string];
+}>();
+
+const {
+  groups,
+  activeWorkgroupId,
+  displayName,
+  worktreeCount,
+  addWorkgroup,
+  updateWorkgroup,
+} = useWorkgroups();
+
+const editingId = ref<string | null>(null);
+const draggingId = ref<string | null>(null);
+
+function select(id: string) {
+  activeWorkgroupId.value = id;
+}
+
+function onChipClick(id: string) {
+  // 既にアクティブなチップを再クリックで編集ダイアログを開く
+  if (activeWorkgroupId.value === id) {
+    editingId.value = id;
+  } else {
+    select(id);
+  }
+}
+
+function onAdd() {
+  const g = addWorkgroup();
+  editingId.value = g.id;
+}
+
+function editingGroup(): Workgroup | undefined {
+  return groups.value.find((g) => g.id === editingId.value);
+}
+
+function onSave(patch: Partial<Workgroup>) {
+  if (editingId.value) updateWorkgroup(editingId.value, patch);
+  editingId.value = null;
+}
+
+function onRemove() {
+  const id = editingId.value;
+  editingId.value = null;
+  if (id) emit("removeWorkgroup", id);
+}
+
+// 並び替え (D&D)
+function onDragStart(id: string, event: DragEvent) {
+  draggingId.value = id;
+  event.dataTransfer?.setData("text/plain", id);
+}
+function onDragOver(id: string, event: DragEvent) {
+  event.preventDefault();
+  if (draggingId.value && draggingId.value !== id) {
+    const { reorderWorkgroup } = useWorkgroups();
+    reorderWorkgroup(draggingId.value, id);
+  }
+}
+function onDragEnd() {
+  draggingId.value = null;
+}
+</script>
+
+<template>
+  <div class="workgroup-bar">
+    <button
+      v-for="g in groups"
+      :key="g.id"
+      class="wg-chip"
+      :class="{ active: g.id === activeWorkgroupId }"
+      :style="{ borderLeftColor: g.color || '#9399b2', ...(g.id === activeWorkgroupId && g.color ? { background: g.color + '30', borderColor: g.color } : {}) }"
+      draggable="true"
+      :title="t('chipTitle')"
+      @click="onChipClick(g.id)"
+      @dragstart="onDragStart(g.id, $event)"
+      @dragover="onDragOver(g.id, $event)"
+      @dragend="onDragEnd"
+    >
+      <span class="wg-name">{{ displayName(g) }}</span>
+      <span class="wg-count">{{ worktreeCount(g.id) }}</span>
+      <span v-if="g.id === activeWorkgroupId" class="wg-edit" @click.stop="editingId = g.id">
+        <i class="pi pi-pencil" style="font-size: 10px" />
+      </span>
+    </button>
+
+    <button class="wg-add" :title="t('addGroup')" @click="onAdd">
+      <i class="pi pi-plus" style="font-size: 12px" />
+    </button>
+
+    <WorkgroupEditDialog
+      v-if="editingGroup()"
+      :group="editingGroup()!"
+      @save="onSave"
+      @remove="onRemove"
+      @cancel="editingId = null"
+    />
+  </div>
+</template>
+
+<style scoped>
+.workgroup-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.wg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 7px;
+  border: 1px solid #313244;
+  border-left: 4px solid #9399b2;
+  background: #181825;
+  color: #a6adc8;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s;
+}
+
+.wg-chip:hover {
+  background: #232336;
+}
+
+.wg-chip.active {
+  background: #313244;
+  color: #cdd6f4;
+  border-color: #585b70;
+}
+
+.wg-count {
+  background: #45475a;
+  color: #bac2de;
+  border-radius: 8px;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 16px;
+  text-align: center;
+}
+
+.wg-chip.active .wg-count {
+  background: #585b70;
+  color: #cdd6f4;
+}
+
+.wg-edit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #9399b2;
+  margin-left: 2px;
+}
+
+.wg-edit:hover {
+  color: #cba6f7;
+}
+
+.wg-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  border: 1px dashed #45475a;
+  background: transparent;
+  color: #6c7086;
+  cursor: pointer;
+}
+
+.wg-add:hover {
+  color: #cba6f7;
+  border-color: #cba6f7;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "addGroup": "Add group",
+    "chipTitle": "Click to switch / click again to edit"
+  },
+  "ja": {
+    "addGroup": "グループを追加",
+    "chipTitle": "クリックで切替 / 再クリックで編集"
+  }
+}
+</i18n>

--- a/src/components/WorkgroupBar.vue
+++ b/src/components/WorkgroupBar.vue
@@ -18,6 +18,7 @@ const {
   worktreeCount,
   addWorkgroup,
   updateWorkgroup,
+  reorderWorkgroup,
 } = useWorkgroups();
 
 const editingId = ref<string | null>(null);
@@ -56,17 +57,23 @@ function onRemove() {
   if (id) emit("removeWorkgroup", id);
 }
 
-// 並び替え (D&D)
+// 並び替え (D&D): 並び替えは drop 時に一度だけ確定する
 function onDragStart(id: string, event: DragEvent) {
   draggingId.value = id;
-  event.dataTransfer?.setData("text/plain", id);
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", id);
+  }
 }
-function onDragOver(id: string, event: DragEvent) {
+function onDragOver(event: DragEvent) {
   event.preventDefault();
+  if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+}
+function onDrop(id: string) {
   if (draggingId.value && draggingId.value !== id) {
-    const { reorderWorkgroup } = useWorkgroups();
     reorderWorkgroup(draggingId.value, id);
   }
+  draggingId.value = null;
 }
 function onDragEnd() {
   draggingId.value = null;
@@ -85,7 +92,8 @@ function onDragEnd() {
       :title="t('chipTitle')"
       @click="onChipClick(g.id)"
       @dragstart="onDragStart(g.id, $event)"
-      @dragover="onDragOver(g.id, $event)"
+      @dragover="onDragOver($event)"
+      @drop="onDrop(g.id)"
       @dragend="onDragEnd"
     >
       <span class="wg-name">{{ displayName(g) }}</span>
@@ -102,6 +110,7 @@ function onDragEnd() {
     <WorkgroupEditDialog
       v-if="editingGroup()"
       :group="editingGroup()!"
+      :can-delete="groups.length > 1"
       @save="onSave"
       @remove="onRemove"
       @cancel="editingId = null"

--- a/src/components/WorkgroupEditDialog.vue
+++ b/src/components/WorkgroupEditDialog.vue
@@ -1,0 +1,348 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { AI_AGENT_LABELS, ALL_AGENT_KINDS } from "../constants/aiAgents";
+import type { AiAgentKind, ClaudeCodeMode, Workgroup } from "../types/settings";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  group: Workgroup;
+}>();
+
+const emit = defineEmits<{
+  save: [patch: Partial<Workgroup>];
+  remove: [];
+  cancel: [];
+}>();
+
+// プリセット色（null = 無色）
+const PRESET_COLORS: (string | null)[] = [
+  null,
+  "#f38ba8", "#fab387", "#f9e2af",
+  "#a6e3a1", "#89b4fa", "#cba6f7", "#94e2d5",
+];
+
+const MODES: ClaudeCodeMode[] = ["plan", "manual", "acceptEdit", "auto"];
+
+const name = ref(props.group.name ?? "");
+const color = ref<string | null>(props.group.color ?? null);
+const autoAssignHotkey = ref(props.group.autoAssignHotkey ?? false);
+const taskAddAgent = ref<AiAgentKind | "">(props.group.taskAddAgent ?? "");
+const claudeCodeMode = ref<ClaudeCodeMode>(props.group.claudeCodeMode ?? "plan");
+const execPrompt = ref(props.group.execPrompt ?? "");
+
+function save() {
+  emit("save", {
+    name: name.value.trim() || undefined,
+    color: color.value ?? undefined,
+    autoAssignHotkey: autoAssignHotkey.value,
+    taskAddAgent: taskAddAgent.value || undefined,
+    claudeCodeMode: claudeCodeMode.value,
+    execPrompt: execPrompt.value.trim() || undefined,
+  });
+}
+</script>
+
+<template>
+  <div class="dialog-overlay" @click.self="emit('cancel')">
+    <div class="dialog">
+      <h3 class="dialog-title">{{ t('title') }}</h3>
+
+      <div class="field">
+        <label class="label">{{ t('name') }}</label>
+        <input v-model="name" class="text-in" type="text" :placeholder="t('namePlaceholder')" />
+      </div>
+
+      <div class="field">
+        <label class="label">{{ t('color') }}</label>
+        <div class="swatches">
+          <button
+            v-for="(c, i) in PRESET_COLORS"
+            :key="i"
+            class="swatch"
+            :class="{ selected: color === c }"
+            :style="{ background: c ?? 'transparent' }"
+            :title="c ?? t('noColor')"
+            @click="color = c"
+          >{{ c ? '' : '∅' }}</button>
+        </div>
+      </div>
+
+      <div class="divider" />
+
+      <div class="field checkbox-field">
+        <label class="checkbox-label">
+          <input v-model="autoAssignHotkey" type="checkbox" />
+          {{ t('autoAssignHotkey') }}
+        </label>
+      </div>
+
+      <div class="field">
+        <label class="label">{{ t('taskAddAgent') }}</label>
+        <select v-model="taskAddAgent" class="select">
+          <option value="">{{ t('notSet') }}</option>
+          <option v-for="kind in ALL_AGENT_KINDS" :key="kind" :value="kind">{{ AI_AGENT_LABELS[kind] }}</option>
+        </select>
+      </div>
+
+      <div v-if="taskAddAgent === 'claudeCode'" class="field">
+        <label class="label">{{ t('claudeCodeMode') }}</label>
+        <div class="mode-row">
+          <button
+            v-for="m in MODES"
+            :key="m"
+            class="mode-btn"
+            :class="{ selected: claudeCodeMode === m }"
+            @click="claudeCodeMode = m"
+          >{{ t('mode.' + m) }}</button>
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="label">{{ t('execPrompt') }}</label>
+        <textarea v-model="execPrompt" class="textarea" :placeholder="t('execPromptPlaceholder')" rows="4" />
+        <p class="hint">{{ t('execPromptHint') }}</p>
+      </div>
+
+      <div class="dialog-actions">
+        <button class="btn-remove" @click="emit('remove')">{{ t('removeGroup') }}</button>
+        <div class="spacer" />
+        <button class="btn-cancel" @click="emit('cancel')">{{ t('common.cancel') }}</button>
+        <button class="btn-primary" @click="save">{{ t('saveButton') }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.dialog {
+  background: #1e1e2e;
+  border: 1px solid #313244;
+  border-radius: 10px;
+  padding: 24px;
+  width: 460px;
+  max-width: 90vw;
+  max-height: 88vh;
+  overflow-y: auto;
+}
+
+.dialog-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #cba6f7;
+  margin: 0 0 16px;
+}
+
+.field {
+  margin-bottom: 14px;
+}
+
+.label {
+  display: block;
+  font-size: 12px;
+  color: #a6adc8;
+  margin-bottom: 5px;
+}
+
+.text-in,
+.select,
+.textarea {
+  width: 100%;
+  background: #313244;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 7px 10px;
+  font-size: 13px;
+  color: #cdd6f4;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.textarea {
+  resize: vertical;
+  font-family: monospace;
+  line-height: 1.5;
+}
+
+.select option {
+  background: #313244;
+}
+
+.swatches {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.swatch {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  border: 1px solid #45475a;
+  cursor: pointer;
+  color: #6c7086;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.swatch.selected {
+  border: 2px solid #cdd6f4;
+  box-shadow: 0 0 0 1px #1e1e2e;
+}
+
+.divider {
+  height: 1px;
+  background: #313244;
+  margin: 16px 0;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #cdd6f4;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+  cursor: pointer;
+  accent-color: #cba6f7;
+}
+
+.mode-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.mode-btn {
+  padding: 6px 12px;
+  border-radius: 5px;
+  border: 1px solid #45475a;
+  background: #313244;
+  color: #a6adc8;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mode-btn.selected {
+  background: #cba6f7;
+  color: #1e1e2e;
+  border-color: #cba6f7;
+}
+
+.hint {
+  font-size: 11px;
+  color: #6c7086;
+  margin: 5px 0 0;
+}
+
+.dialog-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.btn-cancel {
+  background: #313244;
+  color: #cdd6f4;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 7px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.btn-cancel:hover {
+  background: #45475a;
+}
+
+.btn-primary {
+  background: #cba6f7;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 4px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-primary:hover {
+  background: #b794e6;
+}
+
+.btn-remove {
+  background: transparent;
+  color: #f38ba8;
+  border: 1px solid rgba(243, 139, 168, 0.4);
+  border-radius: 4px;
+  padding: 7px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.btn-remove:hover {
+  background: rgba(243, 139, 168, 0.15);
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Edit workgroup",
+    "name": "Name",
+    "namePlaceholder": "Auto: Group (n) if empty",
+    "color": "Color",
+    "noColor": "No color",
+    "autoAssignHotkey": "Auto-assign hotkeys",
+    "taskAddAgent": "Task execution agent",
+    "notSet": "Not set (use global)",
+    "claudeCodeMode": "Claude Code mode",
+    "mode": { "plan": "Plan", "manual": "Manual", "acceptEdit": "AcceptEdit", "auto": "Auto" },
+    "execPrompt": "Execution prompt",
+    "execPromptPlaceholder": "e.g. Work on the following task.\n\n{{PROMPT}}",
+    "execPromptHint": "{{PROMPT}} is replaced with the task prompt. Empty = task prompt only.",
+    "saveButton": "Save",
+    "removeGroup": "Delete this group"
+  },
+  "ja": {
+    "title": "ワークグループの編集",
+    "name": "名称",
+    "namePlaceholder": "空欄なら「グループ(番号)」を自動採番",
+    "color": "色",
+    "noColor": "無色",
+    "autoAssignHotkey": "ホットキー自動割り当て",
+    "taskAddAgent": "タスク実行エージェント",
+    "notSet": "未設定（全体設定を使用）",
+    "claudeCodeMode": "Claude Code モード",
+    "mode": { "plan": "Plan", "manual": "Manual", "acceptEdit": "AcceptEdit", "auto": "Auto" },
+    "execPrompt": "実行プロンプト",
+    "execPromptPlaceholder": "例: 以下のタスクに取り組んでください。\n\n{{PROMPT}}",
+    "execPromptHint": "{{PROMPT}} がタスク実行プロンプトに置換されます。未指定ならプロンプトのみと等価。",
+    "saveButton": "保存",
+    "removeGroup": "このグループを削除"
+  }
+}
+</i18n>

--- a/src/components/WorkgroupEditDialog.vue
+++ b/src/components/WorkgroupEditDialog.vue
@@ -8,6 +8,7 @@ const { t } = useI18n();
 
 const props = defineProps<{
   group: Workgroup;
+  canDelete?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -106,7 +107,12 @@ function save() {
       </div>
 
       <div class="dialog-actions">
-        <button class="btn-remove" @click="emit('remove')">{{ t('removeGroup') }}</button>
+        <button
+          v-if="canDelete"
+          class="btn-remove"
+          :title="t('removeGroup')"
+          @click="emit('remove')"
+        >{{ t('removeGroup') }}</button>
         <div class="spacer" />
         <button class="btn-cancel" @click="emit('cancel')">{{ t('common.cancel') }}</button>
         <button class="btn-primary" @click="save">{{ t('saveButton') }}</button>

--- a/src/components/WorkgroupEditDialog.vue
+++ b/src/components/WorkgroupEditDialog.vue
@@ -328,8 +328,8 @@ function save() {
     "claudeCodeMode": "Claude Code mode",
     "mode": { "plan": "Plan", "manual": "Manual", "acceptEdit": "AcceptEdit", "auto": "Auto" },
     "execPrompt": "Execution prompt",
-    "execPromptPlaceholder": "e.g. Work on the following task.\n\n{{PROMPT}}",
-    "execPromptHint": "{{PROMPT}} is replaced with the task prompt. Empty = task prompt only.",
+    "execPromptPlaceholder": "e.g. Work on the following task.\n\n{'{{PROMPT}}'}",
+    "execPromptHint": "{'{{PROMPT}}'} is replaced with the task prompt. Empty = task prompt only.",
     "saveButton": "Save",
     "removeGroup": "Delete this group"
   },
@@ -345,8 +345,8 @@ function save() {
     "claudeCodeMode": "Claude Code モード",
     "mode": { "plan": "Plan", "manual": "Manual", "acceptEdit": "AcceptEdit", "auto": "Auto" },
     "execPrompt": "実行プロンプト",
-    "execPromptPlaceholder": "例: 以下のタスクに取り組んでください。\n\n{{PROMPT}}",
-    "execPromptHint": "{{PROMPT}} がタスク実行プロンプトに置換されます。未指定ならプロンプトのみと等価。",
+    "execPromptPlaceholder": "例: 以下のタスクに取り組んでください。\n\n{'{{PROMPT}}'}",
+    "execPromptHint": "{'{{PROMPT}}'} がタスク実行プロンプトに置換されます。未指定ならプロンプトのみと等価。",
     "saveButton": "保存",
     "removeGroup": "このグループを削除"
   }

--- a/src/components/WorktreeCard.vue
+++ b/src/components/WorktreeCard.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import type { Worktree } from "../types/worktree";
+import type { Workgroup } from "../types/settings";
 import { useI18n } from "vue-i18n";
+import { useWorkgroups } from "../composables/useWorkgroups";
 
 const { t } = useI18n();
+const { displayName: workgroupDisplayName } = useWorkgroups();
 import TerminalThumbnail from "./TerminalThumbnail.vue";
 import Popover from "primevue/popover";
 import Badge from "primevue/badge";
@@ -22,6 +25,8 @@ const props = defineProps<{
   aiJudging?: boolean;
   tooltip?: string;
   descriptionOpen?: boolean;
+  workgroups?: Workgroup[];
+  currentWorkgroupId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -41,6 +46,7 @@ const emit = defineEmits<{
   openArtifacts: [worktreeId: string];
   duplicateWorktree: [worktreeId: string];
   toggleDescription: [worktreeId: string];
+  moveToWorkgroup: [payload: { worktreeId: string; groupId: string }];
 }>();
 
 // ドラッグ（カード名のD&D並べ替え）直後に発火しうる click を1回だけ無視するためのフラグ。
@@ -74,9 +80,17 @@ function onCardClick(event: MouseEvent) {
 }
 
 const menuRef = ref<InstanceType<typeof Popover> | null>(null);
+const showGroupMenu = ref(false);
 
 function openMenu(event: MouseEvent) {
+  showGroupMenu.value = false;
   menuRef.value?.toggle(event);
+}
+
+function onMoveToWorkgroup(groupId: string) {
+  showGroupMenu.value = false;
+  menuRef.value?.hide();
+  emit("moveToWorkgroup", { worktreeId: props.worktree.id, groupId });
 }
 
 function onMoveWindow() {
@@ -226,6 +240,28 @@ const terminalList = computed(() =>
           <span class="pi pi-copy" />
           {{ t('menu.duplicate') }}
         </button>
+        <button
+          v-if="workgroups && workgroups.length > 0"
+          class="popup-item"
+          :disabled="loading"
+          @click="showGroupMenu = !showGroupMenu"
+        >
+          <span class="pi pi-folder" />
+          {{ t('menu.moveToWorkgroup') }}
+          <span :class="showGroupMenu ? 'pi pi-angle-down' : 'pi pi-angle-right'" style="margin-left: auto" />
+        </button>
+        <div v-if="showGroupMenu" class="popup-submenu">
+          <button
+            v-for="g in workgroups"
+            :key="g.id"
+            class="popup-item popup-subitem"
+            @click="onMoveToWorkgroup(g.id)"
+          >
+            <span class="group-dot" :style="{ background: g.color || '#9399b2' }" />
+            {{ workgroupDisplayName(g) }}
+            <span v-if="g.id === currentWorkgroupId" class="pi pi-check" style="margin-left: auto; color: var(--p-green-400)" />
+          </button>
+        </div>
         <div class="popup-divider" />
         <button class="popup-item popup-item-danger" :disabled="loading" @click="onDelete">
           <span class="pi pi-trash" />
@@ -470,6 +506,27 @@ const terminalList = computed(() =>
   margin: 4px 0;
 }
 
+.popup-submenu {
+  display: flex;
+  flex-direction: column;
+  border-left: 2px solid var(--p-content-border-color);
+  margin-left: 10px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.popup-subitem {
+  font-size: 12px;
+  padding-left: 10px;
+}
+
+.group-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 .loading-overlay {
   position: absolute;
   inset: 0;
@@ -528,6 +585,7 @@ const terminalList = computed(() =>
       "moveToSubWindow": "Move to sub window",
       "moveToMainWindow": "Move to main window",
       "duplicate": "Duplicate",
+      "moveToWorkgroup": "Move to group",
       "delete": "Delete"
     }
   },
@@ -548,6 +606,7 @@ const terminalList = computed(() =>
       "moveToSubWindow": "サブウィンドウに移動",
       "moveToMainWindow": "メインウィンドウに戻す",
       "duplicate": "複製",
+      "moveToWorkgroup": "グループ移動",
       "delete": "削除"
     }
   }

--- a/src/components/settings/SettingsHotkeySection.vue
+++ b/src/components/settings/SettingsHotkeySection.vue
@@ -10,16 +10,7 @@ const { settings, scheduleSave } = useSettings();
 <template>
   <div class="field-group">
     <label class="field-label">{{ t('hotkeys.label') }}</label>
-    <div class="row-input row-input--inline">
-      <input
-        id="auto-assign-hotkey"
-        type="checkbox"
-        class="toggle-checkbox"
-        :checked="settings.autoAssignHotkey"
-        @change="(e) => { settings.autoAssignHotkey = (e.target as HTMLInputElement).checked; scheduleSave(); }"
-      />
-      <label for="auto-assign-hotkey" class="inline-label toggle-label">{{ t('hotkeys.autoAssign') }}</label>
-    </div>
+    <!-- 「ホットキー自動割り当て」はワークグループ単位に移動 -->
     <table v-if="settings.hotkeys" class="hotkey-table">
       <thead>
         <tr>

--- a/src/composables/useAutoHotkey.ts
+++ b/src/composables/useAutoHotkey.ts
@@ -1,4 +1,5 @@
 import { useSettings } from "./useSettings";
+import { useWorkgroups } from "./useWorkgroups";
 
 const HOTKEY_POOL = [
   '1','2','3','4','5','6','7','8','9',
@@ -8,10 +9,18 @@ const HOTKEY_POOL = [
 
 export function useAutoHotkey() {
   const { settings, scheduleSave } = useSettings();
+  const { groupOf } = useWorkgroups();
 
   function tryAutoAssignHotkey(worktreeId: string) {
-    if (!settings.value.autoAssignHotkey) return;
+    const worktree = settings.value.worktrees.find((w) => w.id === worktreeId);
+    if (!worktree) return;
 
+    // 自動割り当ての有効/無効は所属グループ単位（未設定時はグローバル設定にフォールバック）
+    const group = groupOf(worktree);
+    const enabled = group?.autoAssignHotkey ?? settings.value.autoAssignHotkey ?? false;
+    if (!enabled) return;
+
+    // ホットキーのユニーク性は全ワークツリー横断で担保する（仕様: 変化しない）
     const used = new Set(
       settings.value.worktrees
         .filter((w) => w.hotkeyChar)
@@ -20,9 +29,6 @@ export function useAutoHotkey() {
 
     const freeChar = HOTKEY_POOL.find((c) => !used.has(c));
     if (!freeChar) return;
-
-    const worktree = settings.value.worktrees.find((w) => w.id === worktreeId);
-    if (!worktree) return;
 
     worktree.hotkeyChar = freeChar;
     scheduleSave();

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import { error } from "@tauri-apps/plugin-log";
 import { platform } from "@tauri-apps/plugin-os";
-import type { AppSettings, HotkeyBinding, HotkeySettings } from "../types/settings";
+import type { AppSettings, HotkeyBinding, HotkeySettings, Workgroup } from "../types/settings";
 import { setLocale } from "../i18n";
 import { setVerboseLogging } from "../utils/log";
 
@@ -56,6 +56,44 @@ function migrateHotkeys(hotkeys: HotkeySettings): boolean {
   return changed;
 }
 
+/**
+ * ワークグループ移行 (冪等):
+ * 1. グループが無ければデフォルトグループを1件作成し、旧グローバル設定を引き継ぐ
+ * 2. workgroupId 未設定 or 不明なグループを指すワークツリーを先頭グループへ割り当て
+ * 3. activeWorkgroupId を補完
+ * 変更があれば true を返す。
+ */
+function migrateWorkgroups(loaded: AppSettings): boolean {
+  let changed = false;
+
+  if (!loaded.workgroups || loaded.workgroups.length === 0) {
+    const defaultGroup: Workgroup = {
+      id: `wg-default-${Date.now()}`,
+      autoAssignHotkey: loaded.autoAssignHotkey ?? false,
+      taskAddAgent: loaded.aiAgent?.taskAddAgent,
+      claudeCodeMode: "plan",
+    };
+    loaded.workgroups = [defaultGroup];
+    changed = true;
+  }
+
+  const groupIds = new Set(loaded.workgroups.map((g) => g.id));
+  const firstId = loaded.workgroups[0].id;
+  for (const wt of loaded.worktrees) {
+    if (!wt.workgroupId || !groupIds.has(wt.workgroupId)) {
+      wt.workgroupId = firstId;
+      changed = true;
+    }
+  }
+
+  if (!loaded.activeWorkgroupId || !groupIds.has(loaded.activeWorkgroupId)) {
+    loaded.activeWorkgroupId = firstId;
+    changed = true;
+  }
+
+  return changed;
+}
+
 const settings = ref<AppSettings>({
   repositories: [],
   worktreeBaseDir: "",
@@ -92,8 +130,10 @@ async function loadSettings() {
   if (loaded.alwaysOnTop === undefined) {
     loaded.alwaysOnTop = false;
   }
-  // ホットキーマイグレーション (冪等)
-  if (migrateHotkeys(loaded.hotkeys)) {
+  // ホットキー・ワークグループ マイグレーション (冪等)
+  const hotkeyChanged = migrateHotkeys(loaded.hotkeys);
+  const workgroupChanged = migrateWorkgroups(loaded);
+  if (hotkeyChanged || workgroupChanged) {
     try {
       await invoke("save_settings", { settings: loaded });
     } catch (e) {

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -4,11 +4,30 @@ import { message } from "@tauri-apps/plugin-dialog";
 import { platform } from "@tauri-apps/plugin-os";
 import type { Ref } from "vue";
 import type TerminalView from "../components/TerminalView.vue";
-import type { WorktreeEntry, Repository, AppSettings } from "../types/settings";
+import type { WorktreeEntry, Repository, AppSettings, ClaudeCodeMode } from "../types/settings";
 import type { Worktree } from "../types/worktree";
 import type { AddWorktreeTaskCode, AgentWorktreeTaskCode } from "../types/task";
 import type { WebSessionInfo } from "../types/terminal";
 import { decodePtyOutput } from "../utils/decodePtyOutput";
+import { useWorkgroups } from "./useWorkgroups";
+
+/** Claude Code モード → permission-mode フラグ */
+function claudeModeFlag(mode?: ClaudeCodeMode): string {
+  switch (mode) {
+    case "manual": return "--permission-mode default";
+    case "acceptEdit": return "--permission-mode acceptEdits";
+    case "auto": return "--permission-mode bypassPermissions";
+    case "plan":
+    default: return "--permission-mode plan";
+  }
+}
+
+/** 実行プロンプトテンプレートの {{PROMPT}} を実プロンプトに置換。未指定なら実プロンプトそのまま */
+function applyExecPrompt(template: string | undefined, prompt: string): string {
+  if (!template || !template.trim()) return prompt;
+  if (template.includes("{{PROMPT}}")) return template.split("{{PROMPT}}").join(prompt);
+  return `${template}\n\n${prompt}`;
+}
 
 export function useTaskExecution(deps: {
   t: (key: string, values?: Record<string, unknown>) => string;
@@ -51,6 +70,8 @@ export function useTaskExecution(deps: {
     autoApprovalMap,
     onWebSessionDetected,
   } = deps;
+
+  const { groupOf, activeWorkgroupId } = useWorkgroups();
 
   function randomSuffix(): string {
     return Math.random().toString(36).slice(2, 6);
@@ -230,6 +251,7 @@ export function useTaskExecution(deps: {
       repositoryName: repo.name,
       path: `${settings.value.worktreeBaseDir}/${worktreeName}`,
       branchName: code.branch,
+      workgroupId: activeWorkgroupId.value || undefined,
     };
 
     addWorktreePlaceholder(entry);
@@ -341,7 +363,9 @@ export function useTaskExecution(deps: {
       return;
     }
 
-    const agentKind = settings.value.aiAgent?.taskAddAgent ?? settings.value.aiAgent?.approvalAgent ?? "claudeCode";
+    // タスク実行エージェント・モード・実行プロンプトは所属ワークグループ単位
+    const group = groupOf(wt);
+    const agentKind = group?.taskAddAgent ?? settings.value.aiAgent?.taskAddAgent ?? settings.value.aiAgent?.approvalAgent ?? "claudeCode";
     const isWindows = platform() === "windows";
     const shell = resolveShell(wt.id);
     const shellLower = (shell ?? "").toLowerCase();
@@ -350,12 +374,14 @@ export function useTaskExecution(deps: {
       shellLower.includes("pwsh") ||
       (shell === undefined && isWindows);
 
-    // 一時ファイルにプロンプトを書き出し
-    const tempPath = await invoke<string>("write_temp_prompt", { content: code.prompt });
+    // 実行プロンプトテンプレート ({{PROMPT}}) を適用してから一時ファイルへ書き出し
+    const finalPrompt = applyExecPrompt(group?.execPrompt, code.prompt);
+    const tempPath = await invoke<string>("write_temp_prompt", { content: finalPrompt });
 
+    const claudeMode = claudeModeFlag(group?.claudeCodeMode);
     let agentCmd: string;
     switch (agentKind) {
-      case "claudeCode": agentCmd = code.remoteExec ? "claude --remote" : "claude --permission-mode plan"; break;
+      case "claudeCode": agentCmd = code.remoteExec ? `claude --remote ${claudeMode}` : `claude ${claudeMode}`; break;
       case "geminiCli":  agentCmd = "gemini"; break;
       case "codexCli":   agentCmd = "codex"; break;
       case "clineCli":   agentCmd = "cline"; break;

--- a/src/composables/useWorkgroups.ts
+++ b/src/composables/useWorkgroups.ts
@@ -1,0 +1,125 @@
+import { computed } from "vue";
+import { useSettings } from "./useSettings";
+import { useWorktrees } from "./useWorktrees";
+import { i18n } from "../i18n";
+import type { Workgroup } from "../types/settings";
+
+const { settings, scheduleSave } = useSettings();
+const { worktrees } = useWorktrees();
+
+function genId(): string {
+  return `wg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** ワークグループ一覧（settings.workgroups の参照） */
+const groups = computed<Workgroup[]>(() => settings.value.workgroups ?? []);
+
+/** 選択中のワークグループID。未設定/存在しない場合は先頭グループにフォールバック */
+const activeWorkgroupId = computed<string>({
+  get() {
+    const list = groups.value;
+    const cur = settings.value.activeWorkgroupId;
+    if (cur && list.some((g) => g.id === cur)) return cur;
+    return list[0]?.id ?? "";
+  },
+  set(id: string) {
+    settings.value.activeWorkgroupId = id;
+    scheduleSave();
+  },
+});
+
+/** worktree が実際に属するグループID（未設定/不明なら先頭グループにフォールバック） */
+function resolvedGroupId(workgroupId: string | undefined): string {
+  const list = groups.value;
+  if (workgroupId && list.some((g) => g.id === workgroupId)) return workgroupId;
+  return list[0]?.id ?? "";
+}
+
+/** worktree が属するグループを返す（フォールバック込み） */
+function groupOf(worktree: { workgroupId?: string }): Workgroup | undefined {
+  const id = resolvedGroupId(worktree.workgroupId);
+  return groups.value.find((g) => g.id === id);
+}
+
+/** グループの表示名（未設定なら「グループ(番号)」を自動生成） */
+function displayName(group: Workgroup): string {
+  if (group.name && group.name.trim()) return group.name;
+  const idx = groups.value.findIndex((g) => g.id === group.id);
+  return i18n.global.t("workgroup.autoName", { n: idx + 1 });
+}
+
+/** グループに属するワークツリー数（フォールバック込み） */
+function worktreeCount(groupId: string): number {
+  return settings.value.worktrees.filter(
+    (w) => resolvedGroupId(w.workgroupId) === groupId,
+  ).length;
+}
+
+/** 新しいグループを追加して選択状態にする */
+function addWorkgroup(): Workgroup {
+  if (!settings.value.workgroups) settings.value.workgroups = [];
+  const group: Workgroup = {
+    id: genId(),
+    autoAssignHotkey: settings.value.autoAssignHotkey ?? false,
+    claudeCodeMode: "plan",
+  };
+  settings.value.workgroups.push(group);
+  settings.value.activeWorkgroupId = group.id;
+  scheduleSave();
+  return group;
+}
+
+/** グループの属性を更新する */
+function updateWorkgroup(id: string, patch: Partial<Workgroup>): void {
+  const group = settings.value.workgroups?.find((g) => g.id === id);
+  if (!group) return;
+  Object.assign(group, patch);
+  scheduleSave();
+}
+
+/** グループレコードを削除する（所属ワークツリーの削除は呼び出し側で済ませておくこと） */
+function deleteWorkgroupRecord(id: string): void {
+  if (!settings.value.workgroups) return;
+  settings.value.workgroups = settings.value.workgroups.filter((g) => g.id !== id);
+  if (settings.value.activeWorkgroupId === id) {
+    settings.value.activeWorkgroupId = settings.value.workgroups[0]?.id;
+  }
+  scheduleSave();
+}
+
+/** グループの並び替え（fromId を toId の位置へ） */
+function reorderWorkgroup(fromId: string, toId: string): void {
+  if (fromId === toId || !settings.value.workgroups) return;
+  const list = settings.value.workgroups;
+  const fromIdx = list.findIndex((g) => g.id === fromId);
+  const toIdx = list.findIndex((g) => g.id === toId);
+  if (fromIdx === -1 || toIdx === -1) return;
+  const [item] = list.splice(fromIdx, 1);
+  list.splice(toIdx, 0, item);
+  scheduleSave();
+}
+
+/** ワークツリーを別グループへ移動する */
+function moveWorktreeToWorkgroup(worktreeId: string, groupId: string): void {
+  const entry = settings.value.worktrees.find((w) => w.id === worktreeId);
+  if (entry) entry.workgroupId = groupId;
+  const wt = worktrees.value.find((w) => w.id === worktreeId);
+  if (wt) wt.workgroupId = groupId;
+  scheduleSave();
+}
+
+export function useWorkgroups() {
+  return {
+    groups,
+    activeWorkgroupId,
+    resolvedGroupId,
+    groupOf,
+    displayName,
+    worktreeCount,
+    addWorkgroup,
+    updateWorkgroup,
+    deleteWorkgroupRecord,
+    reorderWorkgroup,
+    moveWorktreeToWorkgroup,
+  };
+}

--- a/src/composables/useWorktreeRemove.ts
+++ b/src/composables/useWorktreeRemove.ts
@@ -208,6 +208,7 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
           branch_name: worktree.branchName,
           archived_at: Date.now(),
           description: worktree.description ?? null,
+          workgroup_id: worktree.workgroupId ?? null,
         });
       },
       async (worktree) => {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -14,6 +14,9 @@ export default {
     clear: 'Clear',
     notConfigured: 'Not configured',
   },
+  workgroup: {
+    autoName: 'Group ({n})',
+  },
   search: {
     noResults: '0 results',
     results: '{count} results',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -14,6 +14,9 @@ export default {
     clear: 'クリア',
     notConfigured: '未設定',
   },
+  workgroup: {
+    autoName: 'グループ({n})',
+  },
   search: {
     noResults: '0件',
     results: '{count}件',

--- a/src/types/archive.ts
+++ b/src/types/archive.ts
@@ -8,6 +8,7 @@ export interface ArchiveRow {
   branch_name: string;
   archived_at: number;
   description?: string | null;
+  workgroup_id?: string | null;
 }
 
 export interface ArchiveListResult {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -28,6 +28,20 @@ export interface WorktreeEntry {
   autoApprovalPrompt?: string;
   description?: string; // AIが自動生成する説明（ExitPlanMode hookでプランを要約してセット）
   descriptionOpen?: boolean; // ホームカードの description 開閉状態（ワークツリー毎）
+  workgroupId?: string; // 所属するワークグループのID（未設定は先頭グループにフォールバック）
+}
+
+// Claude Code の起動モード（taskAddAgent が claudeCode のときのみ意味を持つ）
+export type ClaudeCodeMode = 'plan' | 'manual' | 'acceptEdit' | 'auto';
+
+export interface Workgroup {
+  id: string;
+  name?: string;                    // 未指定時は表示時に「グループ(番号)」を生成
+  color?: string;                   // プリセット色。未指定 = 無色
+  autoAssignHotkey?: boolean;       // ホットキー自動割り当て（グループ単位）
+  taskAddAgent?: AiAgentKind;       // タスク実行エージェント（グループ単位）
+  claudeCodeMode?: ClaudeCodeMode;  // Claude Code モード（既定: plan）
+  execPrompt?: string;              // 実行プロンプトテンプレート（置換タグ {{PROMPT}}）
 }
 
 export interface TerminalSettings {
@@ -99,6 +113,8 @@ export interface AppSettings {
   repositories: Repository[];
   worktreeBaseDir: string;
   worktrees: WorktreeEntry[];
+  workgroups?: Workgroup[];
+  activeWorkgroupId?: string; // ホームで選択中のワークグループ
   terminal: TerminalSettings;
   hotkeys: HotkeySettings;
   alwaysOnTop: boolean;


### PR DESCRIPTION
## 概要
ワークツリーをグルーピングする「ワークグループ」機能を追加します。ワークグループは管理上の概念で、実際のワークツリーの位置には影響しません。仕様: Obsidian `omaera/oretachi_ワークグループ`。

## 主な変更
- **データモデル**: `Workgroup` 型・`ClaudeCodeMode` 型を新設。`WorktreeEntry.workgroupId`、`AppSettings.workgroups`/`activeWorkgroupId` を追加（TS + Rust）。アーカイブDBに `workgroup_id` カラムを追加（所属グループの記録）。
- **起動時マイグレーション**: グループが無ければデフォルトグループを作成し既存ワークツリーを集約。旧グローバル設定（`autoAssignHotkey` / `taskAddAgent`）を引き継ぎ（冪等）。
- **グループ単位化**: ホットキー自動割り当て・タスク実行エージェント・Claude Code モード（`plan`/`manual`/`acceptEdit`/`auto`）・実行プロンプト（`{{PROMPT}}` 置換）をワークグループ単位に移動。ホットキーのユニーク性は全体で担保。
- **UI**:
  - `WorkgroupBar`: ホームのセレクトボックス右隣に折り返し可能なチップバー（名前 + 件数バッジ + 色、再クリックで編集、追加、D&D 並び替え）。
  - `WorkgroupEditDialog`: 名称 / 色プリセット / 各種グループ設定（モードは Claude Code 選択時のみ表示）。
  - `RemoveWorkgroupDialog`: 確認 → 所属ワークツリー全削除 → グループ削除。最後の1グループは削除不可。
  - `WorktreeCard`: メニューに「グループ移動」サブメニューを追加。
  - `HomeView`: アクティブグループでワークツリー一覧をフィルタ。
- 設定タブから移行済み項目（ホットキー自動割り当て・タスク実行エージェント）を削除。
- タスク追加からのワークツリー追加・アーカイブは現在表示中グループに紐付け。

## レビュー対応
- セキュリティレビュー: 高確信度の脆弱性なし。
- バグレビュー指摘を修正: 新規ワークツリーの `workgroupId` 付与順、最後の1グループ削除不可ガード、D&D を drop 時確定に変更。
- i18n の `{{PROMPT}}` をリテラル補間でエスケープ（unplugin-vue-i18n エラー解消）。

## 検証
- `pnpm run type-check`: エラーなし
- `cargo check`: exit 0
- `vite build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)