### PR TITLE
fix(task): ClaudeCode の Auto モードを bypassPermissions ではなく auto にマッピング

### DIFF
--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -16,7 +16,7 @@ function claudeModeFlag(mode?: ClaudeCodeMode): string {
   switch (mode) {
     case "manual": return "--permission-mode default";
     case "acceptEdit": return "--permission-mode acceptEdits";
-    case "auto": return "--permission-mode bypassPermissions";
+    case "auto": return "--permission-mode auto";
     case "plan":
     default: return "--permission-mode plan";
   }


### PR DESCRIPTION
## 概要

ワークグループのタスク実行で Claude Code「Auto」モードを選択したとき、誤って `--permission-mode bypassPermissions`（全ての許可確認を完全スキップする最も危険なモード）に変換されていた問題を修正する。

Claude Code には 2026年3月リリースの正規モード `--permission-mode auto`（Anthropic のサーバーサイド安全分類器が危険なアクションのみブロックし、ルーチンな許可確認を削減する）が存在するため、そちらを渡すように修正した。`bypassPermissions` とは安全性の意味が真逆であった。

## 変更内容

`src/composables/useTaskExecution.ts` の `claudeModeFlag()` で、`auto` の戻り値を `--permission-mode bypassPermissions` から `--permission-mode auto` に変更。

型・UI選択肢・保存/マイグレーション処理は変更不要（UIラベル「Auto」も実態と一致）。

## 検証

- `pnpm run type-check` 通過
- ワークグループで ClaudeCode・Auto を設定 → タスク実行時の起動コマンドが `claude --permission-mode auto ...` になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
