### PR TITLE
fix(artifact): アーティファクト一覧にスクロールバーを追加

### DIFF
--- a/src/ArtifactViewerApp.vue
+++ b/src/ArtifactViewerApp.vue
@@ -120,20 +120,22 @@ onUnmounted(() => {
         <span class="pi pi-box sidebar-icon" />
         <span class="sidebar-title">{{ worktreeName }}</span>
       </div>
-      <div v-if="artifacts.length === 0" class="empty-list">
-        {{ t("emptyList") }}
-      </div>
-      <div
-        v-for="artifact in artifacts"
-        :key="artifact.id"
-        class="artifact-item"
-        :class="{ selected: selectedId === artifact.id }"
-        @click="selectArtifact(artifact.id)"
-      >
-        <span :class="`pi ${typeIcon(artifact.content_type)} artifact-icon`" />
-        <div class="artifact-item-info">
-          <span class="artifact-title">{{ artifact.title }}</span>
-          <span class="artifact-meta">{{ formatDate(artifact.updated_at) }}</span>
+      <div class="artifact-list">
+        <div v-if="artifacts.length === 0" class="empty-list">
+          {{ t("emptyList") }}
+        </div>
+        <div
+          v-for="artifact in artifacts"
+          :key="artifact.id"
+          class="artifact-item"
+          :class="{ selected: selectedId === artifact.id }"
+          @click="selectArtifact(artifact.id)"
+        >
+          <span :class="`pi ${typeIcon(artifact.content_type)} artifact-icon`" />
+          <div class="artifact-item-info">
+            <span class="artifact-title">{{ artifact.title }}</span>
+            <span class="artifact-meta">{{ formatDate(artifact.updated_at) }}</span>
+          </div>
         </div>
       </div>
     </div>
@@ -236,6 +238,13 @@ onUnmounted(() => {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: #cdd6f4;
+}
+
+.artifact-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .empty-list {


### PR DESCRIPTION
## 概要
アーティファクトビューアのサイドバー一覧に、アイテム数が多いときスクロールバーが出ず、画面の高さを超えた過去のアーティファクトが見えなくなる問題を修正。

## 原因
`.sidebar` が `display: flex; flex-direction: column; overflow: hidden;` でヘッダーとアイテム群を同じフレックスコンテナに直置きしており、はみ出したアイテムが切り捨てられ、専用のスクロール領域が存在しなかった。

## 変更内容
`src/ArtifactViewerApp.vue`
- アイテム群（空表示 + `v-for`）を新規 `.artifact-list` でラップ。ヘッダー（`.sidebar-header`）は固定のまま外に残す。
- `.artifact-list` に `flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden;` を付与（`min-height: 0` は flex column 内でスクロールを効かせるため必須）。

## 確認
- `pnpm run type-check` 通過
- bug-review 指摘なし
- アイテムが画面高を超えても一覧のみ縦スクロール、ヘッダーは固定

🤖 Generated with [Claude Code](https://claude.com/claude-code)