### PR TITLE
fix(workgroup): カウントと表示ワークツリー数の不一致を解消

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -802,16 +802,20 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
     if (lfsSkipped) {
       await message(t("lfsWarning"), { kind: "warning" });
     }
-
-    // 全後続処理が成功した後にMCPクライアントへ追加完了を通知
-    await invoke("notify_worktree_added", {
-      id: entry.id,
-      name: entry.name,
-      branchName: entry.branchName,
-    });
   } catch (e) {
     await message(t("worktreeSetupIncomplete", { error: e }), { kind: "warning" });
   } finally {
+    // ワークツリーは作成済み・永続化済みなので、セットアップ途中失敗でも MCP ピアへは
+    // 必ず追加完了を通知する（カードは残るのに通知だけ飛ばない不整合を防ぐ）。
+    try {
+      await invoke("notify_worktree_added", {
+        id: entry.id,
+        name: entry.name,
+        branchName: entry.branchName,
+      });
+    } catch {
+      // 通知失敗はワークツリー追加の成否に影響しない
+    }
     loadingWorktrees.delete(entry.id);
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -699,16 +699,30 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
   addWorktreePlaceholder(entry);
   loadingWorktrees.set(entry.id, copyWorkingChangesFrom ? t("duplicatingText") : t("creatingText"));
 
+  const repo = settings.value.repositories.find((r) => r.id === entry.repositoryId);
+  let lfsSkipped = false;
+
+  // commit 前（git worktree 作成・永続化まで）。ここでの失敗のみロールバック対象。
+  // この時点では settings に未追加なので、ランタイムのみ削除する rollbackWorktree で整合する。
   try {
-    const repo = settings.value.repositories.find((r) => r.id === entry.repositoryId);
     if (repo?.pullBeforeAdd) {
       await invoke("git_pull", { repoPath: repo.path });
     }
 
-    const lfsSkipped = await invokeWorktreeAdd(entry, sourceBranch);
+    lfsSkipped = await invokeWorktreeAdd(entry, sourceBranch);
 
     // 成功時: 設定に永続化
     commitWorktree(entry);
+  } catch (e) {
+    rollbackWorktree(entry.id);
+    await message(t("worktreeCreateFailed", { error: e }), { kind: "error" });
+    loadingWorktrees.delete(entry.id);
+    return;
+  }
+
+  // commit 後の後続処理。ワークツリーは作成済み・永続化済みのため、ここで失敗しても
+  // ロールバックしない（ランタイムのみ削除すると settings と乖離し、カウントと表示が分裂する）。
+  try {
     tryAutoAssignHotkey(entry.id);
 
     // デフォルト: 自動承認
@@ -796,8 +810,7 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
       branchName: entry.branchName,
     });
   } catch (e) {
-    rollbackWorktree(entry.id);
-    await message(t("worktreeCreateFailed", { error: e }), { kind: "error" });
+    await message(t("worktreeSetupIncomplete", { error: e }), { kind: "warning" });
   } finally {
     loadingWorktrees.delete(entry.id);
   }
@@ -1949,6 +1962,7 @@ onMounted(async () => {
     "copyTargetsFailed": "Some files could not be copied after worktree creation: {error}",
     "claudeHooksFailed": "Failed to write Claude Code notification hooks: {error}",
     "sessionCopyFailed": "Failed to copy Claude Code session data: {error}",
+    "worktreeSetupIncomplete": "Worktree created, but some setup steps failed: {error}",
     "shuttingDown": "Shutting down...",
     "minimize": "Minimize",
     "maximize": "Maximize",
@@ -1980,6 +1994,7 @@ onMounted(async () => {
     "copyTargetsFailed": "ワークツリー追加後のファイルコピーに失敗しました: {error}",
     "claudeHooksFailed": "Claude Code通知フックの書き込みに失敗しました: {error}",
     "sessionCopyFailed": "Claude Codeセッションデータのコピーに失敗しました: {error}",
+    "worktreeSetupIncomplete": "ワークツリーは作成されましたが、一部のセットアップ処理に失敗しました: {error}",
     "shuttingDown": "終了しています...",
     "minimize": "最小化",
     "maximize": "最大化",

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -330,7 +330,11 @@ export function useTaskExecution(deps: {
         branchName: entry.branchName,
       });
     } catch (e) {
-      await message(t("worktreeSetupIncomplete", { error: e }), { kind: "warning" });
+      // ワークツリーは作成済み・永続化済みなのでロールバックしない（settings との乖離=
+      // カウントと表示の分裂を防ぐ）。ただし後続タスクステップ（agent_worktree 等）は
+      // セットアップ完了を前提とするため、エラーは伝播させてタスクを中断する。
+      loadingWorktrees.delete(entry.id);
+      throw e;
     }
 
     loadingWorktrees.delete(entry.id);

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -331,8 +331,19 @@ export function useTaskExecution(deps: {
       });
     } catch (e) {
       // ワークツリーは作成済み・永続化済みなのでロールバックしない（settings との乖離=
-      // カウントと表示の分裂を防ぐ）。ただし後続タスクステップ（agent_worktree 等）は
-      // セットアップ完了を前提とするため、エラーは伝播させてタスクを中断する。
+      // カウントと表示の分裂を防ぐ）。カードは残り続けるため、手動経路が finally で
+      // 通知するのと同様に MCP ピアへも追加を通知しておく（通知漏れの不整合を防ぐ）。
+      try {
+        await invoke("notify_worktree_added", {
+          id: entry.id,
+          name: entry.name,
+          branchName: entry.branchName,
+        });
+      } catch {
+        // 通知失敗はワークツリー追加の成否に影響しない
+      }
+      // 後続タスクステップ（agent_worktree 等）はセットアップ完了を前提とするため、
+      // エラーは伝播させてタスクを中断する。
       loadingWorktrees.delete(entry.id);
       throw e;
     }

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -257,6 +257,8 @@ export function useTaskExecution(deps: {
     addWorktreePlaceholder(entry);
     loadingWorktrees.set(entry.id, t("creatingText"));
 
+    // commit 前（git worktree 作成・永続化まで）。ここでの失敗のみロールバック対象。
+    // この時点では settings に未追加なので、ランタイムのみ削除する rollbackWorktree で整合する。
     try {
       if (repo.pullBeforeAdd) {
         await invoke("git_pull", { repoPath: repo.path });
@@ -264,6 +266,15 @@ export function useTaskExecution(deps: {
 
       await invokeWorktreeAdd(entry, code.source_branch);
       commitWorktree(entry);
+    } catch (e) {
+      rollbackWorktree(entry.id);
+      loadingWorktrees.delete(entry.id);
+      throw e;
+    }
+
+    // commit 後の後続処理。ワークツリーは作成済み・永続化済みのため、ここで失敗しても
+    // ロールバックしない（ランタイムのみ削除すると settings と乖離し、カウントと表示が分裂する）。
+    try {
       tryAutoAssignHotkey(entry.id);
 
       // デフォルト: 自動承認
@@ -319,9 +330,7 @@ export function useTaskExecution(deps: {
         branchName: entry.branchName,
       });
     } catch (e) {
-      rollbackWorktree(entry.id);
-      loadingWorktrees.delete(entry.id);
-      throw e;
+      await message(t("worktreeSetupIncomplete", { error: e }), { kind: "warning" });
     }
 
     loadingWorktrees.delete(entry.id);


### PR DESCRIPTION
## 背景

あるワークグループのカウントバッジが「5」なのに、そのグループに切り替えると 3 つしかワークツリーカードが表示されない不具合。リサイズ/スクロールしても出ず、再起動すると直る（永続データは正しい）。

## 根本原因

ワークツリーは2つの並行配列で管理されている:
- `settings.value.worktrees`（永続化／カウント側）
- `worktrees.value`（ランタイム／表示側）

追加フローで `commitWorktree()`（settings へ追加）の**後**に実行される後続処理（ターミナル起動・スクリプト待ち・サブウィンドウ移動・MCP通知）が失敗すると、catch の `rollbackWorktree()` が**ランタイム配列からのみ削除**し settings と乖離。結果カウント=5／表示=3 となりセッション中持続、再起動の `loadWorktreesFromSettings` で治癒していた。

## 修正

`executeAddWorktree`（`useTaskExecution.ts`）と `onAddWorktreeConfirm`（`App.vue`）の try を `commitWorktree` を境界に2段へ分割:

- **commit 前**（`git_pull` / `invokeWorktreeAdd`）の失敗のみ `rollbackWorktree`（settings 未追加なので整合）
- **commit 後**の失敗はロールバックせずカードを残す
  - 手動経路: 警告（`worktreeSetupIncomplete`）表示。`notify_worktree_added` を `finally` で必ず送信
  - タスク経路: MCP 通知を送ってから re-throw し、後続タスクステップ（`agent_worktree` 等）を正しく中断

## レビュー対応

- general-purpose bug-review: タスクのエラー伝播喪失（re-throw で解消）／MCP通知取りこぼし（finally 通知で解消）
- codex-review round 1: タスク経路の中断時も MCP 通知（解消）

## 確認

- `pnpm run type-check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)