### PR TITLE
feat(cat): 猫ターミナル左下にCPU/メモリ/ネットワーク使用状況を表示

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2415,7 +2415,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3506,6 +3506,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3645,6 +3655,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "subtle",
+ "sysinfo 0.38.4",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -3698,7 +3709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5804,6 +5815,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7452,7 +7477,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8336,7 +8361,7 @@ dependencies = [
  "image 0.24.9",
  "log",
  "percent-encoding",
- "sysinfo",
+ "sysinfo 0.30.13",
  "thiserror 1.0.69",
  "windows 0.52.0",
  "xcb",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ base64 = "0.22"
 rand = "0.8"
 subtle = "2"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+sysinfo = "0.38"
 tauri-plugin-prevent-default = "4"
 tauri-plugin-mcp = { git = "https://github.com/P3GLEG/tauri-plugin-mcp" }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod process_utils;
 mod pty_manager;
 mod report_db;
 mod settings;
+mod system_metrics;
 mod task_db;
 mod task_executor;
 mod terminal_session;
@@ -29,6 +30,7 @@ use fs_watcher::FsWatcherManager;
 use process_utils::WorktreeRemoveManager;
 use pty_manager::{AiAgentChangedPayload, PtyManager};
 use settings::{AppSettings, SettingsManager};
+use system_metrics::SystemMetricsState;
 use tauri::{Emitter, Listener, Manager, State};
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 
@@ -800,6 +802,18 @@ fn get_force_wizard() -> bool {
         .unwrap_or(false)
 }
 
+/// 猫ターミナル向けシステムメトリクスのポーリングを開始する。
+#[tauri::command]
+fn system_metrics_start(app_handle: tauri::AppHandle, state: State<SystemMetricsState>) {
+    state.start(app_handle);
+}
+
+/// システムメトリクスのポーリングを停止する。
+#[tauri::command]
+fn system_metrics_stop(state: State<SystemMetricsState>) {
+    state.stop();
+}
+
 /// メインウィンドウの WebView2 にネイティブ診断イベントを登録する (Windows 限定)。
 ///
 /// - `ProcessFailed`: browser/renderer プロセス破綻を ERROR ログ。完全アイドル中のフリーズ
@@ -983,6 +997,7 @@ pub fn run() {
         .manage(ai_description::DescriptionManager::new())
         .manage(task_executor::TaskGenerateManager::new())
         .manage(FsWatcherManager::new())
+        .manage(SystemMetricsState::new())
         // ReportPool は setup() 内で非同期初期化するため、ここでは登録しない
         .invoke_handler(tauri::generate_handler![
             pty_spawn,
@@ -1063,6 +1078,8 @@ pub fn run() {
             set_debug_mode,
             get_debug_mode,
             get_force_wizard,
+            system_metrics_start,
+            system_metrics_stop,
         ])
         .setup(move |app| {
             // env var が false の場合は DB初期化などの起動ログを含め debug! を抑制する。

--- a/src-tauri/src/system_metrics.rs
+++ b/src-tauri/src/system_metrics.rs
@@ -1,0 +1,104 @@
+//! システム全体の CPU/メモリ/ネットワーク使用状況を周期取得し、
+//! `system-metrics` イベントでフロントエンド（猫ターミナル）へ通知する。
+//!
+//! 猫ターミナルはホーム画面の装飾オーバーレイであり特定の PTY セッションに
+//! 紐づかないため、ここではシステム全体の指標を扱う。
+//! CPU 使用率とネットワークレートは前回 refresh からの差分で算出されるため、
+//! `System` / `Networks` をポーリングスレッド内で生かし続ける。
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use sysinfo::{Networks, System};
+use tauri::{AppHandle, Emitter};
+
+/// ポーリング間隔（秒）。sysinfo の MINIMUM_CPU_UPDATE_INTERVAL より十分長い。
+const POLL_INTERVAL_SECS: u64 = 2;
+
+/// 将来 disk 等の指標を増やせるよう、各指標をフラットに並べた構造体。
+#[derive(Clone, serde::Serialize)]
+pub struct SystemMetrics {
+    /// システム全体の CPU 使用率（%）
+    pub cpu_percent: f32,
+    /// 使用中メモリ（バイト）
+    pub mem_used: u64,
+    /// 総メモリ（バイト）
+    pub mem_total: u64,
+    /// 受信レート（バイト/秒）
+    pub net_rx_per_sec: u64,
+    /// 送信レート（バイト/秒）
+    pub net_tx_per_sec: u64,
+}
+
+/// システムメトリクスのポーリング制御を保持する managed state。
+pub struct SystemMetricsState {
+    /// ポーリングスレッドが稼働すべきか（stop で false）
+    running: Arc<AtomicBool>,
+    /// 起動世代。start のたびに増加させ、古いスレッドを確実に終了させる。
+    epoch: Arc<AtomicU64>,
+}
+
+impl SystemMetricsState {
+    pub fn new() -> Self {
+        Self {
+            running: Arc::new(AtomicBool::new(false)),
+            epoch: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// 2秒周期でシステムメトリクスを emit するスレッドを起動する。
+    /// 世代チェックにより、同時に稼働するスレッドは最新の1本のみとなる。
+    pub fn start(&self, app_handle: AppHandle) {
+        let my_epoch = self.epoch.fetch_add(1, Ordering::SeqCst) + 1;
+        self.running.store(true, Ordering::SeqCst);
+
+        let running = self.running.clone();
+        let epoch = self.epoch.clone();
+
+        std::thread::spawn(move || {
+            let mut sys = System::new();
+            let mut networks = Networks::new_with_refreshed_list();
+
+            // 初回 CPU サンプル（差分計算の基準。この時点の値は 0 のため捨てる）
+            sys.refresh_cpu_all();
+
+            while running.load(Ordering::SeqCst) && epoch.load(Ordering::SeqCst) == my_epoch {
+                std::thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
+                if !running.load(Ordering::SeqCst) || epoch.load(Ordering::SeqCst) != my_epoch {
+                    break;
+                }
+
+                sys.refresh_cpu_all();
+                sys.refresh_memory();
+                networks.refresh(false);
+
+                // refresh 以降の差分（= POLL_INTERVAL_SECS 間の受信/送信量）を全 IF で合算
+                let mut rx = 0u64;
+                let mut tx = 0u64;
+                for (_, data) in &networks {
+                    rx += data.received();
+                    tx += data.transmitted();
+                }
+
+                let metrics = SystemMetrics {
+                    cpu_percent: sys.global_cpu_usage(),
+                    mem_used: sys.used_memory(),
+                    mem_total: sys.total_memory(),
+                    net_rx_per_sec: rx / POLL_INTERVAL_SECS,
+                    net_tx_per_sec: tx / POLL_INTERVAL_SECS,
+                };
+
+                // ウィンドウ破棄後などで emit に失敗したら終了
+                if app_handle.emit("system-metrics", &metrics).is_err() {
+                    break;
+                }
+            }
+        });
+    }
+
+    /// ポーリングを停止する（次の世代開始まで再開しない）。
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+    }
+}

--- a/src/components/HomeCatTerminal.vue
+++ b/src/components/HomeCatTerminal.vue
@@ -4,7 +4,8 @@ import { useI18n } from "vue-i18n";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { invoke } from "@tauri-apps/api/core";
-import { useCat } from "../composables/useCat";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useCat, type SystemMetrics } from "../composables/useCat";
 
 interface ReportSummary {
   worktree_added: number;
@@ -17,13 +18,14 @@ interface ReportSummary {
 const { t } = useI18n();
 const containerRef = ref<HTMLDivElement | null>(null);
 
-const { start, stop, redraw, topic } = useCat();
+const { start, stop, redraw, topic, setMetrics } = useCat();
 
 let terminal: Terminal | null = null;
 let fitAddon: FitAddon | null = null;
 let resizeObserver: ResizeObserver | null = null;
 let meowTimer: ReturnType<typeof setTimeout> | null = null;
 let reportTimer: ReturnType<typeof setInterval> | null = null;
+let unlistenMetrics: UnlistenFn | null = null;
 
 function scheduleMeow() {
   const delay = 15000 + Math.random() * 10000; // 15〜25秒
@@ -100,6 +102,12 @@ onMounted(() => {
   scheduleMeow();
   reportTimer = setInterval(fetchReport, 60000);
 
+  // システムメトリクスのポーリングを開始し、更新イベントを購読する
+  invoke("system_metrics_start").catch(() => {});
+  listen<SystemMetrics>("system-metrics", (e) => setMetrics(e.payload))
+    .then((un) => { unlistenMetrics = un; })
+    .catch(() => {});
+
   resizeObserver = new ResizeObserver(() => {
     if (containerRef.value && containerRef.value.offsetWidth > 0) {
       fitAddon?.fit();
@@ -113,6 +121,8 @@ onMounted(() => {
 onUnmounted(() => {
   if (meowTimer) { clearTimeout(meowTimer); meowTimer = null; }
   if (reportTimer) { clearInterval(reportTimer); reportTimer = null; }
+  if (unlistenMetrics) { unlistenMetrics(); unlistenMetrics = null; }
+  invoke("system_metrics_stop").catch(() => {});
   stop();
   resizeObserver?.disconnect();
   terminal?.dispose();

--- a/src/components/HomeCatTerminal.vue
+++ b/src/components/HomeCatTerminal.vue
@@ -26,6 +26,7 @@ let resizeObserver: ResizeObserver | null = null;
 let meowTimer: ReturnType<typeof setTimeout> | null = null;
 let reportTimer: ReturnType<typeof setInterval> | null = null;
 let unlistenMetrics: UnlistenFn | null = null;
+let unmounted = false;
 
 function scheduleMeow() {
   const delay = 15000 + Math.random() * 10000; // 15〜25秒
@@ -105,7 +106,10 @@ onMounted(() => {
   // システムメトリクスのポーリングを開始し、更新イベントを購読する
   invoke("system_metrics_start").catch(() => {});
   listen<SystemMetrics>("system-metrics", (e) => setMetrics(e.payload))
-    .then((un) => { unlistenMetrics = un; })
+    .then((un) => {
+      // 購読完了前にアンマウントされていた場合は即座に解除（リスナーリーク防止）
+      if (unmounted) { un(); } else { unlistenMetrics = un; }
+    })
     .catch(() => {});
 
   resizeObserver = new ResizeObserver(() => {
@@ -119,6 +123,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  unmounted = true;
   if (meowTimer) { clearTimeout(meowTimer); meowTimer = null; }
   if (reportTimer) { clearInterval(reportTimer); reportTimer = null; }
   if (unlistenMetrics) { unlistenMetrics(); unlistenMetrics = null; }

--- a/src/composables/useCat.ts
+++ b/src/composables/useCat.ts
@@ -16,8 +16,8 @@ const MAX_QUEUE_SIZE = 20;
 const MAX_SPEECH_WIDTH = 40;      // セリフ1行の最大表示列数
 const MAX_SPEECH_LINES = 3;       // セリフ最大行数
 
-// システムメトリクス（左上表示）
-const METRICS_WIDTH = 16;         // 左上メトリクス領域の幅（列）
+// システムメトリクス（左下表示）
+const METRICS_WIDTH = 16;         // 左下メトリクス領域の幅（列）
 
 export interface SystemMetrics {
   cpu_percent: number;
@@ -120,7 +120,7 @@ export function useCat() {
     terminal.write(seq);
   }
 
-  // ----- システムメトリクス（左上）の描画 -----
+  // ----- システムメトリクス（左下）の描画 -----
 
   // 受信したメトリクスを表示用の行配列へ整形して再描画する
   function setMetrics(m: SystemMetrics) {
@@ -328,7 +328,7 @@ export function useCat() {
       if (speechState === "typing" || speechState === "holding") {
         drawSpeechLines(currentSpeechLines, displayedCharCount);
       }
-      // 左上メトリクス（上書きからの復元）
+      // 左下メトリクス（上書きからの復元）
       drawMetrics();
     }, REDRAW_INTERVAL_MS);
   }

--- a/src/composables/useCat.ts
+++ b/src/composables/useCat.ts
@@ -16,6 +16,25 @@ const MAX_QUEUE_SIZE = 20;
 const MAX_SPEECH_WIDTH = 40;      // セリフ1行の最大表示列数
 const MAX_SPEECH_LINES = 3;       // セリフ最大行数
 
+// システムメトリクス（左上表示）
+const METRICS_WIDTH = 16;         // 左上メトリクス領域の幅（列）
+
+export interface SystemMetrics {
+  cpu_percent: number;
+  mem_used: number;   // bytes
+  mem_total: number;  // bytes
+  net_rx_per_sec: number; // bytes/sec
+  net_tx_per_sec: number; // bytes/sec
+}
+
+// バイト数を K/M/G 単位の短い文字列へ整形
+function fmtBytes(n: number): string {
+  if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(1)}G`;
+  if (n >= 1024 ** 2) return `${(n / 1024 ** 2).toFixed(1)}M`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)}K`;
+  return `${n}B`;
+}
+
 const catFrames = {
   normal: [" ∧_∧", "( o.o )", " じしˍ,)ノ"],
   blink: [" ∧_∧", "( -.- )", " じしˍ,)ノ"],
@@ -61,6 +80,11 @@ export function useCat() {
   let blinkScheduleTimer: ReturnType<typeof setTimeout> | null = null;
   let blinkRestoreTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // システムメトリクス（左下表示）。未受信の間は空配列で何も描かない。
+  let metricsLines: string[] = [];
+  // 前回描画したメトリクスの最大行幅（桁数が減ったときの残骸クリア用）
+  let metricsDrawnWidth = 0;
+
   // セリフ状態
   const topics: Topic[] = [];
   let speechState: SpeechState = "idle";
@@ -94,6 +118,39 @@ export function useCat() {
     }
     seq += "\x1b8";
     terminal.write(seq);
+  }
+
+  // ----- システムメトリクス（左上）の描画 -----
+
+  // 受信したメトリクスを表示用の行配列へ整形して再描画する
+  function setMetrics(m: SystemMetrics) {
+    metricsLines = [
+      `CPU ${Math.round(m.cpu_percent)}%`,
+      `MEM ${(m.mem_used / 1024 ** 3).toFixed(1)}/${(m.mem_total / 1024 ** 3).toFixed(0)}G`,
+      `NET ↓${fmtBytes(m.net_rx_per_sec)} ↑${fmtBytes(m.net_tx_per_sec)}`,
+    ];
+    drawMetrics();
+  }
+
+  // 左下（最下行から上方・列1）へ固定位置描画。猫=右下・セリフ=右側上方なので衝突しない。
+  function drawMetrics() {
+    if (!terminal || terminal.rows < 6 || terminal.cols < METRICS_WIDTH || metricsLines.length === 0) return;
+    // 今回の最大行幅と前回描画幅の大きい方をクリア（桁数が減ったときの右側残骸を消す）
+    const curWidth = metricsLines.reduce((m, l) => Math.max(m, measureWidth(l)), 0);
+    const clearWidth = Math.min(terminal.cols, Math.max(curWidth, metricsDrawnWidth));
+    const totalLines = metricsLines.length;
+    let seq = "\x1b7";
+    for (let i = 0; i < totalLines; i++) {
+      // 最終行を最下行に合わせ、上方向に積む
+      const row = terminal.rows - (totalLines - 1 - i);
+      if (row < 1) continue;
+      // クリア→描画（残骸・桁あふれ防止）
+      seq += `\x1b[${row};1H${" ".repeat(clearWidth)}`;
+      seq += `\x1b[${row};1H${metricsLines[i]}`;
+    }
+    seq += "\x1b8";
+    terminal.write(seq);
+    metricsDrawnWidth = curWidth;
   }
 
   // ----- テキスト折り返し -----
@@ -271,6 +328,8 @@ export function useCat() {
       if (speechState === "typing" || speechState === "holding") {
         drawSpeechLines(currentSpeechLines, displayedCharCount);
       }
+      // 左上メトリクス（上書きからの復元）
+      drawMetrics();
     }, REDRAW_INTERVAL_MS);
   }
 
@@ -287,9 +346,10 @@ export function useCat() {
     if (speechState === "typing" || speechState === "holding") {
       drawSpeechLines(currentSpeechLines, displayedCharCount);
     }
+    drawMetrics();
   }
 
   onUnmounted(stop);
 
-  return { start, stop, redraw, topic };
+  return { start, stop, redraw, topic, setMetrics };
 }


### PR DESCRIPTION
## 概要
ホーム画面の装飾オーバーレイである猫ターミナルの**左下**に、システム全体の CPU 使用率・メモリ使用量・ネットワーク送受信レートを表示します。

表示例:
```
CPU 23%
MEM 5.2/16G
NET ↓1.2M ↑0.3M
```

## 設計
拡張可能な CLI コマンド実行方式（A案）と、sysinfo によるネイティブ取得の固定方式（B案）を比較し、**B案を採用**。猫ターミナルは更新頻度が高く表示幅が狭い装飾用途のため、固定指標で目的を満たせる。A案の毎ティック プロセス spawn・OS別コマンド設定・任意出力パースのコストが拡張性の利点を上回ると判断した。内部はメトリクスをフラットに並べた構造体とし、将来 disk 等をネイティブに追加できる余地は確保。

## 実装
### バックエンド（Rust）
- `system_metrics.rs`（新規）: `System`/`Networks` をスレッド内で生かし続け、2秒周期で CPU%/メモリ/ネット差分を算出し `system-metrics` イベントを emit。**起動世代（epoch）**方式で start/stop 競合時も稼働スレッドを最新1本に収束。
- `lib.rs`: `system_metrics_start`/`system_metrics_stop` コマンドと managed state を追加。
- `sysinfo` は rustc 1.92 互換のため `0.38` を採用（0.39 は MSRV 1.95）。

### フロントエンド（Vue/TS）
- `useCat.ts`: `setMetrics`/`drawMetrics` を追加し redraw ループへ統合。ANSI 絶対座標で左下に描画。クリア幅は実測幅＋前回描画幅の最大を取り、桁数減少時の残骸を防止。
- `HomeCatTerminal.vue`: マウント/アンマウントで start/stop と `system-metrics` 購読を制御。

## レビュー対応
- **security-review**: 指摘 0 件（数値のみの read-only テレメトリで untrusted input なし）。
- **bug-review**: リスナーリーク（解決前アンマウント）を `unmounted` フラグで修正、コメント表記の不整合を修正。

## 検証
- ✅ `cargo check`
- ✅ `pnpm run type-check`
- 実機での目視確認（`enableHomeCat` 有効化 → 左下に3行表示・約2秒更新・猫/セリフと非衝突・リサイズ復元）は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)