### PR TITLE
feat(ide): 「IDEで開く」にファイルエクスプローラーの選択肢を追加

### DIFF
--- a/src-tauri/src/ide_launcher.rs
+++ b/src-tauri/src/ide_launcher.rs
@@ -59,3 +59,30 @@ pub fn open_in_ide(command: &str, path: &str) -> Result<(), String> {
         .map_err(|e| format!("IDE の起動に失敗しました: {}", e))?;
     Ok(())
 }
+
+pub fn open_in_file_explorer(path: &str) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        // エクスプローラーはパス区切りに `\` を要求するため正規化する
+        let normalized = path.replace('/', "\\");
+        make_command("explorer")
+            .arg(&normalized)
+            .spawn()
+            .map_err(|e| format!("ファイルエクスプローラーの起動に失敗しました: {}", e))?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        make_command("open")
+            .arg(path)
+            .spawn()
+            .map_err(|e| format!("ファイルエクスプローラーの起動に失敗しました: {}", e))?;
+    }
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    {
+        make_command("xdg-open")
+            .arg(path)
+            .spawn()
+            .map_err(|e| format!("ファイルエクスプローラーの起動に失敗しました: {}", e))?;
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -453,6 +453,12 @@ fn open_in_ide(command: String, path: String) -> Result<(), String> {
     ide_launcher::open_in_ide(&command, &path)
 }
 
+#[tauri::command]
+fn open_in_file_explorer(path: String) -> Result<(), String> {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::OpenInFileExplorer);
+    ide_launcher::open_in_file_explorer(&path)
+}
+
 // ─── MCP コマンド ─────────────────────────────────────────────────────────────
 
 #[tauri::command]
@@ -1038,6 +1044,7 @@ pub fn run() {
             detect_ides,
             detect_ai_agents,
             open_in_ide,
+            open_in_file_explorer,
             get_mcp_status,
             restart_mcp_server,
             regenerate_mcp_api_key,

--- a/src-tauri/src/main_thread_watch.rs
+++ b/src-tauri/src/main_thread_watch.rs
@@ -40,6 +40,7 @@ pub enum Activity {
     DetectIdes,
     DetectAiAgents,
     OpenInIde,
+    OpenInFileExplorer,
     RegenerateMcpApiKey,
     GetMcpStatus,
     PathExists,
@@ -54,7 +55,7 @@ pub enum Activity {
 }
 
 /// [`Activity`] の discriminant 順に並んだ表示ラベル。enum と順序を一致させること。
-const LABELS: [&str; 24] = [
+const LABELS: [&str; 25] = [
     "idle",
     "run-event",
     "watchdog-probe",
@@ -68,6 +69,7 @@ const LABELS: [&str; 24] = [
     "cmd:detect_ides",
     "cmd:detect_ai_agents",
     "cmd:open_in_ide",
+    "cmd:open_in_file_explorer",
     "cmd:regenerate_mcp_api_key",
     "cmd:get_mcp_status",
     "cmd:path_exists",

--- a/src/components/IdeSelectDialog.vue
+++ b/src/components/IdeSelectDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { IdeInfo } from "../types/ide";
 import { useI18n } from "vue-i18n";
+import { isMac } from "../composables/usePlatform";
 
 const { t } = useI18n();
 
@@ -12,6 +13,15 @@ const emit = defineEmits<{
   select: [ide: IdeInfo];
   cancel: [];
 }>();
+
+function ideName(ide: IdeInfo): string {
+  if (ide.id === "file-explorer") return isMac ? "Finder" : t("fileExplorer");
+  return ide.name;
+}
+
+function ideIcon(ide: IdeInfo): string {
+  return ide.id === "file-explorer" ? "pi pi-folder-open" : "pi pi-desktop";
+}
 </script>
 
 <template>
@@ -26,8 +36,8 @@ const emit = defineEmits<{
           class="ide-btn"
           @click="emit('select', ide)"
         >
-          <span class="pi pi-desktop ide-icon" />
-          <span class="ide-name">{{ ide.name }}</span>
+          <span :class="[ideIcon(ide), 'ide-icon']" />
+          <span class="ide-name">{{ ideName(ide) }}</span>
         </button>
       </div>
 
@@ -124,10 +134,12 @@ const emit = defineEmits<{
 <i18n lang="json">
 {
   "en": {
-    "select": "Select IDE"
+    "select": "Select IDE",
+    "fileExplorer": "File Explorer"
   },
   "ja": {
-    "select": "IDE を選択"
+    "select": "IDE を選択",
+    "fileExplorer": "エクスプローラー"
   }
 }
 </i18n>

--- a/src/composables/useIdeSelect.ts
+++ b/src/composables/useIdeSelect.ts
@@ -40,8 +40,8 @@ export function useIdeSelect() {
   async function openInIde(path: string, options: IdeSelectOptions = {}): Promise<void> {
     const ides = await invoke<IdeInfo[]>("detect_ides");
 
-    // 実IDE + ファイルエクスプローラー + Code Reviewer をダイアログで選択させる
-    detectedIdes.value = [...ides, FILE_EXPLORER_IDE, CODE_REVIEWER_IDE];
+    // 実IDE + Code Reviewer + ファイルエクスプローラー（末尾）をダイアログで選択させる
+    detectedIdes.value = [...ides, CODE_REVIEWER_IDE, FILE_EXPLORER_IDE];
     ideTargetPath.value = path;
     ideTargetOptions.value = options;
     showIdeDialog.value = true;

--- a/src/composables/useIdeSelect.ts
+++ b/src/composables/useIdeSelect.ts
@@ -11,6 +11,12 @@ export const CODE_REVIEWER_IDE: IdeInfo = {
   command: "",
 };
 
+export const FILE_EXPLORER_IDE: IdeInfo = {
+  id: "file-explorer",
+  name: "File Explorer", // 実表示は IdeSelectDialog 側で OS 依存に出し分け
+  command: "",
+};
+
 export interface IdeSelectOptions {
   /** worktreeId を渡す（Code Reviewer ウィンドウ識別に使用） */
   worktreeId?: string;
@@ -34,8 +40,8 @@ export function useIdeSelect() {
   async function openInIde(path: string, options: IdeSelectOptions = {}): Promise<void> {
     const ides = await invoke<IdeInfo[]>("detect_ides");
 
-    // 実IDE + Code Reviewer をダイアログで選択させる（Code Reviewer は末尾）
-    detectedIdes.value = [...ides, CODE_REVIEWER_IDE];
+    // 実IDE + ファイルエクスプローラー + Code Reviewer をダイアログで選択させる
+    detectedIdes.value = [...ides, FILE_EXPLORER_IDE, CODE_REVIEWER_IDE];
     ideTargetPath.value = path;
     ideTargetOptions.value = options;
     showIdeDialog.value = true;
@@ -51,6 +57,15 @@ export function useIdeSelect() {
         ideTargetPath.value,
         ideTargetOptions.value.origin,
       );
+      return;
+    }
+
+    if (ide.id === "file-explorer") {
+      try {
+        await invoke("open_in_file_explorer", { path: ideTargetPath.value });
+      } catch (e) {
+        await message(`ファイルエクスプローラーの起動に失敗しました: ${e}`, { kind: "error" });
+      }
       return;
     }
 


### PR DESCRIPTION
## 概要

「IDE で開く」ダイアログに **ファイルエクスプローラー** の選択肢を追加し、ワークツリーのフォルダを OS 標準のファイルマネージャーで直接開けるようにする。

- Windows: エクスプローラー（`explorer`）
- macOS: Finder（`open`）
- Linux: `xdg-open`

検出済みの実IDE（Cursor / VS Code / Antigravity）と擬似エントリ「Code Reviewer」の間に、同じ擬似エントリ方式で差し込む。

## 変更内容

### Rust
- `ide_launcher.rs`: `open_in_file_explorer(path)` を新設。`#[cfg(target_os)]` で OS ごとに起動コマンドを切り替え。Windows はエクスプローラーがパス区切りに `\` を要求するため `/`→`\` に正規化。
- `lib.rs`: Tauri コマンド `open_in_file_explorer` を追加し `invoke_handler` に登録。
- `main_thread_watch.rs`: `Activity::OpenInFileExplorer` バリアント・許可リスト・`LABELS` 配列サイズを更新。

### フロント
- `useIdeSelect.ts`: `FILE_EXPLORER_IDE` 擬似エントリを追加し、選択時に `open_in_file_explorer` を invoke（失敗時はエラーダイアログ）。
- `IdeSelectDialog.vue`: file-explorer のみ OS 依存でラベル（Windows=「エクスプローラー」/ mac=「Finder」）とアイコン（`pi pi-folder-open`）を出し分け。i18n キー `fileExplorer` を追加。

`detect_ides` / `open_in_ide` / トリガーボタン（Worktree カード・ヘッダー）は変更なし。

## 検証

- ✅ `cargo check`
- ✅ `cargo test main_thread_watch`（4 passed / enum・LABELS 整合性テスト含む）
- ✅ `pnpm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)