### PR TITLE
fix(workgroup): 切替時の auto-animate でカードが重複/漏れする問題を解消

### DIFF
--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -290,6 +290,21 @@ const worktreesRef = computed(() =>
 );
 const tasksRef = sortedTasks;
 
+// ワークグループ切替は一覧の総入れ替え。auto-animate に「追加/削除」と誤認させると
+// 退場アニメ中の旧カード DOM が約250ms 残り、高速連打で DOM 二重化（重複表示）や
+// 旧グループカードの残留（別グループ漏れ）を招く。切替時はアニメを無効化して即時入れ替えにする。
+watch(activeWorkgroupId, () => {
+  for (const ctrl of columnControllers.values()) ctrl.disable();
+  nextTick(() => {
+    resetAllCardTransforms();
+    // 削除（autoAnimateDisableDepth>0）/ drag（draggingId）進行中は、その完了処理に
+    // enable を委ね、ここでは再有効化しない（二重 enable・進行中アニメ破壊を防ぐ）。
+    if (autoAnimateDisableDepth === 0 && !draggingId.value) {
+      for (const ctrl of columnControllers.values()) ctrl.enable();
+    }
+  });
+});
+
 function onMoveToWorkgroup(payload: { worktreeId: string; groupId: string }) {
   moveWorktreeToWorkgroup(payload.worktreeId, payload.groupId);
 }


### PR DESCRIPTION
## 概要
ホーム画面でワークグループをショートカット (Ctrl+PageDown/PageUp) で**高速連打**切替すると、(1) 同じワークツリーカードが重複表示され、(2) 別グループのカードが現在グループに漏れて表示されるバグを修正します。切替操作のみで再現します。

> #93 でマージした設定層の修正は本バグの原因ではありませんでした（別の競合クラスへの妥当なハードニングとして残置）。本 PR が真の原因への修正です。

## 根本原因
原因は描画層の `@formkit/auto-animate` でした。

- `src/components/HomeView.vue` の各 masonry カラムに `autoAnimate(el, { duration: 250 })` が適用されている（`registerColumn`）。
- 表示は `worktreesRef`(グループフィルタ) → `useMasonryLayout` の純粋 computed `columns` → `:key="worktree.id"` で描画。データ側は常に整合し重複を生まない。
- ワークグループ切替で `activeWorkgroupId` が変わると `columns` が**総入れ替え**され、各カラムの子要素が大きく変化する。auto-animate はこれを追加/削除と解釈し、**退場するカード DOM を約250ms間スキップ保持**する。
- 250ms 以内に連打すると、退場処理中の旧カードが残ったまま再入場の新 DOM が生成され、同一 key のカード DOM が二重化（重複）＋旧グループカードの残留（別グループ漏れ）が起きる。
- `columns` は純粋 computed のため、ゆっくり切り替えれば破綻しない＝高速連打時のみ再現、という症状と一致。

## 修正内容
既存の「特定操作時に auto-animate を無効化する」パターン（drag: `watch(draggingId)` / 削除: `autoAnimateDisableDepth`）に倣い、`activeWorkgroupId` 変化時にカラムの auto-animate を一時無効化して**即時入れ替え**にします（`src/components/HomeView.vue`、watch 1個・15行）。

```ts
watch(activeWorkgroupId, () => {
  for (const ctrl of columnControllers.values()) ctrl.disable();
  nextTick(() => {
    resetAllCardTransforms();
    if (autoAnimateDisableDepth === 0 && !draggingId.value) {
      for (const ctrl of columnControllers.values()) ctrl.enable();
    }
  });
});
```

`watch` の既定 flush `'pre'` により無効化が再描画前に走るため、切替パッチ時には常にアニメが無効です。drag 並べ替え・削除フェード・幅変更リフローなど既存アニメーションは維持します。

## 検証
- `pnpm run type-check` グリーン
- `/bug-review`（deep バリデータ）実施済み: enable 漏れ・flush タイミング・columnCount 変化・初回発火・既存アニメ回帰の5観点すべて問題なし、指摘0件
- ⏳ ランタイム確認（GUI 連打再現・既存アニメ非回帰）

🤖 Generated with [Claude Code](https://claude.com/claude-code)