### PR TITLE
feat(home): 通知有りワークツリーを含むワークグループのチップに赤枠を表示

### DIFF
--- a/src/components/WorkgroupBar.vue
+++ b/src/components/WorkgroupBar.vue
@@ -16,6 +16,7 @@ const {
   activeWorkgroupId,
   displayName,
   worktreeCount,
+  notifiedGroupIds,
   addWorkgroup,
   updateWorkgroup,
   reorderWorkgroup,
@@ -86,7 +87,7 @@ function onDragEnd() {
       v-for="g in groups"
       :key="g.id"
       class="wg-chip"
-      :class="{ active: g.id === activeWorkgroupId }"
+      :class="{ active: g.id === activeWorkgroupId, notified: notifiedGroupIds.has(g.id) }"
       :style="{ borderLeftColor: g.color || '#9399b2', ...(g.id === activeWorkgroupId && g.color ? { background: g.color + '30', borderColor: g.color } : {}) }"
       draggable="true"
       :title="t('chipTitle')"
@@ -153,6 +154,20 @@ function onDragEnd() {
   background: #313244;
   color: #cdd6f4;
   border-color: #585b70;
+}
+
+.wg-chip.notified {
+  box-shadow: 0 0 0 2px #f38ba8;
+  animation: wg-notification-pulse 2s ease-in-out infinite;
+}
+
+@keyframes wg-notification-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 2px rgba(243, 139, 168, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 0 2px rgba(243, 139, 168, 1), 0 0 8px 2px rgba(243, 139, 168, 0.3);
+  }
 }
 
 .wg-count {

--- a/src/composables/useWorkgroups.ts
+++ b/src/composables/useWorkgroups.ts
@@ -1,11 +1,13 @@
 import { computed } from "vue";
 import { useSettings } from "./useSettings";
 import { useWorktrees } from "./useWorktrees";
+import { useNotifications } from "./useNotifications";
 import { i18n } from "../i18n";
 import type { Workgroup } from "../types/settings";
 
 const { settings, scheduleSave } = useSettings();
 const { worktrees } = useWorktrees();
+const { notifications } = useNotifications();
 
 function genId(): string {
   return `wg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -54,6 +56,16 @@ function worktreeCount(groupId: string): number {
     (w) => resolvedGroupId(w.workgroupId) === groupId,
   ).length;
 }
+
+/** 通知有りのワークツリーを 1 つ以上含むグループの ID 集合 */
+const notifiedGroupIds = computed<Set<string>>(() => {
+  const set = new Set<string>();
+  for (const id of notifications.keys()) {
+    const wt = settings.value.worktrees.find((w) => w.id === id);
+    if (wt) set.add(resolvedGroupId(wt.workgroupId));
+  }
+  return set;
+});
 
 /** 新しいグループを追加して選択状態にする */
 function addWorkgroup(): Workgroup {
@@ -116,6 +128,7 @@ export function useWorkgroups() {
     groupOf,
     displayName,
     worktreeCount,
+    notifiedGroupIds,
     addWorkgroup,
     updateWorkgroup,
     deleteWorkgroupRecord,


### PR DESCRIPTION
## 概要
通知が来たワークツリーを 1 つ以上含むワークグループのチップ（ホームタブのワークグループボタン）に赤枠（パルス）を表示します。別グループに通知が来ても、現在は非アクティブなグループのワークツリーカードが表示されず気づけなかった問題を解消します。

## 変更内容
- `src/composables/useWorkgroups.ts`
  - `useNotifications()` のモジュールレベル `notifications` Map を参照
  - `notifiedGroupIds` computed を追加 — 通知中の各ワークツリーを `resolvedGroupId()` で所属グループへ解決した ID 集合を返す（`worktreeCount` と同じフォールバックロジック）
  - `useWorkgroups()` の返却に `notifiedGroupIds` を追加
- `src/components/WorkgroupBar.vue`
  - チップの `:class` に `notified: notifiedGroupIds.has(g.id)` を追加
  - `.wg-chip.notified` に `box-shadow` ベースの赤枠＋パルスアニメーション（既存通知色 `#f38ba8` に統一）を追加。インラインの `border-left-color` / active 時スタイルと衝突しないよう border ではなく box-shadow で描画

## 動作
- 通知 Map はリアクティブなため、別グループに通知が来るとそのチップに赤枠が出る
- フォーカス等で `clearNotification` が呼ばれると `notifiedGroupIds` が再計算され赤枠は自動的に消える（追加対応不要）

## 確認
- `pnpm run type-check` パス
- bug-review 実施済み（critical/warning/suggestion すべて 0 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)