### PR TITLE
feat(hotkey): ホームタブでワークグループを循環切替するホットキーを追加

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -126,6 +126,14 @@ fn default_add_task() -> HotkeyBinding {
     platform_hotkey(true, false, "n")
 }
 
+fn default_workgroup_next() -> HotkeyBinding {
+    HotkeyBinding { ctrl: true, meta: false, shift: false, alt: false, key: "PageDown".to_string() }
+}
+
+fn default_workgroup_prev() -> HotkeyBinding {
+    HotkeyBinding { ctrl: true, meta: false, shift: false, alt: false, key: "PageUp".to_string() }
+}
+
 fn default_global_tray_popup() -> HotkeyBinding {
     platform_hotkey(true, false, "o")
 }
@@ -168,6 +176,10 @@ pub struct HotkeySettings {
     pub home_tab: HotkeyBinding,
     #[serde(default = "default_add_task", rename = "addTask")]
     pub add_task: HotkeyBinding,
+    #[serde(default = "default_workgroup_next", rename = "workgroupNext")]
+    pub workgroup_next: HotkeyBinding,
+    #[serde(default = "default_workgroup_prev", rename = "workgroupPrev")]
+    pub workgroup_prev: HotkeyBinding,
 }
 
 impl Default for HotkeySettings {
@@ -181,6 +193,8 @@ impl Default for HotkeySettings {
             tray_next: default_tray_next(),
             home_tab: default_home_tab(),
             add_task: default_add_task(),
+            workgroup_next: default_workgroup_next(),
+            workgroup_prev: default_workgroup_prev(),
         }
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -349,7 +349,7 @@ const {
 } = useRemoveWorktreeDialog(worktreeRemoveCore);
 
 // ワークグループ
-const { activeWorkgroupId, resolvedGroupId, deleteWorkgroupRecord, displayName: workgroupDisplayName } = useWorkgroups();
+const { activeWorkgroupId, cycleWorkgroup, resolvedGroupId, deleteWorkgroupRecord, displayName: workgroupDisplayName } = useWorkgroups();
 
 // タスク追加ダイアログ用: 現在表示中グループのタスク実行エージェント（リモート実行チェックボックスの出し分け）
 const activeTaskExecAgent = computed(() => {
@@ -1113,6 +1113,7 @@ const hotkeys = useAppHotkeys({
   onAddTerminal,
   showAddTaskDialog,
   goHome,
+  cycleWorkgroup,
   onTrayButtonClick,
   suppressed: showFirstRunWizard,
 });

--- a/src/components/settings/SettingsHotkeySection.vue
+++ b/src/components/settings/SettingsHotkeySection.vue
@@ -91,6 +91,24 @@ const { settings, scheduleSave } = useSettings();
             />
           </td>
         </tr>
+        <tr>
+          <td class="hotkey-td-label">{{ t('hotkeys.workgroupNext') }}</td>
+          <td class="hotkey-td-input">
+            <HotkeyInput
+              :model-value="settings.hotkeys.workgroupNext"
+              @update:model-value="(v) => { settings.hotkeys.workgroupNext = v; scheduleSave(); }"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td class="hotkey-td-label">{{ t('hotkeys.workgroupPrev') }}</td>
+          <td class="hotkey-td-input">
+            <HotkeyInput
+              :model-value="settings.hotkeys.workgroupPrev"
+              @update:model-value="(v) => { settings.hotkeys.workgroupPrev = v; scheduleSave(); }"
+            />
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -111,7 +129,9 @@ const { settings, scheduleSave } = useSettings();
       "terminalClose": "Close terminal",
       "trayNext": "Next notification (tray)",
       "homeTab": "Home tab",
-      "addTask": "Add task"
+      "addTask": "Add task",
+      "workgroupNext": "Switch workgroup: next",
+      "workgroupPrev": "Switch workgroup: prev"
     }
   },
   "ja": {
@@ -127,7 +147,9 @@ const { settings, scheduleSave } = useSettings();
       "terminalClose": "ターミナルを閉じる",
       "trayNext": "次の通知へ (トレイ)",
       "homeTab": "ホームタブへ戻る",
-      "addTask": "タスク追加"
+      "addTask": "タスク追加",
+      "workgroupNext": "ワークグループ切替: 次",
+      "workgroupPrev": "ワークグループ切替: 前"
     }
   }
 }

--- a/src/composables/useAppHotkeys.ts
+++ b/src/composables/useAppHotkeys.ts
@@ -23,6 +23,7 @@ interface UseAppHotkeysDeps {
   ) => Promise<void>;
   showAddTaskDialog: Ref<boolean>;
   goHome: () => void;
+  cycleWorkgroup: (delta: number) => void;
   onTrayButtonClick: () => Promise<void>;
   /** true の間はアプリ内ホットキーを無効化する (初回起動ウィザード表示中など) */
   suppressed?: Ref<boolean>;
@@ -135,6 +136,16 @@ export function useAppHotkeys(deps: UseAppHotkeysDeps) {
           deps.goHome();
         },
       });
+    }
+
+    // ワークグループ切替はホーム表示時のみ有効（非ホーム時はキーを横取りしない）
+    if (deps.viewMode.value === "home") {
+      if (hk.workgroupNext) {
+        actions.push({ binding: hk.workgroupNext, handler: () => deps.cycleWorkgroup(1) });
+      }
+      if (hk.workgroupPrev) {
+        actions.push({ binding: hk.workgroupPrev, handler: () => deps.cycleWorkgroup(-1) });
+      }
     }
 
     return actions;

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -18,6 +18,8 @@ const defaultHotkeys = () => ({
   trayNext: isMac ? { meta: true, key: "n" } : { ctrl: true, key: "n" },
   homeTab: { alt: true, key: "0" },
   addTask: isMac ? { meta: true, shift: true, key: "n" } : { ctrl: true, shift: true, key: "n" },
+  workgroupNext: { ctrl: true, key: "PageDown" },
+  workgroupPrev: { ctrl: true, key: "PageUp" },
 });
 
 function migrateHotkeys(hotkeys: HotkeySettings): boolean {

--- a/src/composables/useWorkgroups.ts
+++ b/src/composables/useWorkgroups.ts
@@ -28,6 +28,16 @@ const activeWorkgroupId = computed<string>({
   },
 });
 
+/** アクティブグループを delta だけ循環移動（末尾↔先頭でラップ） */
+function cycleWorkgroup(delta: number): void {
+  const list = groups.value;
+  if (list.length <= 1) return;
+  const idx = list.findIndex((g) => g.id === activeWorkgroupId.value);
+  const base = idx === -1 ? 0 : idx;
+  const next = (base + delta + list.length) % list.length;
+  activeWorkgroupId.value = list[next].id;
+}
+
 /** worktree が実際に属するグループID（未設定/不明なら先頭グループにフォールバック） */
 function resolvedGroupId(workgroupId: string | undefined): string {
   const list = groups.value;
@@ -112,6 +122,7 @@ export function useWorkgroups() {
   return {
     groups,
     activeWorkgroupId,
+    cycleWorkgroup,
     resolvedGroupId,
     groupOf,
     displayName,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -68,6 +68,8 @@ export interface HotkeySettings {
   trayNext: HotkeyBinding;      // デフォルト: { ctrl: true, key: "n" }
   homeTab: HotkeyBinding;         // デフォルト: { alt: true, key: "0" }
   addTask: HotkeyBinding;       // デフォルト: { ctrl: true, shift: true, key: "n" }
+  workgroupNext: HotkeyBinding; // デフォルト: { ctrl: true, key: "PageDown" }
+  workgroupPrev: HotkeyBinding; // デフォルト: { ctrl: true, key: "PageUp" }
 }
 
 export type AiAgentKind = 'claudeCode' | 'geminiCli' | 'codexCli' | 'clineCli';


### PR DESCRIPTION
## 概要
メインウィンドウのホームタブで、ワークグループを次/前へ循環切替するホットキーを追加しました。

- 既定キー: `Ctrl+PageDown`=次 / `Ctrl+PageUp`=前
- 有効範囲: **ホームタブ表示時のみ**（`viewMode === home`）。ターミナル表示中はキーを横取りしません
- 末尾↔先頭でラップ、`WorkgroupBar` のチップ並び順に従う
- 設定画面（設定 → ホットキー）から任意キーへ再割り当て可能

## 変更内容
| ファイル | 変更 |
|---|---|
| `src/composables/useWorkgroups.ts` | `cycleWorkgroup(delta)` を追加（末尾↔先頭ラップ） |
| `src/types/settings.ts` | `HotkeySettings` に `workgroupNext` / `workgroupPrev` を追加 |
| `src/composables/useSettings.ts` | `defaultHotkeys()` に既定値を追加 |
| `src-tauri/src/settings.rs` | Rust側デフォルト関数・structフィールド・`Default` impl を追加（serde default 付きで旧設定互換） |
| `src/composables/useAppHotkeys.ts` | `cycleWorkgroup` deps + ホーム時のみアクション登録 |
| `src/App.vue` | `useWorkgroups` から `cycleWorkgroup` を取得し `useAppHotkeys` へ配線 |
| `src/components/settings/SettingsHotkeySection.vue` | 設定UIに2行 + i18n(en/ja) を追加 |

## 検証
- `pnpm run type-check` 通過
- `cargo check`（src-tauri）通過
- セキュリティレビュー: 指摘なし
- bug-review: 指摘なし

## 設計上のポイント
- 既存のホットキー基盤（`HotkeySettings` → `useHotkeyListener` → 設定UI）にそのまま乗せたため、`settings-changed` で即反映。
- 旧 `settings.json` でも `#[serde(default)]` とフロント側マージで欠損補完され、破壊的変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)