### PR TITLE
fix(task): タスク生成のMCP認証ヘッダ欠落によるタイムアウトを解消 + 追加先ワークグループ選択

### DIFF
--- a/src-tauri/src/task_executor.rs
+++ b/src-tauri/src/task_executor.rs
@@ -190,7 +190,10 @@ pub async fn task_generate(
             "mcpServers": {
                 "oretachi": {
                     "type": "http",
-                    "url": format!("http://127.0.0.1:{}/mcp", port)
+                    "url": format!("http://127.0.0.1:{}/mcp", port),
+                    "headers": {
+                        "Authorization": format!("Bearer {}", settings.mcp_api_key)
+                    }
                 }
             }
         });
@@ -220,6 +223,8 @@ pub async fn task_generate(
             JSON_SCHEMA.to_string(),
             "--mcp-config".to_string(),
             config_path.to_string_lossy().to_string(),
+            // プラグイン側の同名 oretachi サーバとの二重ロードを防ぐ
+            "--strict-mcp-config".to_string(),
         ]);
 
         (prog, a, final_prompt, Some(config_path))

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@ import { useWorktreeRemove } from "./composables/useWorktreeRemove";
 import { useRemoveWorktreeDialog } from "./composables/useRemoveWorktreeDialog";
 import { useAutoHotkey } from "./composables/useAutoHotkey";
 import { useWorkgroups } from "./composables/useWorkgroups";
+import { useHomePanel } from "./composables/useHomePanel";
 import { useAppAutoApproval } from "./composables/useAppAutoApproval";
 import { useAppHotkeys } from "./composables/useAppHotkeys";
 import { useSubWindowEvents } from "./composables/useSubWindowEvents";
@@ -355,6 +356,15 @@ const activeTaskExecAgent = computed(() => {
   const g = settings.value.workgroups?.find((w) => w.id === activeWorkgroupId.value);
   return g?.taskAddAgent ?? settings.value.aiAgent?.taskAddAgent ?? settings.value.aiAgent?.approvalAgent;
 });
+
+// タスク追加ダイアログ「追加先」のデフォルト:
+// ホームのパネルが worktree 一覧なら現在選択中グループ、それ以外（task/archive）なら先頭グループ
+const { panelMode } = useHomePanel();
+const taskDialogDefaultWorkgroupId = computed(() =>
+  panelMode.value === "worktree"
+    ? activeWorkgroupId.value
+    : (settings.value.workgroups?.[0]?.id ?? ""),
+);
 
 // ワークグループ削除フロー
 const removeWorkgroupId = ref<string | null>(null);
@@ -1795,7 +1805,8 @@ onMounted(async () => {
       :mode="rerunTaskId ? 'rerun' : 'add'"
       :show-remote-exec="activeTaskExecAgent === 'claudeCode'"
       :initial-remote-exec="settings.aiAgent?.remoteExec ?? false"
-      @confirm="(prompt, remoteExec) => onAddTaskConfirm(prompt, remoteExec)"
+      :initial-workgroup-id="taskDialogDefaultWorkgroupId"
+      @confirm="(prompt, remoteExec, workgroupId) => onAddTaskConfirm(prompt, remoteExec, workgroupId)"
       @cancel="onAddTaskCancel"
     />
 

--- a/src/components/AddTaskDialog.vue
+++ b/src/components/AddTaskDialog.vue
@@ -1,23 +1,27 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
+import { useWorkgroups } from "../composables/useWorkgroups";
 
 const { t } = useI18n();
+const { groups, displayName } = useWorkgroups();
 
 const props = withDefaults(defineProps<{
   initialPrompt?: string;
   mode?: "add" | "rerun";
   showRemoteExec?: boolean;
   initialRemoteExec?: boolean;
+  initialWorkgroupId?: string;
 }>(), {
   initialPrompt: "",
   mode: "add",
   showRemoteExec: false,
   initialRemoteExec: false,
+  initialWorkgroupId: "",
 });
 
 const emit = defineEmits<{
-  confirm: [prompt: string, remoteExec: boolean];
+  confirm: [prompt: string, remoteExec: boolean, workgroupId: string];
   cancel: [];
 }>();
 
@@ -25,6 +29,7 @@ const promptText = ref(props.initialPrompt);
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const showConfirm = ref(false);
 const remoteExec = ref(props.initialRemoteExec);
+const selectedWorkgroupId = ref(props.initialWorkgroupId);
 
 const isDirty = computed(() => promptText.value.trim() !== props.initialPrompt.trim());
 
@@ -35,7 +40,7 @@ onMounted(() => {
 function confirm() {
   const trimmed = promptText.value.trim();
   if (!trimmed) return;
-  emit("confirm", trimmed, remoteExec.value);
+  emit("confirm", trimmed, remoteExec.value, selectedWorkgroupId.value);
 }
 
 function tryCancel() {
@@ -88,6 +93,13 @@ function onKeydown(e: KeyboardEvent) {
           @keydown="onKeydown"
         />
         <p class="hint">{{ t('submitHint') }}</p>
+      </div>
+
+      <div v-if="groups.length > 1" class="field">
+        <label class="label">{{ t('destination') }}</label>
+        <select v-model="selectedWorkgroupId" class="select">
+          <option v-for="g in groups" :key="g.id" :value="g.id">{{ displayName(g) }}</option>
+        </select>
       </div>
 
       <div v-if="showRemoteExec" class="field checkbox-field">
@@ -173,6 +185,24 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 .textarea:focus {
+  border-color: #cba6f7;
+}
+
+.select {
+  width: 100%;
+  background: #313244;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-size: 13px;
+  color: #cdd6f4;
+  outline: none;
+  box-sizing: border-box;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.select:focus {
   border-color: #cba6f7;
 }
 
@@ -304,6 +334,7 @@ function onKeydown(e: KeyboardEvent) {
     "addTitle": "Add Task",
     "rerunTitle": "Rerun Task",
     "prompt": "Prompt",
+    "destination": "Destination",
     "promptPlaceholder": "e.g. Implement https://github.com/owner/repo/issues/123",
     "submitHint": "Ctrl+Enter to submit",
     "remoteExec": "Start in web session",
@@ -317,6 +348,7 @@ function onKeydown(e: KeyboardEvent) {
     "addTitle": "タスクを追加",
     "rerunTitle": "タスクを再実行",
     "prompt": "プロンプト",
+    "destination": "追加先",
     "promptPlaceholder": "例: https://github.com/owner/repo/issues/123 を実装してください",
     "submitHint": "Ctrl+Enter で送信",
     "remoteExec": "Webセッションで開始",

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -11,6 +11,7 @@ import WorkgroupBar from "./WorkgroupBar.vue";
 import { useMasonryLayout } from "../composables/useMasonryLayout";
 import { useSettings } from "../composables/useSettings";
 import { useWorkgroups } from "../composables/useWorkgroups";
+import { useHomePanel } from "../composables/useHomePanel";
 import { useTasks } from "../composables/useTasks";
 import { useTaskPersistence } from "../composables/useTaskPersistence";
 import { useTaskSearch } from "../composables/useTaskSearch";
@@ -229,8 +230,7 @@ const emit = defineEmits<{
   removeWorkgroup: [groupId: string];
 }>();
 
-type PanelMode = "worktree" | "task" | "archive";
-const panelMode = ref<PanelMode>("worktree");
+const { panelMode } = useHomePanel();
 
 const { sortedTasks } = useTasks();
 const { hasMore, isLoading, loadTasks, loadMore, search } = useTaskPersistence();

--- a/src/composables/useAddTaskDialog.ts
+++ b/src/composables/useAddTaskDialog.ts
@@ -67,7 +67,7 @@ export function useAddTaskDialog(executeStep: StepExecutor) {
     }
   }
 
-  async function onAddTaskConfirm(prompt: string, remoteExec: boolean = false): Promise<void> {
+  async function onAddTaskConfirm(prompt: string, remoteExec: boolean = false, workgroupId?: string): Promise<void> {
     const trimmed = prompt.trim();
     if (!trimmed) return;
     prompt = trimmed;
@@ -94,6 +94,13 @@ export function useAddTaskDialog(executeStep: StepExecutor) {
         for (const code of taskProcessCode.code) {
           if (code.type === "agent_worktree") {
             code.remoteExec = true;
+          }
+        }
+      }
+      if (workgroupId) {
+        for (const code of taskProcessCode.code) {
+          if (code.type === "add_worktree") {
+            code.workgroupId = workgroupId;
           }
         }
       }

--- a/src/composables/useHomePanel.ts
+++ b/src/composables/useHomePanel.ts
@@ -1,0 +1,13 @@
+import { ref } from "vue";
+
+export type HomePanelMode = "worktree" | "task" | "archive";
+
+/** ホームタブのパネル表示モード（worktree 一覧 / task / archive）。
+ *  HomeView がローカルに持っていた状態を、App.vue 等からも参照できるようモジュールシングトンとして共有する。 */
+const panelMode = ref<HomePanelMode>("worktree");
+
+export function useHomePanel() {
+  return {
+    panelMode,
+  };
+}

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -251,7 +251,7 @@ export function useTaskExecution(deps: {
       repositoryName: repo.name,
       path: `${settings.value.worktreeBaseDir}/${worktreeName}`,
       branchName: code.branch,
-      workgroupId: activeWorkgroupId.value || undefined,
+      workgroupId: code.workgroupId ?? (activeWorkgroupId.value || undefined),
     };
 
     addWorktreePlaceholder(entry);

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -3,6 +3,7 @@ export type AddWorktreeTaskCode = {
   repository: string;
   branch: string;
   source_branch?: string;
+  workgroupId?: string;
 };
 
 export type AgentWorktreeTaskCode = {


### PR DESCRIPTION
## 概要

タスク追加（コード生成）が時間切れでタイムアウトする不具合を修正し、あわせてタスク実行ダイアログに追加先ワークグループの選択機能を追加します。

## 修正内容

### 1. タスク生成のタイムアウト解消（`6889e08`）
`task_generate` の `claude -p` に渡す `--mcp-config` が `Authorization` ヘッダを欠いており、MCP サーバに 401 で弾かれていた。その結果、システムプロンプトが指示する `oretachi_list_repository` / `oretachi_get_worktree_status` を叩けず、リトライしたまま制限時間まで張り付いてタイムアウトしていた。

- `mcp_api_key` を使った `Bearer` 認証ヘッダを追加（プラグイン側 `claude_plugin.rs` と同様）
- プラグイン側の同名 `oretachi` サーバとの二重ロードを防ぐ `--strict-mcp-config` を付与

**根拠（実機ログ）**: タイムアウト発生時はいずれも起動直後に `[mcp] unauthorized request: missing or invalid API key` が出力され、MCP ツール呼び出しが一度も成功しないまま `AI agent timed out` に至っていた。

### 2. 追加先ワークグループ選択（`e29f10e`）
タスク実行ダイアログで追加先ワークグループを選択可能に。デフォルトはホームのパネルが worktree 一覧なら現在選択中グループ、task/archive パネルなら先頭ワークグループ。選択した `workgroupId` を `add_worktree` コードへ注入して新規ワークツリーへ反映する。

## 確認

- `cargo check` 成功
- security-review: HIGH/MEDIUM 指摘なし（MCP 接続に認証を付与する純粋なセキュリティ改善）
- bug-review: critical 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)