### PR TITLE
fix(task): PR URL のブランチ名 fetch をやめタスク生成のタイムアウトを解消

### DIFF
--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1544,7 +1544,17 @@ async fn api_key_auth(
     if authorized {
         Ok(next.run(request).await)
     } else {
-        log::warn!("[mcp] unauthorized request: missing or invalid API key");
+        // 再発時の切り分け用に最小限の差分情報を出す（秘密値そのものは出さない）。
+        let reason = match auth_header {
+            None => "authorization header missing".to_string(),
+            Some(h) if !h.starts_with("Bearer ") => "authorization header is not a Bearer token".to_string(),
+            Some(h) => format!(
+                "key mismatch (provided len={}, expected len={})",
+                h.len().saturating_sub(7),
+                expected_key.len()
+            ),
+        };
+        log::warn!("[mcp] unauthorized request: {}", reason);
         Err(StatusCode::UNAUTHORIZED)
     }
 }

--- a/src-tauri/src/task_executor.rs
+++ b/src-tauri/src/task_executor.rs
@@ -33,10 +33,10 @@ request and repositories, and perform appropriate worktree operations.
 3. Generate the task process code and output it as JSON.
 
 ## Task List Generation Rules
-- When an issue URL is specified, compare it with the remote information from
-  oretachi_list_repository to select the repository. Do NOT look into the issue or
-  pull request contents - only compare repository names and remote information. Leave
-  precise matching to later flows.
+- When an issue or pull request URL is specified, compare it with the remote information
+  from oretachi_list_repository to select the repository. Do NOT look into (fetch) the
+  issue or pull request contents - only compare repository names and remote information.
+  Leave precise matching to later flows.
 - The "prompt" field in agent_worktree MUST contain the user's original words verbatim.
   Do NOT rephrase, summarize, elaborate, or make the request more specific.
 - If the request maps to a single task, copy the entire user request as-is into the prompt field.
@@ -46,12 +46,12 @@ request and repositories, and perform appropriate worktree operations.
   splitting only — the downstream AI agent will interpret the prompt.
 - When only an issue URL is provided or context is unclear, pass the full text as-is.
 - By default, each task creates a new worktree (add_worktree + agent_worktree).
-- Use an EXISTING worktree (agent_worktree only, no add_worktree) in these cases:
-  - A pull request URL is provided: fetch the PR's branch name and check if it matches
-    an existing worktree's branch. If it matches, use that worktree.
-  - The user explicitly refers to a previous task (e.g. "continue the task for X"):
-    use the existing worktree only if the repository AND branch/name exactly match.
-    Do not reuse a worktree just because the repository is the same.
+- Use an EXISTING worktree (agent_worktree only, no add_worktree) ONLY when the user
+  explicitly refers to a previous task (e.g. "continue the task for X"): use the existing
+  worktree only if the repository AND branch/name exactly match. Do not reuse a worktree
+  just because the repository is the same.
+  - Do NOT fetch a pull request's branch name to look for a matching worktree. Treat a
+    pull request URL like any other request and create a new worktree by default.
 - When a specific branch name is provided in the request:
   1. First check if any existing worktree uses that exact branch. If yes, use that
      existing worktree (agent_worktree only, no add_worktree).
@@ -169,17 +169,15 @@ pub async fn task_generate(
     let use_mcp =
         agent_kind == AiAgentKind::ClaudeCode && mcp_status.running && mcp_status.port.is_some();
 
-    // For non-MCP agents, embed repo list and worktree list directly in prompt
-    let final_prompt = if use_mcp {
-        full_prompt
-    } else {
-        format!(
-            "{}\n\n{}\n\n{}",
-            full_prompt,
-            build_repo_list_text(&settings),
-            build_worktree_list_text(&settings)
-        )
-    };
+    // repo / worktree 一覧は常にプロンプトへ直接埋め込む。
+    // use_mcp 時も MCP 往復(401等)に依存せず生成できるようにし、ハング→タイムアウトを防ぐ。
+    // MCP 設定(--mcp-config)は最新情報の追加ソースとして残す。
+    let final_prompt = format!(
+        "{}\n\n{}\n\n{}",
+        full_prompt,
+        build_repo_list_text(&settings),
+        build_worktree_list_text(&settings)
+    );
 
     // Build command and args
     // mcp_config_temp_path: Some(path) なら処理完了後に削除する

--- a/src/composables/useAddTaskDialog.ts
+++ b/src/composables/useAddTaskDialog.ts
@@ -5,6 +5,7 @@ import { useI18n } from "vue-i18n";
 import type { ToastMessageOptions } from "primevue/toast";
 import { useTasks } from "./useTasks";
 import { useSettings } from "./useSettings";
+import { useWorkgroups } from "./useWorkgroups";
 import type { TaskCode, TaskProcessCode } from "../types/task";
 
 type StepExecutor = (code: TaskCode) => Promise<void>;
@@ -15,6 +16,7 @@ export function useAddTaskDialog(executeStep: StepExecutor) {
   const toast = useToast();
   const { t } = useI18n();
   const { settings, scheduleSave } = useSettings();
+  const { activeWorkgroupId } = useWorkgroups();
   const { sortedTasks, addTask, setTaskSteps, updateStepStatus, updateTaskStatus } = useTasks();
 
   const showAddTaskDialog = ref(false);
@@ -73,6 +75,10 @@ export function useAddTaskDialog(executeStep: StepExecutor) {
     prompt = trimmed;
     showAddTaskDialog.value = false;
     rerunTaskId.value = null;
+    // 追加先WGをアクティブにして、作成される worktree が現在のホーム表示に出るようにする
+    if (workgroupId) {
+      activeWorkgroupId.value = workgroupId;
+    }
     if (settings.value.aiAgent) {
       settings.value.aiAgent.remoteExec = remoteExec;
     } else {


### PR DESCRIPTION
## 背景

「タスクのタイムアウトを修正したつもりが直っていない。非デフォルトのワークグループを指定するとタスク追加トーストが止まって見え、後でエラーになる」という報告を調査。

ログ調査で、タイムアウトの最有力の残存原因は **PR URL のブランチ名 fetch 指示**であることが判明した。プランナー用システムプロンプトが「PR URL のときは PR のブランチ名を fetch して既存 worktree と照合せよ」と指示していたため、`claude -p` が GitHub へ問い合わせ（`gh pr view` 等）に行きハング・タイムアウトしていた。MCP 認証ヘッダ追加（#87 / 6889e08）はこの fetch には効かないため「直したのに直っていない」が説明できる。

- 証拠（修正前ログ）: 07:56〜08:08 の連続4回のタイムアウト（180/180/240/240s）はすべて同一の PR URL タスク（`.../pull/18229`）で、08:13 にようやく成功。

## 変更内容

- **`task_executor.rs`（修正0・最優先）**: PR URL を Issue URL と同列に扱い、中身を fetch せずリポジトリ名/リモート情報だけで判定し既定どおり新規 worktree を作成。`49-51行` の PR ブランチ fetch 指示を削除。→ task 生成段階の GitHub 往復が消え、PR URL タスクの遅延・タイムアウトを解消。
- **`task_executor.rs`（修正1・堅牢化）**: `task_generate` で repo/worktree 一覧を `use_mcp` の真偽に関わらず常にプロンプトへ埋め込み。MCP が 401 等で失敗しても埋め込み済みコンテキストから生成でき、ハングが原理的に消える。
- **`mcp_server.rs`（修正2）**: `api_key_auth` の 401 ログを「ヘッダ欠落 / Bearer 不正 / キー長不一致（長さのみ）」に細分化。秘密値は出さず再発時の切り分けを容易に。
- **`useAddTaskDialog.ts`（修正3）**: 非デフォルトWGへタスク追加時に `activeWorkgroupId` を追加先へ切替。作成 worktree が現在のホーム表示に出るようにし「止まって見える」誤認を解消。

## 検証

- `cd src-tauri && cargo check` / `pnpm run type-check` ともにパス。
- PR URL でタスク追加 → `[TaskGenerate] AI agent response` が短時間で返りタイムアウトしないこと、出力が新規 worktree（add_worktree + agent_worktree）であること。
- WG を2つ以上用意し非デフォルトWGでタスク追加 → 作成 worktree がそのWGのホームに表示されること。
- セキュリティレビュー / バグレビューともに確定指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
