### PR TITLE
fix(notify): userConfig 非依存化で CC 2.1.207 の通知hookフォーマットエラーを解消

### DIFF
--- a/src-tauri/notify/src/main.rs
+++ b/src-tauri/notify/src/main.rs
@@ -6,10 +6,14 @@
 // 同処理を行っていたが、数十MBの GUI バイナリ起動を避けるため独立サイドカーに分離した。
 //
 // 使い方:
-//   oretachi-notify --notify "<worktree>" [--kind <kind>] [--agent <agent>]
-//     (stdin がパイプの場合、その内容を body として /notify へ送信)
-//   oretachi-notify --set-description "<worktree>"
+//   oretachi-notify --notify --project-dir "<dir>" --event "<Event>" [--agent <agent>]
+//     (stdin がパイプの場合、その内容を body として /notify へ送信。
+//      ワークツリー名と kind の解決はサーバー側で project-dir / event から行う)
+//   oretachi-notify --set-description --project-dir "<dir>"
 //     (stdin の ExitPlanMode hook JSON を /set-description へ転送)
+//
+// hook からは userConfig ではなく CC 組み込み変数 ${CLAUDE_PROJECT_DIR} が --project-dir に渡る。
+// 未置換/空の場合はプロセスの current_dir (hook は worktree ディレクトリで実行される) にフォールバック。
 
 // Prevents a console window flash on Windows when spawned by hooks.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
@@ -21,25 +25,13 @@ const SERVER_INFO_FILE: &str = "mcp-server.json";
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
-    // 通知 (--notify): stdin(hook JSON) を body として /notify へ送る
-    if let Some(name) = find_notify_arg(&args) {
-        let kind = find_kind_arg(&args);
-        let agent = find_agent_arg(&args);
-        let body = read_stdin_if_piped();
-        if let Err(e) = send_notification(&name, kind.as_deref(), body.as_deref(), agent.as_deref()) {
-            #[cfg(debug_assertions)]
-            eprintln!("Notification failed: {}", e);
-            let _ = e;
-            std::process::exit(1);
-        }
-        std::process::exit(0);
-    }
-
     // ExitPlanMode フック (--set-description): stdin の hook JSON を /set-description へ転送し、
     // 稼働中アプリにプランを AI 要約させてワークツリーの description にセットさせる。
-    if let Some(name) = find_set_description_arg(&args) {
+    // --notify より先に判定する（両フラグが同時指定されることは無いが順序を明示）。
+    if has_flag(&args, "--set-description", "-d") {
+        let dir = resolve_project_dir(&args);
         let hook_json = read_stdin_if_piped();
-        if let Err(e) = send_set_description(&name, hook_json.as_deref()) {
+        if let Err(e) = send_set_description(&dir, hook_json.as_deref()) {
             #[cfg(debug_assertions)]
             eprintln!("Set description failed: {}", e);
             let _ = e;
@@ -48,8 +40,24 @@ fn main() {
         std::process::exit(0);
     }
 
+    // 通知 (--notify): stdin(hook JSON) を body として /notify へ送る。
+    // ワークツリー名と kind はサーバー側で project-dir / event から解決する。
+    if has_flag(&args, "--notify", "-n") {
+        let dir = resolve_project_dir(&args);
+        let event = find_event_arg(&args);
+        let agent = find_agent_arg(&args);
+        let body = read_stdin_if_piped();
+        if let Err(e) = send_notification(&dir, event.as_deref(), body.as_deref(), agent.as_deref()) {
+            #[cfg(debug_assertions)]
+            eprintln!("Notification failed: {}", e);
+            let _ = e;
+            std::process::exit(1);
+        }
+        std::process::exit(0);
+    }
+
     #[cfg(debug_assertions)]
-    eprintln!("Usage: oretachi-notify --notify <worktree> [--kind <kind>] [--agent <agent>]\n       oretachi-notify --set-description <worktree>");
+    eprintln!("Usage: oretachi-notify --notify --project-dir <dir> --event <Event> [--agent <agent>]\n       oretachi-notify --set-description --project-dir <dir>");
     std::process::exit(2);
 }
 
@@ -66,20 +74,33 @@ fn find_arg(args: &[String], long: &str, short: &str) -> Option<String> {
     None
 }
 
-fn find_notify_arg(args: &[String]) -> Option<String> {
-    find_arg(args, "--notify", "-n")
+/// 値を取らないフラグ（--notify / --set-description）の有無を判定する。
+fn has_flag(args: &[String], long: &str, short: &str) -> bool {
+    args.iter().skip(1).any(|a| a == long || a == short)
 }
 
-fn find_kind_arg(args: &[String]) -> Option<String> {
-    find_arg(args, "--kind", "-k")
+fn find_project_dir_arg(args: &[String]) -> Option<String> {
+    find_arg(args, "--project-dir", "-p")
+}
+
+fn find_event_arg(args: &[String]) -> Option<String> {
+    find_arg(args, "--event", "-e")
 }
 
 fn find_agent_arg(args: &[String]) -> Option<String> {
     find_arg(args, "--agent", "-a")
 }
 
-fn find_set_description_arg(args: &[String]) -> Option<String> {
-    find_arg(args, "--set-description", "-d")
+/// --project-dir を解決する。${CLAUDE_PROJECT_DIR} が未置換のまま届いた場合や空/未指定の
+/// 場合は、hook が実行される worktree ディレクトリ = プロセスの current_dir にフォールバック。
+fn resolve_project_dir(args: &[String]) -> String {
+    let raw = find_project_dir_arg(args);
+    match raw {
+        Some(d) if !d.is_empty() && !d.contains("${") => d,
+        _ => std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+    }
 }
 
 /// stdin がパイプ（非 TTY）の場合のみ読み取り、タイムアウト付きで返す。
@@ -103,16 +124,20 @@ fn read_stdin_if_piped() -> Option<String> {
 }
 
 /// 起動中の oretachi MCP サーバへ通知を送る（AppHandle 不要のスタンドアロン実装）。
+/// ワークツリー名・kind の解決はサーバー側で project_dir / event から行うため、ここでは
+/// 生の project_dir と event を渡す。
 fn send_notification(
-    worktree_name: &str,
-    kind: Option<&str>,
+    project_dir: &str,
+    event: Option<&str>,
     body: Option<&str>,
     agent: Option<&str>,
 ) -> Result<(), String> {
     let mut payload = serde_json::json!({
-        "worktree": worktree_name,
-        "kind": kind.unwrap_or("general"),
+        "projectDir": project_dir,
     });
+    if let Some(e) = event {
+        payload["event"] = serde_json::Value::String(e.to_string());
+    }
     if let Some(b) = body {
         payload["body"] = serde_json::Value::String(b.to_string());
     }
@@ -124,9 +149,10 @@ fn send_notification(
 
 /// ExitPlanMode フックの hook JSON を /set-description へ転送し、
 /// 稼働中アプリにプランの AI 要約と description セットを依頼する。
-fn send_set_description(worktree_name: &str, hook_json: Option<&str>) -> Result<(), String> {
+/// ワークツリーの特定はサーバー側で project_dir から行う。
+fn send_set_description(project_dir: &str, hook_json: Option<&str>) -> Result<(), String> {
     let mut payload = serde_json::json!({
-        "worktree": worktree_name,
+        "projectDir": project_dir,
     });
     if let Some(j) = hook_json {
         payload["hookJson"] = serde_json::Value::String(j.to_string());
@@ -222,75 +248,75 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_find_notify_arg_long_space() {
-        let args = vec!["bin".to_string(), "--notify".to_string(), "myname".to_string()];
-        assert_eq!(find_notify_arg(&args), Some("myname".to_string()));
+    fn test_has_flag_notify() {
+        let args = vec!["bin".to_string(), "--notify".to_string(), "--agent".to_string(), "cc".to_string()];
+        assert!(has_flag(&args, "--notify", "-n"));
+        assert!(!has_flag(&args, "--set-description", "-d"));
     }
 
     #[test]
-    fn test_find_notify_arg_long_eq() {
-        let args = vec!["bin".to_string(), "--notify=myname".to_string()];
-        assert_eq!(find_notify_arg(&args), Some("myname".to_string()));
+    fn test_has_flag_short() {
+        let args = vec!["bin".to_string(), "-d".to_string()];
+        assert!(has_flag(&args, "--set-description", "-d"));
     }
 
     #[test]
-    fn test_find_notify_arg_short() {
-        let args = vec!["bin".to_string(), "-n".to_string(), "myname".to_string()];
-        assert_eq!(find_notify_arg(&args), Some("myname".to_string()));
-    }
-
-    #[test]
-    fn test_find_notify_arg_none() {
+    fn test_has_flag_absent() {
         let args = vec!["bin".to_string(), "--other".to_string()];
-        assert_eq!(find_notify_arg(&args), None);
+        assert!(!has_flag(&args, "--notify", "-n"));
     }
 
     #[test]
-    fn test_find_notify_arg_no_value() {
+    fn test_find_project_dir_long_space() {
+        let args = vec!["bin".to_string(), "--project-dir".to_string(), "X:/wt/foo".to_string()];
+        assert_eq!(find_project_dir_arg(&args), Some("X:/wt/foo".to_string()));
+    }
+
+    #[test]
+    fn test_find_project_dir_long_eq() {
+        let args = vec!["bin".to_string(), "--project-dir=X:/wt/foo".to_string()];
+        assert_eq!(find_project_dir_arg(&args), Some("X:/wt/foo".to_string()));
+    }
+
+    #[test]
+    fn test_find_project_dir_short() {
+        let args = vec!["bin".to_string(), "-p".to_string(), "X:/wt/foo".to_string()];
+        assert_eq!(find_project_dir_arg(&args), Some("X:/wt/foo".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_project_dir_explicit() {
+        let args = vec!["bin".to_string(), "--project-dir".to_string(), "X:/wt/foo".to_string()];
+        assert_eq!(resolve_project_dir(&args), "X:/wt/foo".to_string());
+    }
+
+    #[test]
+    fn test_resolve_project_dir_unsubstituted_falls_back_to_cwd() {
+        // ${CLAUDE_PROJECT_DIR} が未置換のまま届いたら current_dir にフォールバックする
+        let args = vec!["bin".to_string(), "--project-dir".to_string(), "${CLAUDE_PROJECT_DIR}".to_string()];
+        let cwd = std::env::current_dir().unwrap().to_string_lossy().to_string();
+        assert_eq!(resolve_project_dir(&args), cwd);
+    }
+
+    #[test]
+    fn test_resolve_project_dir_missing_falls_back_to_cwd() {
         let args = vec!["bin".to_string(), "--notify".to_string()];
-        assert_eq!(find_notify_arg(&args), None);
+        let cwd = std::env::current_dir().unwrap().to_string_lossy().to_string();
+        assert_eq!(resolve_project_dir(&args), cwd);
     }
 
     #[test]
-    fn test_find_notify_arg_empty() {
-        let args: Vec<String> = vec!["bin".to_string()];
-        assert_eq!(find_notify_arg(&args), None);
-    }
-
-    #[test]
-    fn test_find_kind_arg_long_space() {
-        let args = vec!["bin".to_string(), "--kind".to_string(), "approval".to_string()];
-        assert_eq!(find_kind_arg(&args), Some("approval".to_string()));
-    }
-
-    #[test]
-    fn test_find_kind_arg_long_eq() {
-        let args = vec!["bin".to_string(), "--kind=completed".to_string()];
-        assert_eq!(find_kind_arg(&args), Some("completed".to_string()));
-    }
-
-    #[test]
-    fn test_find_kind_arg_short() {
-        let args = vec!["bin".to_string(), "-k".to_string(), "general".to_string()];
-        assert_eq!(find_kind_arg(&args), Some("general".to_string()));
-    }
-
-    #[test]
-    fn test_find_kind_arg_none() {
-        let args = vec!["bin".to_string(), "--notify".to_string(), "myname".to_string()];
-        assert_eq!(find_kind_arg(&args), None);
+    fn test_find_event_arg() {
+        let args = vec!["bin".to_string(), "--event".to_string(), "Stop".to_string()];
+        assert_eq!(find_event_arg(&args), Some("Stop".to_string()));
+        let none = vec!["bin".to_string(), "--notify".to_string()];
+        assert_eq!(find_event_arg(&none), None);
     }
 
     #[test]
     fn test_find_agent_arg_long_space() {
         let args = vec!["bin".to_string(), "--agent".to_string(), "cc".to_string()];
         assert_eq!(find_agent_arg(&args), Some("cc".to_string()));
-    }
-
-    #[test]
-    fn test_find_agent_arg_long_eq() {
-        let args = vec!["bin".to_string(), "--agent=codex".to_string()];
-        assert_eq!(find_agent_arg(&args), Some("codex".to_string()));
     }
 
     #[test]
@@ -301,25 +327,7 @@ mod tests {
 
     #[test]
     fn test_find_agent_arg_none() {
-        let args = vec!["bin".to_string(), "--notify".to_string(), "myname".to_string()];
+        let args = vec!["bin".to_string(), "--notify".to_string(), "--event".to_string(), "Stop".to_string()];
         assert_eq!(find_agent_arg(&args), None);
-    }
-
-    #[test]
-    fn test_find_set_description_arg_long_space() {
-        let args = vec!["bin".to_string(), "--set-description".to_string(), "wt".to_string()];
-        assert_eq!(find_set_description_arg(&args), Some("wt".to_string()));
-    }
-
-    #[test]
-    fn test_find_set_description_arg_short() {
-        let args = vec!["bin".to_string(), "-d".to_string(), "wt".to_string()];
-        assert_eq!(find_set_description_arg(&args), Some("wt".to_string()));
-    }
-
-    #[test]
-    fn test_find_set_description_arg_none() {
-        let args = vec!["bin".to_string(), "--notify".to_string(), "wt".to_string()];
-        assert_eq!(find_set_description_arg(&args), None);
     }
 }

--- a/src-tauri/src/claude_plugin.rs
+++ b/src-tauri/src/claude_plugin.rs
@@ -190,19 +190,31 @@ fn sidecar_path() -> String {
 
 fn build_hooks_json(notifier_path: &str) -> serde_json::Value {
     // notifier_path は通知サイドカー (oretachi-notify) の絶対パスを直接ハードコードする。
-    // ${user_config.XXX} は Claude Code プラグイン仕様のユーザー設定値展開構文。
-    // 各ワークツリーの pluginConfigs.oretachi@oretachi.options から値が注入される。
+    //
+    // userConfig 非依存・exec-form で生成する。Claude Code 2.1.207 は
+    //   (a) shell-form の command 内で ${user_config.*} を参照すると拒否し、
+    //   (b) pluginConfigs (${user_config.*} の値) を settings.local.json から読まなくなった
+    // ため、userConfig ベースの旧方式は成立しない。そこで hook からは userConfig ではなく
+    // CC 組み込み変数 ${CLAUDE_PROJECT_DIR}（全バージョンで有効・userConfig ではない）と
+    // イベント名リテラルのみを渡し、「パス→ワークツリー」「イベント→kind」の解決は
+    // oretachi サーバー側 (/notify ハンドラ) で行う。exec-form (args 配列) は shell-form の
+    // ${user_config.*} 拒否チェックの対象外であり、${CLAUDE_PROJECT_DIR} は args 内でも置換される。
     let mut hooks = serde_json::Map::new();
-    for (event, key) in EVENT_CONFIG_KEYS {
-        let command = format!(
-            "\"{}\" --notify \"${{user_config.worktree_name}}\" --kind ${{user_config.{}}} --agent cc",
-            notifier_path, key
-        );
+    for (event, _key) in EVENT_CONFIG_KEYS {
         hooks.insert(
             event.to_string(),
             serde_json::json!([{
                 "matcher": "",
-                "hooks": [{ "type": "command", "command": command }]
+                "hooks": [{
+                    "type": "command",
+                    "command": notifier_path,
+                    "args": [
+                        "--notify",
+                        "--project-dir", "${CLAUDE_PROJECT_DIR}",
+                        "--event", event,
+                        "--agent", "cc"
+                    ]
+                }]
             }]),
         );
     }
@@ -213,13 +225,13 @@ fn build_hooks_json(notifier_path: &str) -> serde_json::Value {
     // PermissionRequest イベントで発火する（matcher "ExitPlanMode"、プラン本文は tool_input.plan）。
     // 既存の通知用 PermissionRequest グループ(matcher "")と共存させるため配列に追記する。
     // decision は返さず観測のみ（exit 0）なので通常の承認フローはブロックしない。
-    let set_desc_command = format!(
-        "\"{}\" --set-description \"${{user_config.worktree_name}}\"",
-        notifier_path
-    );
     let exit_plan_group = serde_json::json!({
         "matcher": "ExitPlanMode",
-        "hooks": [{ "type": "command", "command": set_desc_command }]
+        "hooks": [{
+            "type": "command",
+            "command": notifier_path,
+            "args": ["--set-description", "--project-dir", "${CLAUDE_PROJECT_DIR}"]
+        }]
     });
     if let Some(arr) = hooks
         .get_mut("PermissionRequest")

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -18,7 +18,7 @@ use tokio::sync::{broadcast, oneshot, watch, RwLock};
 
 use crate::git_worktree::get_git_remotes;
 use crate::pty_manager::PtyManager;
-use crate::settings::SettingsManager;
+use crate::settings::{AppSettings, SettingsManager, WorktreeEntry};
 
 const PORT_FILE: &str = "mcp-port";
 const SERVER_INFO_FILE: &str = "mcp-server.json";
@@ -198,7 +198,18 @@ impl McpServerManager {
 
 #[derive(Debug, Deserialize)]
 pub struct NotifyPayload {
-    pub worktree: String,
+    /// userConfig 非依存版の hook が送る CC 組み込み変数 ${CLAUDE_PROJECT_DIR}。
+    /// これからワークツリー名を逆引きする。
+    #[serde(default, rename = "projectDir")]
+    pub project_dir: Option<String>,
+    /// ライフサイクルイベント名（"Stop" 等）。これから kind を解決する。
+    #[serde(default)]
+    pub event: Option<String>,
+    /// 後方互換: ワークツリー名を直接指定する旧形式 / MCP 経由。
+    #[serde(default)]
+    pub worktree: Option<String>,
+    /// 後方互換: kind を直接指定する旧形式。
+    #[serde(default)]
     pub kind: Option<String>,
     pub body: Option<String>,
     pub agent: Option<String>,
@@ -206,7 +217,12 @@ pub struct NotifyPayload {
 
 #[derive(Debug, Deserialize)]
 pub struct SetDescriptionPayload {
-    pub worktree: String,
+    /// userConfig 非依存版の hook が送る ${CLAUDE_PROJECT_DIR}。
+    #[serde(default, rename = "projectDir")]
+    pub project_dir: Option<String>,
+    /// 後方互換: ワークツリー名を直接指定する旧形式。
+    #[serde(default)]
+    pub worktree: Option<String>,
     /// ExitPlanMode フックが stdin で受け取った hook JSON 文字列（生）
     #[serde(rename = "hookJson")]
     pub hook_json: Option<String>,
@@ -1383,19 +1399,97 @@ impl ServerHandler for NotifyService {
     }
 }
 
+// ─── worktree / kind の解決（userConfig 非依存 hook 用） ──────────────────────
+
+/// パスを比較用に正規化する（`\`→`/`、末尾 `/` 除去、Windows は小文字化）。
+fn normalize_path_for_match(p: &str) -> String {
+    let mut s = p.replace('\\', "/");
+    while s.len() > 1 && s.ends_with('/') {
+        s.pop();
+    }
+    if cfg!(windows) {
+        s = s.to_lowercase();
+    }
+    s
+}
+
+/// project_dir（${CLAUDE_PROJECT_DIR}）に一致するワークツリーエントリを返す。
+fn resolve_worktree_by_dir<'a>(settings: &'a AppSettings, dir: &str) -> Option<&'a WorktreeEntry> {
+    let target = normalize_path_for_match(dir);
+    settings
+        .worktrees
+        .iter()
+        .find(|w| normalize_path_for_match(&w.path) == target)
+}
+
+/// イベント名の既定 kind。ユーザー設定 (repo.notification_hooks) が無い場合のフォールバック。
+fn default_kind_for_event(event: &str) -> &'static str {
+    match event {
+        "Stop" => "completed",
+        "PermissionRequest" => "approval",
+        _ => "hook",
+    }
+}
+
+/// ワークツリーの所属リポジトリの notification_hooks から event に対応する kind を解決する。
+/// 設定が無ければ default_kind_for_event にフォールバック。
+fn resolve_kind_for_event(settings: &AppSettings, worktree: &WorktreeEntry, event: &str) -> String {
+    settings
+        .repositories
+        .iter()
+        .find(|r| r.id == worktree.repository_id)
+        .and_then(|r| r.notification_hooks.as_ref())
+        .and_then(|hooks| hooks.iter().find(|h| h.event == event))
+        .map(|h| h.kind.clone())
+        .unwrap_or_else(|| default_kind_for_event(event).to_string())
+}
+
 // ─── Simple REST endpoint (/notify) ──────────────────────────────────────────
 
 async fn notify_handler(
     State(app_handle): State<AppHandle>,
     Json(payload): Json<NotifyPayload>,
 ) -> StatusCode {
+    let settings = app_handle.state::<SettingsManager>().get();
+
+    // ワークツリー: project_dir から逆引き。見つからなければ後方互換の worktree 名で解決。
+    let worktree = payload
+        .project_dir
+        .as_deref()
+        .and_then(|d| resolve_worktree_by_dir(&settings, d));
+    let worktree_name = match worktree {
+        Some(w) => w.name.clone(),
+        None => match payload.worktree.clone() {
+            Some(name) => name,
+            None => {
+                log::warn!(
+                    "[notify] could not resolve worktree (projectDir={:?}); dropping",
+                    payload.project_dir
+                );
+                return StatusCode::OK;
+            }
+        },
+    };
+
+    // kind: 明示指定(旧形式/MCP) > event からの解決 > "general"
+    let kind = if let Some(k) = payload.kind.clone() {
+        k
+    } else if let Some(ev) = payload.event.as_deref() {
+        match worktree {
+            Some(w) => resolve_kind_for_event(&settings, w, ev),
+            None => default_kind_for_event(ev).to_string(),
+        }
+    } else {
+        "general".to_string()
+    };
+
     let event = NotifyWorktreeEvent {
-        worktree_name: payload.worktree.clone(),
-        kind: payload.kind.unwrap_or_else(|| "general".to_string()),
+        worktree_name,
+        kind,
         body: payload.body,
         agent: payload.agent,
     };
-    log::info!("[notify] worktree={} kind={}", payload.worktree, event.kind);
+    log::info!("[notify] worktree={} kind={}", event.worktree_name, event.kind);
 
     let manager = app_handle.state::<McpServerManager>();
     // hook: 3秒 / approval: 1秒 で (worktree, kind) 単位に送信制限。
@@ -1480,6 +1574,23 @@ async fn set_description_handler(
     State(app_handle): State<AppHandle>,
     Json(payload): Json<SetDescriptionPayload>,
 ) -> StatusCode {
+    let settings = app_handle.state::<SettingsManager>().get();
+
+    // ワークツリー: project_dir から逆引き。無ければ後方互換の worktree 名。
+    let worktree_name = payload
+        .project_dir
+        .as_deref()
+        .and_then(|d| resolve_worktree_by_dir(&settings, d))
+        .map(|w| w.name.clone())
+        .or_else(|| payload.worktree.clone());
+    let Some(worktree_name) = worktree_name else {
+        log::warn!(
+            "[set-description] could not resolve worktree (projectDir={:?}); skipping",
+            payload.project_dir
+        );
+        return StatusCode::OK;
+    };
+
     let plan = payload
         .hook_json
         .as_deref()
@@ -1487,14 +1598,14 @@ async fn set_description_handler(
 
     let Some(plan) = plan else {
         // プランが取れない場合はベストエフォートで握りつぶす（フックをブロックしない）
-        log::info!("[set-description] worktree={} no plan extracted; skipping", payload.worktree);
+        log::info!("[set-description] worktree={} no plan extracted; skipping", worktree_name);
         return StatusCode::OK;
     };
 
-    log::info!("[set-description] worktree={} plan_len={}", payload.worktree, plan.len());
+    log::info!("[set-description] worktree={} plan_len={}", worktree_name, plan.len());
 
     let event = SetWorktreeDescriptionEvent {
-        worktree: payload.worktree,
+        worktree: worktree_name,
         plan,
     };
     match app_handle.emit("set-worktree-description", &event) {

--- a/src-tauri/src/task_executor.rs
+++ b/src-tauri/src/task_executor.rs
@@ -382,6 +382,7 @@ mod tests {
             auto_approval_prompt: None,
             description: None,
             description_open: None,
+            workgroup_id: None,
         }
     }
 


### PR DESCRIPTION
## 背景・問題

Claude Code **2.1.207** で oretachi プラグインの通知 hook が「フォーマットエラー」になる。バイナリ解析＋CHANGELOG で判明した破壊的変更は2点:

1. **shell-form の hook 内で `${user_config.*}` を参照すると拒否される**（shell-injection 対策）。exec-form (`args` 配列) が必須。
2. **`pluginConfigs`（`${user_config.*}` の値）を `.claude/settings.local.json` から読まなくなった**。`MFr()` は `["userSettings","flagSettings","policySettings"]` からのみマージ（CHANGELOG「only user, `--settings`, and managed settings are honored」）。未解決キーは `Plugin option "X" isn't set` で失敗。

oretachi は worktree_name / 各 kind を `settings.local.json` の `pluginConfigs` に書くため、2.1.207 では `${user_config.worktree_name}` が解決できず失敗していた（＝真の根本原因）。

## 対応

**userConfig 依存を完全に撤廃。** hook からは CC 組み込み変数 `${CLAUDE_PROJECT_DIR}`（全バージョンで有効・userConfig ではない）とイベント名リテラルのみを exec-form で渡し、「パス→ワークツリー」「イベント→kind」の解決を **oretachi サーバー側**で行う。これにより全 CC バージョンで動作し、per-repo の kind カスタマイズも維持される。

- **`claude_plugin.rs`** (`build_hooks_json`): exec-form + `${CLAUDE_PROJECT_DIR}` + `--event <name>` に変更。`${user_config.*}` を完全排除。
- **`notify/main.rs`**: CLI 刷新（`--notify`/`--set-description` フラグ + `--project-dir`/`--event`）。`${CLAUDE_PROJECT_DIR}` 未置換時は `current_dir()` フォールバック。送信 JSON を `projectDir`/`event` ベースに。
- **`mcp_server.rs`**: `NotifyPayload`/`SetDescriptionPayload` に `projectDir`/`event` を追加（`worktree`/`kind` は後方互換で Option 化）。`normalize_path_for_match` / `resolve_worktree_by_dir` / `resolve_kind_for_event` を追加し、両ハンドラでパス逆引き＋イベント→kind 解決（repo の `notification_hooks` を優先）。
- **`task_executor.rs`**: 既存で壊れていたテストヘルパー（`workgroup_id` 欠落）を1行修正。

## テスト・検証

- `cargo check` ✓ / notify クレート 13件 ✓ / メイン lib 55件 ✓
- 稼働中の 2.1.207 サーバーで実機検証:
  - `hooks.json` が exec-form・`${CLAUDE_PROJECT_DIR}`・`--event`（`${user_config.*}` 無し）で再生成される
  - projectDir → `worktree=oretachi-lsf7` に逆引き
  - event → kind 解決: Stop→`completed` / PreToolUse→`hook` / PermissionRequest→`approval`
  - set-description も projectDir から worktree 解決＋plan 抽出

🤖 Generated with [Claude Code](https://claude.com/claude-code)