### PR TITLE
fix(updater): Windows でアップデートが起動しない不具合を修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -492,19 +492,47 @@ async fn restart_mcp_server(app_handle: tauri::AppHandle) -> Result<mcp_server::
 }
 
 #[tauri::command]
-async fn prepare_for_relaunch(app_handle: tauri::AppHandle) -> Result<(), String> {
-    let mcp_manager = app_handle.state::<mcp_server::McpServerManager>();
-    let _lock = mcp_manager.acquire_restart_lock().await;
-    let completed = mcp_manager
-        .stop_and_wait(std::time::Duration::from_secs(3))
-        .await;
-    if !completed {
-        return Err("MCP server did not shut down within timeout".into());
+async fn download_and_install_update(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri_plugin_updater::UpdaterExt;
+
+    // 自前の on_before_exit を設定した Updater を構築する。
+    // プラグイン既定の on_before_exit (cleanup_before_exit) を踏襲しつつ、
+    // KILL_ON_JOB_CLOSE 解除を追加する。これは Windows で ShellExecute による
+    // インストーラ起動と process::exit(0) の「前」に走る (tauri-plugin-updater updater.rs)。
+    // 既存実装は relaunch 後の prepare_for_relaunch で解除していたが、Windows では
+    // downloadAndInstall 内で process::exit(0) され JS に戻らないため解除されず、
+    // インストーラが Job の巻き込み終了で殺されてアップデートが起動しなかった。
+    let app_hook = app.clone();
+    let updater = app
+        .updater_builder()
+        .on_before_exit(move || {
+            app_hook.cleanup_before_exit();
+            job_object::release_kill_on_close();
+        })
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let Some(update) = updater.check().await.map_err(|e| e.to_string())? else {
+        return Ok(()); // 更新なし
+    };
+
+    // 先にダウンロード。成功してから MCP を止める（失敗時はサーバを生かす）。
+    let bytes = update
+        .download(|_, _| {}, || {})
+        .await
+        .map_err(|e| e.to_string())?;
+
+    {
+        let mcp = app.state::<mcp_server::McpServerManager>();
+        let _lock = mcp.acquire_restart_lock().await;
+        mcp.stop_and_wait(std::time::Duration::from_secs(3)).await;
     }
-    // relaunch でプロセス終了すると Job ハンドルが閉じ、KILL_ON_JOB_CLOSE により updater が
-    // 起動したインストーラごと巻き込み終了されてしまう。relaunch 直前にフラグを解除して延命させる。
-    job_object::release_kill_on_close();
-    Ok(())
+
+    // Windows: install() 内で on_before_exit→process::exit(0) され、ここから戻らない。
+    update.install(bytes).map_err(|e| e.to_string())?;
+
+    // 非 Windows（mac 等）はここで明示再起動。restart() は `!` を返す。
+    app.restart();
 }
 
 // ─── アーティファクトコマンド ─────────────────────────────────────────────────
@@ -991,7 +1019,7 @@ pub fn run() {
             regenerate_mcp_api_key,
             mcp_server::register_detached_worktree,
             mcp_server::unregister_detached_worktree,
-            prepare_for_relaunch,
+            download_and_install_update,
             ai_judge::judge_approval,
             ai_judge::cancel_approval,
             ai_commit_message::generate_commit_message,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -506,6 +506,13 @@ async fn download_and_install_update(app: tauri::AppHandle) -> Result<(), String
     let updater = app
         .updater_builder()
         .on_before_exit(move || {
+            // Windows ではこの後 process::exit(0) され RunEvent::Exit のクリーンアップ
+            // (PtyManager::kill_all_fast 等) が走らない。KILL_ON_JOB_CLOSE を解除すると
+            // Job のセーフティネットも外れるため、解除の「前」に PTY 子プロセス
+            // (ターミナル / AI エージェント) を明示 kill してオーファン化を防ぐ。
+            app_hook
+                .state::<PtyManager>()
+                .kill_all_fast("update-before-exit");
             app_hook.cleanup_before_exit();
             job_object::release_kill_on_close();
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -516,22 +516,24 @@ async fn download_and_install_update(app: tauri::AppHandle) -> Result<(), String
         return Ok(()); // 更新なし
     };
 
-    // 先にダウンロード。成功してから MCP を止める（失敗時はサーバを生かす）。
     let bytes = update
         .download(|_, _| {}, || {})
         .await
         .map_err(|e| e.to_string())?;
 
+    // install() は Windows では成功時に on_before_exit→process::exit(0) され戻らない。
+    // 失敗 (extract 失敗等、インストーラ起動前) 時のみ Err を返す。ここで MCP を止めて
+    // しまうと install 失敗時に MCP が落ちたまま残るため、MCP の停止は install 後
+    // （= 非 Windows の成功パスでのみ到達）に行う。
+    update.install(bytes).map_err(|e| e.to_string())?;
+
+    // 非 Windows（mac 等）のみ到達。restart() 前に MCP を停止してポート競合を避け、
+    // その後明示再起動する。restart() は `!` を返す。
     {
         let mcp = app.state::<mcp_server::McpServerManager>();
         let _lock = mcp.acquire_restart_lock().await;
         mcp.stop_and_wait(std::time::Duration::from_secs(3)).await;
     }
-
-    // Windows: install() 内で on_before_exit→process::exit(0) され、ここから戻らない。
-    update.install(bytes).map_err(|e| e.to_string())?;
-
-    // 非 Windows（mac 等）はここで明示再起動。restart() は `!` を返す。
     app.restart();
 }
 

--- a/src/composables/useUpdater.ts
+++ b/src/composables/useUpdater.ts
@@ -1,6 +1,5 @@
 import { ref } from "vue";
 import { check } from "@tauri-apps/plugin-updater";
-import { relaunch } from "@tauri-apps/plugin-process";
 import { logError, logInfo } from "../utils/log";
 import { invoke } from "@tauri-apps/api/core";
 
@@ -32,9 +31,12 @@ export function useUpdater() {
     if (!update) return;
     isDownloading.value = true;
     try {
-      await update.downloadAndInstall();
-      await invoke("prepare_for_relaunch");
-      await relaunch();
+      // チェック・ダウンロード・インストールを Rust 側コマンドで実施する。
+      // Windows ではインストーラ起動直前に Job の KILL_ON_JOB_CLOSE を解除する
+      // 必要があり、プラグインの downloadAndInstall では process::exit され
+      // JS に戻らないためフックを差し込めない（巻き込み終了でアップデート不発）。
+      await invoke("download_and_install_update");
+      // Windows ではプロセスが置き換わるためここに戻らない。
     } catch (e) {
       logError(`アップデートインストールエラー: ${e}`);
       throw e;


### PR DESCRIPTION
## 背景

oretachi の自動アップデートを実行しても、新バージョンのインストーラが起動せず、毎回同じバージョンで再起動して「更新あり」を再検出するループに陥っていた。コミット `6580c76`「fix(updater): relaunch 時に Job の kill-on-close を解除」で修正済みのはずだが、Windows では全く効いていなかった。

## 根本原因（ログ・crate ソース解析で確定）

1. Windows 起動時にプロセスを `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` 付き Job に割り当てている（アプリ終了時に PTY/WebView2 等の子プロセスを確実に終了させるため）。
2. updater がインストーラ（msiexec/NSIS）を子プロセスとして起動すると同じ Job に入り、アプリ本体終了で Job が閉じると `KILL_ON_JOB_CLOSE` によりインストーラが巻き込み終了 → 更新が完了しない。
3. 既存修正は `release_kill_on_close()` を `prepare_for_relaunch` コマンドに置き、フロントが `update.downloadAndInstall()` の**後**に invoke していた。
4. しかし `tauri-plugin-updater` 2.10.0 の Windows 実装 `Update::install_inner` は、`on_before_exit` フック → `ShellExecuteW` でインストーラ起動 → **`std::process::exit(0)`** を呼び、**JS に戻らない**。プラグインの `Builder` は `on_before_exit` を公開しておらず、`process::exit(0)` は Tauri の `RunEvent::Exit` も迂回するため、`release_kill_on_close()` は一度も実行されなかった（実ログでも `cleared KILL_ON_JOB_CLOSE` は 0 回）。

## 修正内容

正しいフック点である `UpdaterBuilder::on_before_exit`（インストーラ起動と `process::exit(0)` の**前**に走る）を使うよう、インストール処理を Rust 側の独自コマンドに移した。

- **`src-tauri/src/lib.rs`**: `prepare_for_relaunch` を `download_and_install_update` に置換。`app.updater_builder().on_before_exit(...)` で以下を設定した Updater を構築し、check → download → install →（非Windowsのみ）MCP停止 → restart を実行。
  - `on_before_exit` 内で `PtyManager::kill_all_fast` → `cleanup_before_exit` → `release_kill_on_close` の順に実行（Job 解除前に PTY 子プロセスを明示終了し orphan 化を防止）
  - MCP 停止は `install()` の**後**（非Windowsの成功パスのみ到達）に配置し、install 失敗時に MCP が落ちたまま残る回帰を回避
- **`src/composables/useUpdater.ts`**: `downloadAndInstall` を `invoke("download_and_install_update")` 呼び出しに変更。不要な `relaunch` import を削除。

## レビュー

- 署名検証は維持（`download()` 内で minisign 検証が完了してから `install()` に渡る）。security-review でも新規脆弱性なしと確認。
- bug-review: install 失敗時の MCP 停止残り回帰を検出 → 修正（53b13b2）
- codex-review: Job 解除での PTY 子プロセス orphan 化を検出 → 修正（9ba3b4a）

## 検証

- [x] `cd src-tauri && cargo check`
- [x] `pnpm run type-check`
- [ ] 実機 E2E（Windows）: version を一時的に下げてビルド・インストール後、最新版へ更新し、`oretachi.log` に `[job] cleared KILL_ON_JOB_CLOSE for update relaunch` が出力され、新バージョンに更新されてループしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
