### PR TITLE
fix(updater): relaunch 時の Job kill-on-close 解除でアプリ内アップデート失敗を修正

### DIFF
--- a/src-tauri/src/job_object.rs
+++ b/src-tauri/src/job_object.rs
@@ -67,11 +67,45 @@ mod imp {
             log::info!("[job] assigned current process to kill-on-close job object");
         }
     }
+
+    /// Job の `KILL_ON_JOB_CLOSE` を解除する。
+    ///
+    /// アップデートの relaunch では、updater が起動したインストーラ（msiexec/setup.exe）が
+    /// 子プロセスとして本 Job 配下に入る。このまま自プロセスが終了すると最後の Job ハンドルが
+    /// 閉じられ、KILL_ON_JOB_CLOSE によりインストーラごと巻き込み終了されてしまう
+    /// （昇格プロンプトが出る前に殺され、更新がサイレント失敗する）。
+    /// relaunch 直前に本関数でフラグを外し、インストーラを延命させる。
+    ///
+    /// 注: フラグを外すだけで CloseHandle はしない（割当方針は据え置き）。失敗しても致命にしない。
+    pub fn release_kill_on_close() {
+        let Some(&job) = JOB.get() else {
+            return;
+        };
+        unsafe {
+            // LimitFlags=0 を再適用して KILL_ON_JOB_CLOSE を解除する。
+            let info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            let ok = SetInformationJobObject(
+                job as HANDLE,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            );
+            if ok == 0 {
+                log::warn!("[job] failed to clear KILL_ON_JOB_CLOSE; updater installer may be killed on relaunch");
+            } else {
+                log::info!("[job] cleared KILL_ON_JOB_CLOSE for update relaunch");
+            }
+        }
+    }
 }
 
 #[cfg(target_os = "windows")]
-pub use imp::assign_current_process_to_job;
+pub use imp::{assign_current_process_to_job, release_kill_on_close};
 
 /// 非 Windows では no-op。
 #[cfg(not(target_os = "windows"))]
 pub fn assign_current_process_to_job() {}
+
+/// 非 Windows では no-op。
+#[cfg(not(target_os = "windows"))]
+pub fn release_kill_on_close() {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -501,6 +501,9 @@ async fn prepare_for_relaunch(app_handle: tauri::AppHandle) -> Result<(), String
     if !completed {
         return Err("MCP server did not shut down within timeout".into());
     }
+    // relaunch でプロセス終了すると Job ハンドルが閉じ、KILL_ON_JOB_CLOSE により updater が
+    // 起動したインストーラごと巻き込み終了されてしまう。relaunch 直前にフラグを解除して延命させる。
+    job_object::release_kill_on_close();
     Ok(())
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1527,14 +1527,27 @@ onMounted(async () => {
   // 起動後にアップデートを確認 (ウィザード表示中はネイティブダイアログが
   // 割り込まないよう完了まで保留する)
   const runUpdateCheck = async () => {
-    const update = await checkForUpdate();
+    // 起動時の自動チェック。確認失敗は無音（無反応）にしてユーザーを煩わせない。
+    let update: Awaited<ReturnType<typeof checkForUpdate>>;
+    try {
+      update = await checkForUpdate();
+    } catch {
+      return;
+    }
     if (update) {
       const yes = await ask(
         t("update.available", { version: update.version }),
         { title: t("update.title"), kind: "info" }
       );
       if (yes) {
-        await downloadAndInstall(update);
+        try {
+          await downloadAndInstall(update);
+        } catch (e) {
+          await message(t("update.installFailed", { error: String(e) }), {
+            title: t("update.title"),
+            kind: "error",
+          });
+        }
       }
     }
   };

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -42,13 +42,31 @@ async function onUiScaleChange(value: string) {
 }
 
 async function onCheckUpdate() {
-  const update = await checkForUpdate();
+  let update: Awaited<ReturnType<typeof checkForUpdate>>;
+  try {
+    update = await checkForUpdate();
+  } catch (e) {
+    await message(t("update.checkFailed", { error: String(e) }), {
+      title: t("update.title"),
+      kind: "error",
+    });
+    return;
+  }
   if (update) {
     const yes = await ask(
       t("update.available", { version: update.version }),
       { title: t("update.title"), kind: "info" }
     );
-    if (yes) await downloadAndInstall(update);
+    if (yes) {
+      try {
+        await downloadAndInstall(update);
+      } catch (e) {
+        await message(t("update.installFailed", { error: String(e) }), {
+          title: t("update.title"),
+          kind: "error",
+        });
+      }
+    }
   } else {
     await message(t("about.upToDate"), { title: t("update.title"), kind: "info" });
   }

--- a/src/composables/useUpdater.ts
+++ b/src/composables/useUpdater.ts
@@ -8,6 +8,7 @@ export function useUpdater() {
   const isChecking = ref(false);
   const isDownloading = ref(false);
 
+  // 更新なしは null を返す。確認自体に失敗した場合は例外を投げ、呼び出し側で表示する。
   async function checkForUpdate() {
     if (isChecking.value) return null;
     isChecking.value = true;
@@ -17,14 +18,16 @@ export function useUpdater() {
         logInfo(`アップデート利用可能: ${update.version}`);
         return update;
       }
+      return null;
     } catch (e) {
       logError(`アップデート確認エラー: ${e}`);
+      throw e;
     } finally {
       isChecking.value = false;
     }
-    return null;
   }
 
+  // 失敗時は例外を投げ、呼び出し側で表示する（従来は無反応だった）。
   async function downloadAndInstall(update: Awaited<ReturnType<typeof check>>) {
     if (!update) return;
     isDownloading.value = true;
@@ -34,6 +37,7 @@ export function useUpdater() {
       await relaunch();
     } catch (e) {
       logError(`アップデートインストールエラー: ${e}`);
+      throw e;
     } finally {
       isDownloading.value = false;
     }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -30,6 +30,8 @@ export default {
   update: {
     title: 'oretachi Update',
     available: 'A new version {version} is available. Update now?',
+    checkFailed: 'Failed to check for updates.\n{error}',
+    installFailed: 'Failed to install the update.\n{error}',
   },
   about: {
     label: 'About',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -30,6 +30,8 @@ export default {
   update: {
     title: 'oretachi アップデート',
     available: '新しいバージョン {version} が利用可能です。今すぐ更新しますか？',
+    checkFailed: 'アップデートの確認に失敗しました。\n{error}',
+    installFailed: 'アップデートのインストールに失敗しました。\n{error}',
   },
   about: {
     label: 'バージョン情報',


### PR DESCRIPTION
## 概要

一部の Windows 端末でアプリ内からの 0.24.1 へのバージョンアップが失敗していた問題を修正する。手動でインストーラをダウンロードして起動すると更新できる、という症状だった。

## 真因

0.24.0 で追加した Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, `src-tauri/src/job_object.rs`) が、updater の起動したインストーラ（子プロセスは既定で親の Job を継承）を `relaunch()` のアプリ終了時に巻き込み終了させていた。

アップデートのフロー:

```
await update.downloadAndInstall();   // updater がインストーラを子プロセスとして起動
await invoke("prepare_for_relaunch"); // MCP 停止待ち
await relaunch();                     // oretachi 終了 → Job ハンドルが閉じる → インストーラごと kill
```

インストーラが昇格(UAC)を発火する前に kill されるため「昇格プロンプトが出ずにサイレント失敗」していた。

観測事実との整合:
- **今回(0.24.x)から発生** … Job Object は 0.24.0 で追加。≤0.23.x の updater には Job が無く成功していた
- **昇格プロンプトが出なくなった** … インストーラが昇格前に kill される
- **一部端末だけ** … 昇格して AppInfo サービス経由で起動されたプロセスは Job から breakaway するため、昇格タイミング/競合次第で生き残る端末と殺される端末が出る
- **手動なら成功** … 手動起動のインストーラは oretachi の子ではなく Job 外

## 変更内容

- **`job_object.rs`**: `release_kill_on_close()` を追加。割当済み Job に `LimitFlags=0` を再適用して `KILL_ON_JOB_CLOSE` のみ解除（CloseHandle はしない）。Windows 実装 + 非 Windows no-op
- **`lib.rs`**: `prepare_for_relaunch`（relaunch 直前の唯一のチョークポイント）から呼び出し。通常終了/クラッシュ経路は解除を通らないため孤児化防止のセーフティネットは維持
- **`useUpdater.ts`**: 失敗時に例外を呼び出し側へ伝搬（従来は `logError` のみで無反応）
- **`App.vue` / `SettingsView.vue`**: 失敗を `message()` のエラーダイアログで表示（起動時自動チェックの確認失敗のみ無音）
- **`i18n` (ja/en)**: `update.checkFailed` / `update.installFailed` を追加

## ⚠️ 重要な運用上の注意

アップデートを実行するのは「更新先」ではなく「現在インストール済み」の版の updater。本修正を 0.24.2 に入れても、**すでに 0.24.0 / 0.24.1 が入っている端末は壊れた updater で更新するため、0.24.2 への自動更新は依然失敗する**。それらの端末は **一度だけ手動で 0.24.2 を導入**する必要がある。0.24.2 以降同士の自動更新は正常化する。リリースノート/社内案内への明記が必要。

## 検証

- `cargo check` ✅ / `pnpm run type-check` ✅
- security-review ✅（新規の脆弱性なし）
- bug-review ✅（重大なバグなし）
- 実機検証（修正版→新ダミー版の自動更新で昇格プロンプト表示・完走・失敗系ダイアログ表示）は別途実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
