### PR TITLE
fix(workgroup): 高速切替によるワークツリー分裂を解消

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -74,7 +74,7 @@ type ViewMode = "home" | "settings" | "terminal";
 
 const { settings, loadSettings, scheduleSave, flushSave } = useSettings();
 const { appliedZoom } = useUiZoom();
-const { worktrees, loadWorktreesFromSettings, addWorktreePlaceholder, invokeWorktreeAdd, commitWorktree, rollbackWorktree, reorderWorktree, saveWorktreeOrder, restoreWorktreeOrder, addTerminal, removeTerminal, updateTerminalTitle, saveTerminalSession, loadTerminalSession } = useWorktrees();
+const { worktrees, loadWorktreesFromSettings, syncWorktreesFromSettings, addWorktreePlaceholder, invokeWorktreeAdd, commitWorktree, rollbackWorktree, reorderWorktree, saveWorktreeOrder, restoreWorktreeOrder, addTerminal, removeTerminal, updateTerminalTitle, saveTerminalSession, loadTerminalSession } = useWorktrees();
 const { detachedWorktrees, isDetached, moveToSubWindow, moveToMainWindow, focusSubWindow, unregisterSubWindow, getPendingInitData, clearPendingInitData, getDetachedSessionId, registerTerminalSession, closeAllSubWindows } = useSubWindows();
 const { autoApprovalPromptMap, lastJudgedCommandMap, showAutoApprovalPromptDialog, autoApprovalPromptTargetId, restoreFromSettings: restoreAutoApprovalPrompts, onClickAutoApproval, onSaveAutoApprovalPrompt } = useAutoApprovalPrompt(settings, scheduleSave, isDetached);
 const { notifications, initNotificationListener, addNotification, clearNotification, purgeStaleNotifications, getNotifiedWorktreeIds, getTotalNotificationCount } = useNotifications();
@@ -1114,6 +1114,7 @@ const hotkeys = useAppHotkeys({
   showAddTaskDialog,
   goHome,
   cycleWorkgroup,
+  syncWorktreesFromSettings,
   onTrayButtonClick,
   suppressed: showFirstRunWizard,
 });

--- a/src/composables/useAppHotkeys.ts
+++ b/src/composables/useAppHotkeys.ts
@@ -24,6 +24,7 @@ interface UseAppHotkeysDeps {
   showAddTaskDialog: Ref<boolean>;
   goHome: () => void;
   cycleWorkgroup: (delta: number) => void;
+  syncWorktreesFromSettings?: () => void;
   onTrayButtonClick: () => Promise<void>;
   /** true の間はアプリ内ホットキーを無効化する (初回起動ウィザード表示中など) */
   suppressed?: Ref<boolean>;
@@ -154,8 +155,13 @@ export function useAppHotkeys(deps: UseAppHotkeysDeps) {
   async function init() {
     await registerGlobalShortcut();
 
-    await listen("settings-changed", async () => {
+    await listen<{ source?: string } | null>("settings-changed", async (event) => {
+      // 自ウィンドウの保存に由来する settings-changed は無視する。
+      // 自分の保存で自分が再ロードすると、in-memory 変更を巻き戻す lost update や
+      // ランタイム配列との乖離（ワークツリー分裂）が起きるため。
+      if (event.payload?.source === getCurrentWindow().label) return;
       await deps.loadSettings();
+      deps.syncWorktreesFromSettings?.();
       await getCurrentWindow().setAlwaysOnTop(deps.settings.value.alwaysOnTop);
       await registerGlobalShortcut();
     });

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -1,6 +1,7 @@
 import { ref, watch } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { error } from "@tauri-apps/plugin-log";
 import { platform } from "@tauri-apps/plugin-os";
 import type { AppSettings, HotkeyBinding, HotkeySettings, Workgroup } from "../types/settings";
@@ -116,7 +117,7 @@ watch(
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
-async function loadSettings() {
+async function loadSettingsOnce() {
   const loaded = await invoke<AppSettings>("get_settings");
   // 古い設定ファイルに hotkeys がない場合のデフォルト補完
   if (!loaded.hotkeys) {
@@ -148,12 +149,40 @@ async function loadSettings() {
   settings.value = loaded;
 }
 
+// 再入防止 (coalescing): 実行中に再度呼ばれたら 1 回だけ追加実行する。
+// settings-changed の連続発火で loadSettings が並行起動し、get_settings の
+// 戻り順前後で古い内容が新しい内容を上書きする競合を構造的に排除する。
+let loadInflight: Promise<void> | null = null;
+let loadRerun = false;
+
+async function loadSettings(): Promise<void> {
+  if (loadInflight) {
+    loadRerun = true;
+    return loadInflight;
+  }
+  loadInflight = (async () => {
+    do {
+      loadRerun = false;
+      try {
+        await loadSettingsOnce();
+      } catch (e) {
+        // get_settings 失敗時も rerun を取りこぼさず、呼び出し側に reject を
+        // 伝播させない（リスナーの後続処理が止まらないようにする）。
+        console.error("設定の読み込みに失敗:", e);
+      }
+    } while (loadRerun);
+  })().finally(() => {
+    loadInflight = null;
+  });
+  return loadInflight;
+}
+
 function scheduleSave() {
   if (saveTimer) clearTimeout(saveTimer);
   saveTimer = setTimeout(async () => {
     try {
       await invoke("save_settings", { settings: settings.value });
-      await emit("settings-changed");
+      await emit("settings-changed", { source: getCurrentWindow().label });
     } catch (e) {
       console.error("設定の保存に失敗:", e);
     }
@@ -167,7 +196,7 @@ async function flushSave() {
   }
   try {
     await invoke("save_settings", { settings: settings.value });
-    await emit("settings-changed");
+    await emit("settings-changed", { source: getCurrentWindow().label });
   } catch (e) {
     error(`設定の保存に失敗: ${e}`);
   }

--- a/src/composables/useWorktrees.ts
+++ b/src/composables/useWorktrees.ts
@@ -17,6 +17,27 @@ function loadWorktreesFromSettings() {
   }));
 }
 
+/**
+ * settings.value.worktrees を正としてランタイム worktrees を再同期する。
+ * 既存 id の terminals は温存し、ターミナルセッションを壊さない。
+ * 他ウィンドウ発の settings-changed 受信時に、永続化配列とランタイム配列の
+ * 乖離（カードと件数の分裂）を解消する用途で呼ぶ。
+ */
+function syncWorktreesFromSettings() {
+  const byId = new Map(worktrees.value.map((w) => [w.id, w]));
+  const settingsIds = new Set(settings.value.worktrees.map((w) => w.id));
+  const synced = settings.value.worktrees.map((entry) => {
+    const existing = byId.get(entry.id);
+    return existing
+      ? { ...entry, terminals: existing.terminals }
+      : { ...entry, terminals: [] };
+  });
+  // settings 未登録だがランタイムに存在する worktree（git worktree add 完了前の
+  // 追加中プレースホルダ）は温存する。再同期で一瞬カードが消えるのを防ぐ。
+  const placeholders = worktrees.value.filter((w) => !settingsIds.has(w.id));
+  worktrees.value = [...synced, ...placeholders];
+}
+
 /** ワークツリーを UI 一覧に仮追加（バックエンド処理前） */
 function addWorktreePlaceholder(entry: WorktreeEntry): void {
   const worktree: Worktree = { ...entry, terminals: [] };
@@ -35,6 +56,11 @@ async function invokeWorktreeAdd(entry: WorktreeEntry, sourceBranch?: string): P
 
 /** ワークツリーを設定に永続化（成功時に呼ぶ） */
 function commitWorktree(entry: WorktreeEntry): void {
+  // 再ロード競合などで既に登録済みの場合は二重 push しない（保存だけ実行）
+  if (settings.value.worktrees.some((w) => w.id === entry.id)) {
+    scheduleSave();
+    return;
+  }
   settings.value.worktrees.push(entry);
   scheduleSave();
 }
@@ -259,6 +285,7 @@ export function useWorktrees() {
   return {
     worktrees,
     loadWorktreesFromSettings,
+    syncWorktreesFromSettings,
     addWorktreePlaceholder,
     invokeWorktreeAdd,
     commitWorktree,


### PR DESCRIPTION
## 概要
ホーム画面でワークグループをショートカット (Ctrl+PageDown/PageUp) で高速に切り替えると、ワークツリーが「分裂」する（カードと件数の不一致・重複・消失といったデータ不整合）バグを修正します。

## 根本原因
ワークグループ切替そのものではなく、設定の保存↔再ロードのフィードバックループとランタイム/永続化の二重配列管理が原因でした。

- `scheduleSave()` の `emit("settings-changed")` はターゲット指定なしのグローバル同報で、**自ウィンドウのリスナーも発火する**（Tauri v2 仕様）。
- メインウィンドウ (App.vue) が自イベントで `loadSettings()` を呼び、その非同期区間 (`await get_settings` → `settings.value = loaded` で全体置換) に次の切替や worktree commit が割り込むと in-memory 変更を巻き戻す（**lost update**）。
- ランタイム `worktrees` と `settings.value.worktrees` は別配列で、再ロード後にランタイム側が再同期されず乖離する。カード表示は前者、グループ件数は後者を参照するため「分裂」表示になる。

`SettingsView.vue` のコメント「自ウィンドウは即時反映する（他ウィンドウは settings-changed 経由で追従）」が示す通り、自ウィンドウが自分の保存で再ロードするのは設計意図外です。

## 変更内容
- **`useSettings.ts`**: `emit("settings-changed")` に送信元ウィンドウラベル `{ source }` を付与（`scheduleSave`/`flushSave`）。`loadSettings` を再入防止 (coalescing) 構造にラップ（エラー時も rerun を取りこぼさず reject を伝播しない）。
- **`useAppHotkeys.ts`**: `settings-changed` リスナーで送信元が自ウィンドウなら早期 return（自イベント除外）。受信時に `syncWorktreesFromSettings` を呼ぶ。
- **`useWorktrees.ts`**: `syncWorktreesFromSettings()` 追加（terminals 温存マージ・追加中プレースホルダ温存）。`commitWorktree` に id 重複ガード追加。
- **`App.vue`**: `syncWorktreesFromSettings` を `useAppHotkeys` deps に配線。

`main.ts` / `SubWindowApp.vue` / `TrayPopupApp.vue` のリスナーは非変更（別 JS コンテキストの正常系・冪等。`source` 付与は後方互換）。

## 検証
- `pnpm run type-check` グリーン
- `/bug-review` 実施済み（Critical 0件。指摘2件は対応済み: 追加中プレースホルダの温存、coalescing のエラー処理堅牢化）
- ⏳ ランタイム確認（GUI 連打再現・多ウィンドウ非回帰・ターミナル非破壊）

🤖 Generated with [Claude Code](https://claude.com/claude-code)