### PR TITLE
fix: 多数端末時の webview ハング対策 + single-instance ガード導入

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3669,6 +3669,7 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-prevent-default",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
@@ -6270,6 +6271,22 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ tauri-plugin-os = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.8"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -928,6 +928,24 @@ pub fn run() {
     let mcp_enabled = is_mcp_enabled();
 
     let mut builder = tauri::Builder::default();
+
+    // 多重起動防止 (重複起動すると同一ログ/settings/SQLite への並行書き込みと
+    // ワークツリー復元による PTY/AI エージェントの重複 spawn が起きる)。
+    // single-instance プラグインは「最初に登録する」ことが公式要件。
+    // dev と本番は識別子 com.ia.oretachi を共有するため、debug ビルドでは登録しない
+    // (本番稼働中に `pnpm run tauri dev` が起動できなくなるのを避ける)。
+    #[cfg(not(debug_assertions))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            log::warn!("[single-instance] 二重起動を検出。既存インスタンスの main ウィンドウを前面化する");
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show(); // トレイ常駐で非表示のケースに対応
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }));
+    }
+
     if acrylic_enabled {
         builder = builder.plugin(tauri_plugin_liquid_glass::init());
 

--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -3,22 +3,16 @@
 export let terminalMountCount = 0;
 export let terminalUnmountCount = 0;
 export let terminalActiveCount = 0;
-
-// WebGL コンテキストはブラウザ全体で上限 (~16) があり、端末数ぶん生成すると
-// コンテキストロスの連鎖や compositor 停止 (webview ハング) を招く。
-// 可視端末のみロードする方針に加え、保険として同時ロード数に上限を設ける。
-const MAX_WEBGL_CONTEXTS = 8;
-let webglContextCount = 0;
 </script>
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { usePty } from "../composables/usePty";
 import { usePtyWriteBatcher } from "../composables/usePtyWriteBatcher";
+import { useTerminalVisibility } from "../composables/useTerminalVisibility";
 import { useSettings } from "../composables/useSettings";
 import { matchesHotkey } from "../composables/useHotkeys";
 import { useTerminalSearch } from "../composables/useTerminalSearch";
@@ -65,14 +59,15 @@ let fitAddon: FitAddon | null = null;
 let serializeAddon: SerializeAddon | null = null;
 let resizeObserver: ResizeObserver | null = null;
 let resizeDebounce: ReturnType<typeof setTimeout> | null = null;
-let webglAddon: WebglAddon | null = null;
-let webglDisposeTimer: ReturnType<typeof setTimeout> | null = null;
-
-/** オフスクリーン退避後に WebGL を破棄するまでの猶予 (トレイ開閉連打での生成/破棄チャーン回避)。 */
-const WEBGL_DISPOSE_DELAY_MS = 5000;
 
 const { sessionId, spawn, attachToSession, write, resize, kill, isRunning, detach } = usePty();
 const batcher = usePtyWriteBatcher(() => terminal);
+const visibility = useTerminalVisibility({
+  getTerminal: () => terminal,
+  isOffscreen,
+  setWriteSuspended: batcher.setSuspended,
+  getSessionId: () => sessionId.value,
+});
 const { settings } = useSettings();
 
 // UIスケール (webview ズーム) 下でもターミナルの物理グリフサイズを不変に保つため、
@@ -152,7 +147,7 @@ function initTerminal() {
 
   // WebGL は可視端末のみロードする (updateVisibility 経由)。
   // オフスクリーンで open された場合はここではロードされず、可視化時にロードされる。
-  updateVisibility();
+  visibility.updateVisibility();
 
   // 左クリック: 選択テキストがあればコピー＆選択解除
   // capture フェーズで登録し、xterm.js が選択をクリアする前にテキストを取得する
@@ -333,73 +328,8 @@ function isOffscreen(): boolean {
   return !!xtermRef.value?.closest("[data-offscreen]");
 }
 
-function loadWebgl(): void {
-  if (webglAddon || !terminal) return;
-  if (webglContextCount >= MAX_WEBGL_CONTEXTS) {
-    logDebug(`[Terminal] WebGL load skipped (limit ${MAX_WEBGL_CONTEXTS}) sid=${sessionId.value}`);
-    return;
-  }
-  try {
-    const addon = new WebglAddon();
-    addon.onContextLoss(() => {
-      console.warn("[XTERM] WebGL onContextLoss fired!", { sessionId: sessionId.value });
-      disposeWebgl();
-      // dispose 後は xterm.js が自動で DOM レンダラーにフォールバック。
-      // 明示的に refresh を呼んで再描画させる。
-      terminal?.refresh(0, terminal.rows - 1);
-    });
-    terminal.loadAddon(addon);
-    webglAddon = addon;
-    webglContextCount++;
-    logDebug(`[Terminal] WebGL loaded sid=${sessionId.value} count=${webglContextCount}`);
-  } catch {
-    // DOM renderer を使用
-  }
-}
-
-function disposeWebgl(): void {
-  if (!webglAddon) return;
-  try {
-    webglAddon.dispose();
-  } catch {
-    // すでに破棄済み等は無視
-  }
-  webglAddon = null;
-  webglContextCount--;
-  logDebug(`[Terminal] WebGL disposed sid=${sessionId.value} count=${webglContextCount}`);
-}
-
-/**
- * オフスクリーン ↔ 可視 の状態変化を反映する。
- * - 可視: WebGL をロード (上限内) し、write 抑制を解除して蓄積分を排出。
- * - オフスクリーン: write を抑制し、猶予後に WebGL を破棄。
- * DOM reparenting (useTerminalReparenting) と handleTabActivated から呼ばれる。
- */
-function updateVisibility(): void {
-  const offscreen = isOffscreen();
-  batcher.setSuspended(offscreen);
-  if (offscreen) {
-    if (webglAddon && webglDisposeTimer === null) {
-      webglDisposeTimer = setTimeout(() => {
-        webglDisposeTimer = null;
-        // 猶予中に再可視化されていたら破棄しない
-        if (isOffscreen()) {
-          disposeWebgl();
-          terminal?.refresh(0, terminal.rows - 1);
-        }
-      }, WEBGL_DISPOSE_DELAY_MS);
-    }
-  } else {
-    if (webglDisposeTimer !== null) {
-      clearTimeout(webglDisposeTimer);
-      webglDisposeTimer = null;
-    }
-    loadWebgl();
-  }
-}
-
 async function handleTabActivated() {
-  updateVisibility();
+  visibility.updateVisibility();
   await nextTick();
   await new Promise<void>((resolve) => {
     requestAnimationFrame(() => {
@@ -482,14 +412,10 @@ onUnmounted(() => {
   terminalActiveCount--;
   logDebug(`[TerminalView] onUnmounted sessionId=${sessionId.value} cwd=${props.cwd}`);
   if (resizeDebounce) clearTimeout(resizeDebounce);
-  if (webglDisposeTimer !== null) {
-    clearTimeout(webglDisposeTimer);
-    webglDisposeTimer = null;
-  }
   resizeObserver?.disconnect();
   batcher.dispose();
   search.dispose();
-  disposeWebgl(); // terminal.dispose() より前にカウンタを整合させる
+  visibility.dispose(); // terminal.dispose() より前に WebGL カウンタを整合させる
   serializeAddon?.dispose();
   terminal?.dispose();
 });
@@ -506,7 +432,7 @@ defineExpose({
   sessionId,
   serializeBuffer,
   handleTabActivated,
-  updateVisibility,
+  updateVisibility: visibility.updateVisibility,
   waitForReady,
   containerRef,
   toggleSearchBar: search.toggleSearchBar,

--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -3,6 +3,12 @@
 export let terminalMountCount = 0;
 export let terminalUnmountCount = 0;
 export let terminalActiveCount = 0;
+
+// WebGL コンテキストはブラウザ全体で上限 (~16) があり、端末数ぶん生成すると
+// コンテキストロスの連鎖や compositor 停止 (webview ハング) を招く。
+// 可視端末のみロードする方針に加え、保険として同時ロード数に上限を設ける。
+const MAX_WEBGL_CONTEXTS = 8;
+let webglContextCount = 0;
 </script>
 
 <script setup lang="ts">
@@ -59,6 +65,11 @@ let fitAddon: FitAddon | null = null;
 let serializeAddon: SerializeAddon | null = null;
 let resizeObserver: ResizeObserver | null = null;
 let resizeDebounce: ReturnType<typeof setTimeout> | null = null;
+let webglAddon: WebglAddon | null = null;
+let webglDisposeTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** オフスクリーン退避後に WebGL を破棄するまでの猶予 (トレイ開閉連打での生成/破棄チャーン回避)。 */
+const WEBGL_DISPOSE_DELAY_MS = 5000;
 
 const { sessionId, spawn, attachToSession, write, resize, kill, isRunning, detach } = usePty();
 const batcher = usePtyWriteBatcher(() => terminal);
@@ -137,22 +148,11 @@ function initTerminal() {
 
   search.loadAddon(terminal);
 
-  // WebGL addon (失敗時は Canvas フォールバック)
-  try {
-    const webglAddon = new WebglAddon();
-    webglAddon.onContextLoss(() => {
-      console.warn("[XTERM] WebGL onContextLoss fired!", { sessionId: sessionId.value });
-      webglAddon.dispose();
-      // dispose 後は xterm.js が自動で Canvas レンダラーにフォールバック。
-      // 明示的に refresh を呼んで Canvas レンダラーで再描画させる。
-      terminal?.refresh(0, terminal.rows - 1);
-    });
-    terminal.loadAddon(webglAddon);
-  } catch {
-    // Canvas renderer を使用
-  }
-
   terminal.open(xtermRef.value);
+
+  // WebGL は可視端末のみロードする (updateVisibility 経由)。
+  // オフスクリーンで open された場合はここではロードされず、可視化時にロードされる。
+  updateVisibility();
 
   // 左クリック: 選択テキストがあればコピー＆選択解除
   // capture フェーズで登録し、xterm.js が選択をクリアする前にテキストを取得する
@@ -314,14 +314,92 @@ async function attachPty(id: number, snapshot?: string) {
 }
 
 function serializeBuffer(scrollback?: number): string {
+  // 抑制中の蓄積分を先に書き込んでから serialize する (取りこぼし防止)
+  batcher.flush();
   return serializeAddon?.serialize(scrollback !== undefined ? { scrollback } : undefined) ?? "";
+}
+
+function detachPty(): void {
+  // detach 後は pty-output ハンドラが外れるため、蓄積分を先に排出する
+  batcher.flush();
+  detach();
 }
 
 function focus() {
   terminal?.focus();
 }
 
+function isOffscreen(): boolean {
+  return !!xtermRef.value?.closest("[data-offscreen]");
+}
+
+function loadWebgl(): void {
+  if (webglAddon || !terminal) return;
+  if (webglContextCount >= MAX_WEBGL_CONTEXTS) {
+    logDebug(`[Terminal] WebGL load skipped (limit ${MAX_WEBGL_CONTEXTS}) sid=${sessionId.value}`);
+    return;
+  }
+  try {
+    const addon = new WebglAddon();
+    addon.onContextLoss(() => {
+      console.warn("[XTERM] WebGL onContextLoss fired!", { sessionId: sessionId.value });
+      disposeWebgl();
+      // dispose 後は xterm.js が自動で DOM レンダラーにフォールバック。
+      // 明示的に refresh を呼んで再描画させる。
+      terminal?.refresh(0, terminal.rows - 1);
+    });
+    terminal.loadAddon(addon);
+    webglAddon = addon;
+    webglContextCount++;
+    logDebug(`[Terminal] WebGL loaded sid=${sessionId.value} count=${webglContextCount}`);
+  } catch {
+    // DOM renderer を使用
+  }
+}
+
+function disposeWebgl(): void {
+  if (!webglAddon) return;
+  try {
+    webglAddon.dispose();
+  } catch {
+    // すでに破棄済み等は無視
+  }
+  webglAddon = null;
+  webglContextCount--;
+  logDebug(`[Terminal] WebGL disposed sid=${sessionId.value} count=${webglContextCount}`);
+}
+
+/**
+ * オフスクリーン ↔ 可視 の状態変化を反映する。
+ * - 可視: WebGL をロード (上限内) し、write 抑制を解除して蓄積分を排出。
+ * - オフスクリーン: write を抑制し、猶予後に WebGL を破棄。
+ * DOM reparenting (useTerminalReparenting) と handleTabActivated から呼ばれる。
+ */
+function updateVisibility(): void {
+  const offscreen = isOffscreen();
+  batcher.setSuspended(offscreen);
+  if (offscreen) {
+    if (webglAddon && webglDisposeTimer === null) {
+      webglDisposeTimer = setTimeout(() => {
+        webglDisposeTimer = null;
+        // 猶予中に再可視化されていたら破棄しない
+        if (isOffscreen()) {
+          disposeWebgl();
+          terminal?.refresh(0, terminal.rows - 1);
+        }
+      }, WEBGL_DISPOSE_DELAY_MS);
+    }
+  } else {
+    if (webglDisposeTimer !== null) {
+      clearTimeout(webglDisposeTimer);
+      webglDisposeTimer = null;
+    }
+    loadWebgl();
+  }
+}
+
 async function handleTabActivated() {
+  updateVisibility();
   await nextTick();
   await new Promise<void>((resolve) => {
     requestAnimationFrame(() => {
@@ -404,9 +482,14 @@ onUnmounted(() => {
   terminalActiveCount--;
   logDebug(`[TerminalView] onUnmounted sessionId=${sessionId.value} cwd=${props.cwd}`);
   if (resizeDebounce) clearTimeout(resizeDebounce);
+  if (webglDisposeTimer !== null) {
+    clearTimeout(webglDisposeTimer);
+    webglDisposeTimer = null;
+  }
   resizeObserver?.disconnect();
   batcher.dispose();
   search.dispose();
+  disposeWebgl(); // terminal.dispose() より前にカウンタを整合させる
   serializeAddon?.dispose();
   terminal?.dispose();
 });
@@ -415,7 +498,7 @@ defineExpose({
   startPty,
   attachPty,
   kill,
-  detach,
+  detach: detachPty,
   focus,
   write,
   getTerminal,
@@ -423,6 +506,7 @@ defineExpose({
   sessionId,
   serializeBuffer,
   handleTabActivated,
+  updateVisibility,
   waitForReady,
   containerRef,
   toggleSearchBar: search.toggleSearchBar,

--- a/src/composables/usePtyDispatcher.ts
+++ b/src/composables/usePtyDispatcher.ts
@@ -1,5 +1,13 @@
 import { listen } from "@tauri-apps/api/event";
 import { decodePtyOutput } from "../utils/decodePtyOutput";
+import { logDebug } from "../utils/log";
+
+/**
+ * ハンドラ未登録セッションの保留バッファ上限 (per-session)。
+ * Rust 側 `pty_manager.rs` の `MAX_PENDING_BYTES`(8MB) と揃える。
+ * 超過時は最古チャンクから破棄する (無制限蓄積によるヒープ肥大の防止)。
+ */
+const MAX_PENDING_BUFFER_BYTES = 8 * 1024 * 1024;
 
 interface PtyOutputPayload {
   sessionId: number;
@@ -17,6 +25,7 @@ const outputHandlers = new Map<number, OutputHandler>();
 const exitHandlers = new Map<number, ExitHandler>();
 const dirtySessionIds = new Set<number>();
 const pendingBuffers = new Map<number, Uint8Array[]>();
+const pendingBufferBytes = new Map<number, number>();
 let initialized = false;
 
 async function init() {
@@ -37,6 +46,20 @@ async function init() {
         pendingBuffers.set(sessionId, buf);
       }
       buf.push(bytes);
+      let total = (pendingBufferBytes.get(sessionId) ?? 0) + bytes.length;
+      // 上限超過時は最古チャンクから破棄する
+      let droppedBytes = 0;
+      while (total > MAX_PENDING_BUFFER_BYTES && buf.length > 1) {
+        const dropped = buf.shift()!;
+        total -= dropped.length;
+        droppedBytes += dropped.length;
+      }
+      if (droppedBytes > 0) {
+        logDebug(
+          `[PtyDispatcher] pending buffer overflow sid=${sessionId} dropped=${droppedBytes}B kept=${total}B`
+        );
+      }
+      pendingBufferBytes.set(sessionId, total);
     }
   });
 
@@ -60,6 +83,7 @@ export function activateSession(
   const buf = pendingBuffers.get(sessionId);
   if (buf) {
     pendingBuffers.delete(sessionId);
+    pendingBufferBytes.delete(sessionId);
     for (const data of buf) {
       onOutput(data);
     }
@@ -80,6 +104,7 @@ export function unregisterPtyHandlers(sessionId: number): void {
   exitHandlers.delete(sessionId);
   dirtySessionIds.delete(sessionId);
   pendingBuffers.delete(sessionId);
+  pendingBufferBytes.delete(sessionId);
 }
 
 export function isDirty(sessionId: number): boolean {

--- a/src/composables/usePtyWriteBatcher.ts
+++ b/src/composables/usePtyWriteBatcher.ts
@@ -18,12 +18,19 @@ const HIGH_WATERMARK_BYTES = 8 * 1024 * 1024;
  * 恒久ブロックする。これを防ぐため次の二段のフォールバックを併用する:
  *   1. setTimeout によるフォールバック排出(rAF が来なくても排出する)。
  *   2. HIGH_WATERMARK_BYTES 超過時の同期即時 flush(タイマ throttle に依存せず上限を保証)。
+ *
+ * さらに setSuspended(true) でオフスクリーン端末の排出を抑制できる。
+ * 抑制中は enqueue のみ行い terminal.write() をスケジュールしない
+ * (多数のオフスクリーン端末が並行して parse/render コストを消費し、
+ * メインスレッドを飽和させる webview ハングの対策)。
+ * HIGH_WATERMARK_BYTES 超過時は抑制中でも flush する (ANSI ストリームは破棄不可のため)。
  */
 export function usePtyWriteBatcher(getTerminal: () => Terminal | null) {
   let chunks: Uint8Array[] = [];
   let totalLength = 0;
   let rafId: number | null = null;
   let timerId: ReturnType<typeof setTimeout> | null = null;
+  let suspended = false;
 
   function clearScheduled(): void {
     if (rafId !== null) {
@@ -42,6 +49,10 @@ export function usePtyWriteBatcher(getTerminal: () => Terminal | null) {
     // 上限超過時はタイマ throttle 非依存でその場排出し、ヒープを上限内に固定する。
     if (totalLength >= HIGH_WATERMARK_BYTES) {
       flush();
+      return;
+    }
+    // 抑制中(オフスクリーン)は蓄積のみ。setSuspended(false) 時にまとめて排出する。
+    if (suspended) {
       return;
     }
     // 前面では rAF が先に発火して滑らかにバッチ。オクルージョン時は rAF が来ないため
@@ -80,10 +91,25 @@ export function usePtyWriteBatcher(getTerminal: () => Terminal | null) {
     totalLength = 0;
   }
 
+  /**
+   * オフスクリーン時の排出抑制を切り替える。
+   * 抑制解除時は蓄積分を即 flush する (可視化直後の fit/refresh が最新内容を描画できるように)。
+   */
+  function setSuspended(value: boolean): void {
+    if (suspended === value) return;
+    suspended = value;
+    if (value) {
+      // スケジュール済みの排出を取り消して蓄積モードへ
+      clearScheduled();
+    } else if (chunks.length > 0) {
+      flush();
+    }
+  }
+
   function dispose(): void {
     clearScheduled();
     flush();
   }
 
-  return { enqueue, dispose };
+  return { enqueue, flush, setSuspended, dispose };
 }

--- a/src/composables/useTerminalReparenting.ts
+++ b/src/composables/useTerminalReparenting.ts
@@ -3,6 +3,8 @@ import { logDebug } from "../utils/log";
 
 interface HasContainerRef {
   containerRef: HTMLElement | null;
+  /** オフスクリーン ↔ 可視 の状態変化を反映する (TerminalView が公開)。 */
+  updateVisibility?: () => void;
 }
 
 /**
@@ -21,6 +23,13 @@ export function useTerminalReparenting<TEntry, TRef extends HasContainerRef>(
     }
   }
 
+  /** DOM 移動後に各 TerminalView へ可視状態の変化を通知する (WebGL/write 抑制の切替)。 */
+  function notifyVisibility(): void {
+    for (const [tid] of terminalEntries) {
+      terminalRefs.get(tid)?.updateVisibility?.();
+    }
+  }
+
   /** 全TerminalViewをオフスクリーンdivに退避 */
   function returnAllToOffscreen(): void {
     const offscreen = document.querySelector("[data-offscreen]");
@@ -32,6 +41,7 @@ export function useTerminalReparenting<TEntry, TRef extends HasContainerRef>(
         offscreen.appendChild(el);
       }
     }
+    notifyVisibility();
   }
 
   /** 各TerminalViewを対応するterminal-hostに移動 */
@@ -40,13 +50,16 @@ export function useTerminalReparenting<TEntry, TRef extends HasContainerRef>(
       const comp = terminalRefs.get(tid);
       const el = comp?.containerRef;
       const host = document.getElementById(`terminal-host-${tid}`);
-      const hostStatus = host ? `found(${host.clientWidth}x${host.clientHeight})` : "not_found";
-      const elStatus = el ? "found" : "not_found";
-      logDebug(`[Terminal] mountTerminalsToHosts tid=${tid} host=${hostStatus} el=${elStatus}`);
+      // 注意: ここで host.clientWidth 等を読むと appendChild (レイアウト無効化) と
+      // 交互になり端末数ぶん強制同期リフローが発生する (layout thrashing)。読まないこと。
+      logDebug(
+        `[Terminal] mountTerminalsToHosts tid=${tid} host=${host ? "found" : "not_found"} el=${el ? "found" : "not_found"}`
+      );
       if (el && host && el.parentElement !== host) {
         host.appendChild(el);
       }
     }
+    notifyVisibility();
   }
 
   return { setTerminalRef, returnAllToOffscreen, mountTerminalsToHosts };

--- a/src/composables/useTerminalVisibility.ts
+++ b/src/composables/useTerminalVisibility.ts
@@ -1,0 +1,114 @@
+import type { Terminal } from "@xterm/xterm";
+import { WebglAddon } from "@xterm/addon-webgl";
+import { logDebug } from "../utils/log";
+
+// WebGL コンテキストはブラウザ全体で上限 (~16) があり、端末数ぶん生成すると
+// コンテキストロスの連鎖や compositor 停止 (webview ハング) を招く。
+// 可視端末のみロードする方針に加え、保険として同時ロード数に上限を設ける。
+// カウンタはモジュールスコープ = 同一 webview 内の全端末で共有。
+const MAX_WEBGL_CONTEXTS = 8;
+let webglContextCount = 0;
+
+/** オフスクリーン退避後に WebGL を破棄するまでの猶予 (トレイ開閉連打での生成/破棄チャーン回避)。 */
+const WEBGL_DISPOSE_DELAY_MS = 5000;
+
+interface TerminalVisibilityOptions {
+  getTerminal: () => Terminal | null;
+  /** オフスクリーン div ([data-offscreen]) 配下にいるか */
+  isOffscreen: () => boolean;
+  /** オフスクリーン時の write 抑制切替 (usePtyWriteBatcher.setSuspended) */
+  setWriteSuspended: (suspended: boolean) => void;
+  /** ログ用 */
+  getSessionId: () => number | null;
+}
+
+/**
+ * ターミナルのオフスクリーン ↔ 可視 状態に応じたリソース管理。
+ *
+ * - 可視: WebGL をロード (上限内) し、write 抑制を解除して蓄積分を排出。
+ * - オフスクリーン: write を抑制し、猶予後に WebGL を破棄。
+ *
+ * updateVisibility は DOM reparenting (useTerminalReparenting) と
+ * handleTabActivated から呼ばれる。dispose は onUnmounted で呼ぶこと
+ * (WebGL カウンタの整合のため terminal.dispose() より前)。
+ */
+export function useTerminalVisibility(options: TerminalVisibilityOptions) {
+  const { getTerminal, isOffscreen, setWriteSuspended, getSessionId } = options;
+
+  let webglAddon: WebglAddon | null = null;
+  let disposeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function loadWebgl(): void {
+    const terminal = getTerminal();
+    if (webglAddon || !terminal) return;
+    if (webglContextCount >= MAX_WEBGL_CONTEXTS) {
+      logDebug(`[Terminal] WebGL load skipped (limit ${MAX_WEBGL_CONTEXTS}) sid=${getSessionId()}`);
+      return;
+    }
+    try {
+      const addon = new WebglAddon();
+      addon.onContextLoss(() => {
+        console.warn("[XTERM] WebGL onContextLoss fired!", { sessionId: getSessionId() });
+        disposeWebgl();
+        // dispose 後は xterm.js が自動で DOM レンダラーにフォールバック。
+        // 明示的に refresh を呼んで再描画させる。
+        const t = getTerminal();
+        t?.refresh(0, t.rows - 1);
+      });
+      terminal.loadAddon(addon);
+      webglAddon = addon;
+      webglContextCount++;
+      logDebug(`[Terminal] WebGL loaded sid=${getSessionId()} count=${webglContextCount}`);
+    } catch {
+      // DOM renderer を使用
+    }
+  }
+
+  function disposeWebgl(): void {
+    if (!webglAddon) return;
+    try {
+      webglAddon.dispose();
+    } catch {
+      // すでに破棄済み等は無視
+    }
+    webglAddon = null;
+    webglContextCount--;
+    logDebug(`[Terminal] WebGL disposed sid=${getSessionId()} count=${webglContextCount}`);
+  }
+
+  function clearDisposeTimer(): void {
+    if (disposeTimer !== null) {
+      clearTimeout(disposeTimer);
+      disposeTimer = null;
+    }
+  }
+
+  /** オフスクリーン ↔ 可視 の状態変化を反映する。 */
+  function updateVisibility(): void {
+    const offscreen = isOffscreen();
+    setWriteSuspended(offscreen);
+    if (offscreen) {
+      if (webglAddon && disposeTimer === null) {
+        disposeTimer = setTimeout(() => {
+          disposeTimer = null;
+          // 猶予中に再可視化されていたら破棄しない
+          if (isOffscreen()) {
+            disposeWebgl();
+            const t = getTerminal();
+            t?.refresh(0, t.rows - 1);
+          }
+        }, WEBGL_DISPOSE_DELAY_MS);
+      }
+    } else {
+      clearDisposeTimer();
+      loadWebgl();
+    }
+  }
+
+  function dispose(): void {
+    clearDisposeTimer();
+    disposeWebgl();
+  }
+
+  return { updateVisibility, dispose };
+}


### PR DESCRIPTION
## 背景

07-14 に webview がフリーズ (heartbeat pong 途絶、バックエンドは正常)。ログ解析で**同時アクティブ端末数と強相関** (フリーズ時 15〜24 端末 / 正常時 5〜7)。停止部位は2変種:

- **07-14 型**: JS/レンダラのイベントループのみ停止 (main-thread watchdog は非発火)
- **07-09 型**: tao ネイティブ UI スレッドまで停止 (watchdog 発火 + minidump、`activity: idle`)

さらに 07-15 に本番アプリの重複起動が発生 (18:56:33 に heartbeat pong が2本並行記録)。single-instance ガードが未導入で、2個目がワークツリー復元により PTY を10個重複 spawn した。

## 原因

1. **WebGL コンテキストが端末数ぶん生成される** — 全端末が `WebglAddon` をロードし、ブラウザ上限 (~16) に接近・超過してコンテキストロス連鎖や compositor 停止を誘発 (07-09 型)
2. **オフスクリーン端末も write し続ける** — 非 detached 全ワークツリーの全端末が常時 mount され、200ms フォールバックがオフスクリーンでも `term.write()` を排出し続け parse/render コストを並行消費 (07-14 型)
3. **reparent 時の layout thrashing** — `mountTerminalsToHosts` がループ内で `clientWidth` (読み) と `appendChild` (書き) を交互実行し端末数ぶん強制同期リフロー
4. **重複起動**: `tauri-plugin-single-instance` 未導入

## 変更内容

### webview ハング対策
- `TerminalView.vue`: WebGL を可視端末のみロード (オフスクリーン退避 5s 後に破棄、同時上限 8)。`updateVisibility()` を公開
- `usePtyWriteBatcher.ts`: `setSuspended()` 追加。オフスクリーン中は蓄積のみ (8MB 超過時は強制排出)、可視化時に即 flush
- `useTerminalReparenting.ts`: `clientWidth` 読み取り削除でリフロー解消 + DOM 移動後に全端末へ可視状態を通知
- `usePtyDispatcher.ts`: pendingBuffers に per-session 8MB 上限
- serialize / detach 前に batcher を flush (スナップショット取りこぼし防止)

### 重複起動対策
- `tauri-plugin-single-instance` を builder の最初のプラグインとして登録 (release ビルドのみ)
- 二重起動時は既存 main ウィンドウを show + unminimize + set_focus
- debug ビルドは登録スキップ (本番稼働中の `pnpm run tauri dev` を阻害しないため)

## 検証

- [x] `pnpm run type-check`
- [x] `cargo check` (dev)
- [x] `cargo check --release` (cfg ガードされた single-instance ブロックの検証)
- [ ] 実機: 15端末以上 + 連続出力でトレイ開閉連打 → `webview unresponsive` が出ない・WebGL ロード数が上限内
- [ ] 実機: detach → 戻しで表示内容が欠けない
- [ ] 実機 (release): 二重起動で既存ウィンドウが前面化、アップデート再起動 / RedirectionGuard リローンチの回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)