### PR TITLE
feat(description): プランモード以外でも description を更新可能にする

### DIFF
--- a/src-tauri/notify/src/main.rs
+++ b/src-tauri/notify/src/main.rs
@@ -11,6 +11,9 @@
 //      ワークツリー名と kind の解決はサーバー側で project-dir / event から行う)
 //   oretachi-notify --set-description --project-dir "<dir>"
 //     (stdin の ExitPlanMode hook JSON を /set-description へ転送)
+//   oretachi-notify --prompt-context --project-dir "<dir>"
+//     (UserPromptSubmit フック用。/prompt-context から現在の description を取得し、
+//      additionalContext JSON を stdout に出力して Claude のコンテキストに注入する)
 //
 // hook からは userConfig ではなく CC 組み込み変数 ${CLAUDE_PROJECT_DIR} が --project-dir に渡る。
 // 未置換/空の場合はプロセスの current_dir (hook は worktree ディレクトリで実行される) にフォールバック。
@@ -40,6 +43,22 @@ fn main() {
         std::process::exit(0);
     }
 
+    // UserPromptSubmit フック (--prompt-context): /prompt-context から現在の description を
+    // 取得し、additionalContext JSON を stdout に出力する。スロットル中 (skip) やサーバ
+    // 未起動時は何も出力しない。フックをブロックしないよう常に exit 0 で終える。
+    if has_flag(&args, "--prompt-context", "-c") {
+        let dir = resolve_project_dir(&args);
+        match send_prompt_context(&dir) {
+            Ok(Some(output)) => println!("{}", output),
+            Ok(None) => {}
+            Err(_e) => {
+                #[cfg(debug_assertions)]
+                eprintln!("Prompt context failed: {}", _e);
+            }
+        }
+        std::process::exit(0);
+    }
+
     // 通知 (--notify): stdin(hook JSON) を body として /notify へ送る。
     // ワークツリー名と kind はサーバー側で project-dir / event から解決する。
     if has_flag(&args, "--notify", "-n") {
@@ -57,7 +76,7 @@ fn main() {
     }
 
     #[cfg(debug_assertions)]
-    eprintln!("Usage: oretachi-notify --notify --project-dir <dir> --event <Event> [--agent <agent>]\n       oretachi-notify --set-description --project-dir <dir>");
+    eprintln!("Usage: oretachi-notify --notify --project-dir <dir> --event <Event> [--agent <agent>]\n       oretachi-notify --set-description --project-dir <dir>\n       oretachi-notify --prompt-context --project-dir <dir>");
     std::process::exit(2);
 }
 
@@ -158,6 +177,93 @@ fn send_set_description(project_dir: &str, hook_json: Option<&str>) -> Result<()
         payload["hookJson"] = serde_json::Value::String(j.to_string());
     }
     post_json("/set-description", &payload)
+}
+
+/// UserPromptSubmit フック用。/prompt-context から現在の description を取得し、
+/// stdout に出力すべき additionalContext JSON を返す。skip 時は Ok(None)。
+fn send_prompt_context(project_dir: &str) -> Result<Option<String>, String> {
+    let payload = serde_json::json!({
+        "projectDir": project_dir,
+    });
+    let body = post_json_read_body("/prompt-context", &payload)?;
+    Ok(build_prompt_context_output(&body))
+}
+
+/// /prompt-context のレスポンスボディから UserPromptSubmit 用の
+/// additionalContext JSON を組み立てる。skip / parse 失敗時は None。
+fn build_prompt_context_output(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    if v["skip"].as_bool() == Some(true) {
+        return None;
+    }
+    let context = match v["description"].as_str().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(desc) => format!(
+            "[oretachi] このワークツリーの現在の description: 「{}」。これは作業全体の目的を表す1行です。今の作業がこの説明の範囲内（同一プランのサブタスク進行・レビュー対応など）なら更新は不要です。全く別の作業に切り替わった場合、または説明が実態と大きくずれている場合のみ oretachi_set_description ツールで更新してください。",
+            desc
+        ),
+        None => "[oretachi] このワークツリーの description は未設定です。作業内容が決まっていれば oretachi_set_description ツールで作業全体の目的を1行でセットしてください。".to_string(),
+    };
+    let output = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": context,
+        }
+    });
+    Some(output.to_string())
+}
+
+/// post_json と同様に POST し、レスポンスボディまで読んで返す。
+/// /prompt-context のようにサーバの返す JSON が必要な場合に使う。
+fn post_json_read_body(path: &str, payload: &serde_json::Value) -> Result<String, String> {
+    let (port, api_key) = read_server_info()?;
+    let payload_str = payload.to_string();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nContent-Type: application/json\r\nAuthorization: Bearer {api_key}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload_str}",
+        payload_str.len()
+    );
+
+    use std::io::{Read, Write};
+    use std::time::Duration;
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port)
+        .parse()
+        .map_err(|e| format!("Invalid address: {}", e))?;
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(3))
+        .map_err(|e| format!("Cannot connect to oretachi MCP server: {}", e))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .map_err(|e| format!("Failed to set write timeout: {}", e))?;
+    // body まで必要なので post_json より長めの読み取りタイムアウト（ローカル接続なので通常は数ms）
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|e| format!("Failed to set read timeout: {}", e))?;
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| format!("Failed to send request: {}", e))?;
+    stream
+        .flush()
+        .map_err(|e| format!("Failed to flush: {}", e))?;
+
+    // Connection: close なのでサーバが閉じるまで読み切る（タイムアウト時は読めた分まで）
+    let mut raw = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => raw.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+    let response = String::from_utf8_lossy(&raw);
+    let (head, body) = response
+        .split_once("\r\n\r\n")
+        .ok_or_else(|| "Incomplete HTTP response".to_string())?;
+    let status_line = head.lines().next().unwrap_or_default();
+    if !status_line.contains(" 200 ") {
+        return Err(format!("Server returned unexpected response: {}", status_line));
+    }
+    // axum の Json レスポンスは Content-Length 付き（chunked ではない）前提でそのまま返す
+    Ok(body.to_string())
 }
 
 /// mcp-server.json のポート/APIキーを読み、指定パスへ JSON を POST する。
@@ -264,6 +370,44 @@ mod tests {
     fn test_has_flag_absent() {
         let args = vec!["bin".to_string(), "--other".to_string()];
         assert!(!has_flag(&args, "--notify", "-n"));
+    }
+
+    #[test]
+    fn test_has_flag_prompt_context() {
+        let args = vec!["bin".to_string(), "--prompt-context".to_string(), "--project-dir".to_string(), "X:/wt/foo".to_string()];
+        assert!(has_flag(&args, "--prompt-context", "-c"));
+        assert!(!has_flag(&args, "--notify", "-n"));
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_with_description() {
+        let body = r#"{"worktreeName":"foo","description":"認証機能のリファクタリング"}"#;
+        let out = build_prompt_context_output(body).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "UserPromptSubmit");
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.contains("認証機能のリファクタリング"));
+        assert!(ctx.contains("oretachi_set_description"));
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_without_description() {
+        let body = r#"{"worktreeName":"foo","description":null}"#;
+        let out = build_prompt_context_output(body).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.contains("未設定"));
+        assert!(ctx.contains("oretachi_set_description"));
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_skip() {
+        assert_eq!(build_prompt_context_output(r#"{"skip":true}"#), None);
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_invalid_json() {
+        assert_eq!(build_prompt_context_output("not json"), None);
     }
 
     #[test]

--- a/src-tauri/src/claude_plugin.rs
+++ b/src-tauri/src/claude_plugin.rs
@@ -242,6 +242,22 @@ fn build_hooks_json(notifier_path: &str) -> serde_json::Value {
         hooks.insert("PermissionRequest".to_string(), serde_json::json!([exit_plan_group]));
     }
 
+    // UserPromptSubmit フック: プロンプト送信時にサイドカーを起動し、現在の description を
+    // additionalContext として注入する（逸脱していたら oretachi_set_description で更新させる）。
+    // 頻度はサーバー側 (/prompt-context) のワークツリー単位スロットルで抑制する。
+    // 通知は不要なので EVENT_CONFIG_KEYS には含めない（あちらは通知 kind の設定用）。
+    hooks.insert(
+        "UserPromptSubmit".to_string(),
+        serde_json::json!([{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": notifier_path,
+                "args": ["--prompt-context", "--project-dir", "${CLAUDE_PROJECT_DIR}"]
+            }]
+        }]),
+    );
+
     serde_json::json!({ "hooks": hooks })
 }
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -101,6 +101,10 @@ pub struct McpServerManager {
     /// hook: 3秒、approval: 1秒 debounce。general/completed や任意の kind は
     /// debounce しない（MCP クライアントの意図的な通知を握り潰さないため）
     notify_last_sent: Mutex<HashMap<(String, String), Option<std::time::Instant>>>,
+    /// /prompt-context のスロットル: worktree_id → 最終送信時刻。
+    /// UserPromptSubmit はプロンプトごとに発火するため、期間内は skip を返して
+    /// コンテキスト注入のノイズを抑える。
+    prompt_context_last_sent: Mutex<HashMap<String, std::time::Instant>>,
 }
 
 /// kind ごとの debounce 秒数。None の kind は debounce しない（毎回送信）。
@@ -162,6 +166,7 @@ impl McpServerManager {
             notify_listener_id: Mutex::new(None),
             hook_tx: broadcast::channel::<NotifyWorktreeEvent>(256).0,
             notify_last_sent: Mutex::new(HashMap::new()),
+            prompt_context_last_sent: Mutex::new(HashMap::new()),
         }
     }
 
@@ -231,7 +236,17 @@ pub struct SetDescriptionPayload {
 #[derive(Debug, Serialize, Clone)]
 pub struct SetWorktreeDescriptionEvent {
     pub worktree: String,
-    pub plan: String,
+    /// ExitPlanMode 経路: フロント側で AI 要約してから description にセットする
+    pub plan: Option<String>,
+    /// MCP 直接セット経路 (oretachi_set_description): AI 要約をスキップしてそのまま採用する
+    pub description: Option<String>,
+}
+
+/// UserPromptSubmit フック (--prompt-context) が送るペイロード
+#[derive(Debug, Deserialize)]
+pub struct PromptContextPayload {
+    #[serde(default, rename = "projectDir")]
+    pub project_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -242,6 +257,18 @@ pub struct NotifyWorktreeParams {
     pub kind: Option<String>,
     #[schemars(description = "通知本文（ライフサイクルフックのコンテキスト情報など）。省略可")]
     pub body: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetWorktreeDescriptionParams {
+    #[schemars(description = "ワークツリーの1行説明。このワークツリーで進めている作業全体の目的を簡潔に表す（改行なし、日本語なら15〜40文字程度）")]
+    pub description: String,
+    #[schemars(description = "ワークツリーのルートディレクトリ絶対パス（通常は自分の作業ディレクトリ）。worktree_name/worktree_id 未指定時はこれでワークツリーを特定する")]
+    pub project_dir: Option<String>,
+    #[schemars(description = "対象ワークツリー名（project_dir で特定できない場合に指定）")]
+    pub worktree_name: Option<String>,
+    #[schemars(description = "対象ワークツリーID（同名ワークツリーが複数ある場合に指定）")]
+    pub worktree_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -880,7 +907,87 @@ impl NotifyService {
         }
     }
 
-    #[tool(description = "登録済みワークツリーのステータス一覧を取得する")]
+    #[tool(description = "ワークツリーの1行説明(description)を直接セットする。description はこのワークツリーで進めている作業全体の目的を表す1行。更新するのは (a) 未設定のとき (b) 全く別の作業・目的に切り替わったとき (c) 説明が実態と大きくずれているとき、のみ。同一プラン内のサブタスク進行・レビュー対応・細部の修正では更新しないこと")]
+    fn oretachi_set_description(
+        &self,
+        Parameters(SetWorktreeDescriptionParams { description, project_dir, worktree_name, worktree_id }): Parameters<SetWorktreeDescriptionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        // 改行は空白に潰して1行に正規化。長すぎる場合は切り詰める。
+        let description: String = description
+            .replace(['\r', '\n'], " ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if description.is_empty() {
+            return Err(McpError::invalid_params("description must not be empty", None));
+        }
+        let description: String = description.chars().take(200).collect();
+
+        let settings_manager = self.app_handle.state::<SettingsManager>();
+        let settings = settings_manager.get();
+
+        // 解決優先順位: worktree_id > worktree_name > project_dir 逆引き
+        let wt = if let Some(id) = worktree_id.as_deref() {
+            settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
+                McpError::invalid_params(format!("worktree id '{}' not found", id), None)
+            })?
+        } else if let Some(name) = worktree_name.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == name).collect();
+            match matches.len() {
+                0 => {
+                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
+                    return Err(McpError::invalid_params(
+                        format!("worktree '{}' not found. available: [{}]", name, names.join(", ")),
+                        None,
+                    ));
+                }
+                1 => matches[0],
+                _ => {
+                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
+                    return Err(McpError::invalid_params(
+                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", name, ids.join(", ")),
+                        None,
+                    ));
+                }
+            }
+        } else if let Some(dir) = project_dir.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            resolve_worktree_by_dir(&settings, dir).ok_or_else(|| {
+                let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
+                McpError::invalid_params(
+                    format!("no worktree matches project_dir '{}'. available: [{}]", dir, names.join(", ")),
+                    None,
+                )
+            })?
+        } else {
+            return Err(McpError::invalid_params(
+                "specify one of project_dir / worktree_name / worktree_id",
+                None,
+            ));
+        };
+
+        let previous = wt.description.clone();
+        let event = SetWorktreeDescriptionEvent {
+            worktree: wt.name.clone(),
+            plan: None,
+            description: Some(description.clone()),
+        };
+        self.app_handle
+            .emit("set-worktree-description", &event)
+            .map_err(|e: tauri::Error| McpError::internal_error(e.to_string(), None))?;
+        log::info!("[mcp] oretachi_set_description: worktree={} desc={}", wt.name, description);
+
+        let json = serde_json::json!({
+            "ok": true,
+            "worktree": wt.name,
+            "previous": previous,
+            "new": description,
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string(&json).map_err(|e| McpError::internal_error(e.to_string(), None))?,
+        )]))
+    }
+
+    #[tool(description = "登録済みワークツリーのステータス一覧を取得する。各エントリはルートパス(path)と現在の1行説明(description)を含む")]
     fn oretachi_get_worktree_status(
         &self,
         Parameters(_params): Parameters<GetWorktreeStatusParams>,
@@ -897,6 +1004,8 @@ impl NotifyService {
                 serde_json::json!({
                     "id": wt.id,
                     "name": wt.name,
+                    "path": wt.path,
+                    "description": wt.description,
                     "repositoryName": wt.repository_name,
                     "branchName": wt.branch_name,
                     "isDetached": detached.contains(wt.id.as_str()),
@@ -1369,7 +1478,9 @@ impl ServerHandler for NotifyService {
                 title: Some("oretachi 通知サーバー".to_string()),
                 ..Default::default()
             },
-            instructions: Some("ワークツリーへの通知を管理します".to_string()),
+            instructions: Some(
+                "ワークツリーへの通知と description(1行説明) を管理します。作業内容が決まったら oretachi_set_description で作業全体の目的を1行でセットし、作業の目的そのものが変わったら更新してください（サブタスクの進行では更新不要）".to_string(),
+            ),
         }
     }
 
@@ -1594,7 +1705,8 @@ async fn set_description_handler(
 
     let event = SetWorktreeDescriptionEvent {
         worktree: worktree_name,
-        plan,
+        plan: Some(plan),
+        description: None,
     };
     match app_handle.emit("set-worktree-description", &event) {
         Ok(_) => StatusCode::OK,
@@ -1603,6 +1715,55 @@ async fn set_description_handler(
             StatusCode::INTERNAL_SERVER_ERROR
         }
     }
+}
+
+/// UserPromptSubmit フック (--prompt-context) 用。現在の description を返す。
+/// ワークツリー単位でスロットルし、期間内の再送・未解決時は {"skip":true} を返す
+/// （サイドカーは skip 時に何も出力せず exit 0 する）。
+const PROMPT_CONTEXT_THROTTLE_SECS: u64 = 600;
+
+async fn prompt_context_handler(
+    State(app_handle): State<AppHandle>,
+    Json(payload): Json<PromptContextPayload>,
+) -> Json<serde_json::Value> {
+    let settings = app_handle.state::<SettingsManager>().get();
+
+    let Some(wt) = payload
+        .project_dir
+        .as_deref()
+        .and_then(|d| resolve_worktree_by_dir(&settings, d))
+    else {
+        log::debug!(
+            "[prompt-context] could not resolve worktree (projectDir={:?}); skipping",
+            payload.project_dir
+        );
+        return Json(serde_json::json!({ "skip": true }));
+    };
+
+    let manager = app_handle.state::<McpServerManager>();
+    let now = std::time::Instant::now();
+    {
+        let mut map = manager
+            .prompt_context_last_sent
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(prev) = map.get(&wt.id) {
+            if now.duration_since(*prev).as_secs() < PROMPT_CONTEXT_THROTTLE_SECS {
+                return Json(serde_json::json!({ "skip": true }));
+            }
+        }
+        map.insert(wt.id.clone(), now);
+    }
+
+    log::info!(
+        "[prompt-context] worktree={} description={:?}",
+        wt.name,
+        wt.description
+    );
+    Json(serde_json::json!({
+        "worktreeName": wt.name,
+        "description": wt.description,
+    }))
 }
 
 // ─── API Key Authentication Middleware ───────────────────────────────────────
@@ -2025,6 +2186,7 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
             .nest_service("/mcp", service)
             .route("/notify", post(notify_handler))
             .route("/set-description", post(set_description_handler))
+            .route("/prompt-context", post(prompt_context_handler))
             .with_state(app_handle.clone())
             .layer(middleware::from_fn(move |mut req: Request, next: Next| {
                 let key = api_key_state.clone();

--- a/src/App.vue
+++ b/src/App.vue
@@ -113,6 +113,10 @@ const artifactCounts = reactive(new Map<string, number>());
 // ホームカードの description 開閉状態（ワークツリー毎・settings.json に永続化）
 const descriptionOpenMap = reactive(new Map<string, boolean>());
 
+// MCP 直接セットの時刻（ワークツリーID毎）。進行中だった AI 要約が
+// 完了後に直接セットを上書きしないための競合ガード
+const descriptionDirectSetAt = new Map<string, number>();
+
 function onToggleDescription(worktreeId: string) {
   const cur = descriptionOpenMap.get(worktreeId) ?? false;
   descriptionOpenMap.set(worktreeId, !cur);
@@ -1232,22 +1236,42 @@ onMounted(async () => {
     onAddTaskConfirm(event.payload.prompt, event.payload.remote_exec);
   });
 
-  // ExitPlanMode フック由来: プランを AI 要約してワークツリーの description にセット
-  await listen<{ worktree: string; plan: string }>("set-worktree-description", async (event) => {
-    const { worktree, plan } = event.payload;
+  // ワークツリーの description セット
+  // - plan あり (ExitPlanMode フック由来): AI 要約してからセット
+  // - description あり (MCP oretachi_set_description 由来): AI 要約をスキップして直接セット
+  await listen<{ worktree: string; plan?: string; description?: string }>("set-worktree-description", async (event) => {
+    const { worktree, plan, description } = event.payload;
     const rt = worktrees.value.find((w) => w.name === worktree);
-    if (!rt || !plan?.trim()) return;
+    if (!rt) return;
+    // ランタイム用 worktrees.value（カード表示用）と
+    // 永続化対象 settings.value.worktrees（loadWorktreesFromSettings でシャローコピー
+    // される別オブジェクト）の両方を更新する
+    const apply = (text: string) => {
+      rt.description = text;
+      const entry = settings.value.worktrees.find((w) => w.id === rt.id);
+      if (entry) entry.description = text;
+      scheduleSave();
+    };
+    if (description?.trim()) {
+      // 直接セットが常に勝つ: 進行中の AI 要約をキャンセルし、
+      // 完了済みの要約が後から上書きしないようセット時刻を記録する
+      descriptionDirectSetAt.set(rt.id, Date.now());
+      invoke("cancel_description_generation", { worktreeId: rt.id }).catch(() => {});
+      apply(description.trim());
+      logDebug(`[Description] direct set for worktree=${worktree}: ${description.trim()}`);
+      return;
+    }
+    if (!plan?.trim()) return;
+    const requestedAt = Date.now();
     try {
       const summary = await invoke<string>("generate_description_from_plan", { worktreeId: rt.id, plan });
+      if ((descriptionDirectSetAt.get(rt.id) ?? 0) > requestedAt) {
+        logDebug(`[Description] summary discarded (direct set is newer) for worktree=${worktree}`);
+        return;
+      }
       const trimmed = summary?.trim();
       if (trimmed) {
-        // ランタイム用 worktrees.value（カード表示用）と
-        // 永続化対象 settings.value.worktrees（loadWorktreesFromSettings でシャローコピー
-        // される別オブジェクト）の両方を更新する
-        rt.description = trimmed;
-        const entry = settings.value.worktrees.find((w) => w.id === rt.id);
-        if (entry) entry.description = trimmed;
-        scheduleSave();
+        apply(trimmed);
         logDebug(`[Description] set for worktree=${worktree}: ${trimmed}`);
       }
     } catch (e) {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -26,7 +26,7 @@ export interface WorktreeEntry {
   hotkeyChar?: string; // Alt+[この文字] でフォーカス
   autoApproval?: boolean;
   autoApprovalPrompt?: string;
-  description?: string; // AIが自動生成する説明（ExitPlanMode hookでプランを要約してセット）
+  description?: string; // 作業全体の目的を表す1行説明（ExitPlanMode hookのAI要約、または MCP oretachi_set_description で直接セット）
   descriptionOpen?: boolean; // ホームカードの description 開閉状態（ワークツリー毎）
   workgroupId?: string; // 所属するワークグループのID（未設定は先頭グループにフォールバック）
 }


### PR DESCRIPTION
## 概要

ワークツリーの description（作業全体の目的を表す1行説明）は従来 ExitPlanMode フック経由の AI 要約でのみ更新されていた。プランモードを使わないセッションでも適切なタイミングで description を設定・更新できるようにする。

## 変更内容

### 1. MCP ツール `oretachi_set_description` を追加 (`mcp_server.rs`)
- Claude 自身が1行説明を直接セットできる（AI 要約をスキップ）
- ワークツリー特定: `worktree_id` > `worktree_name` > `project_dir` 逆引き
- ツール説明文に粒度基準を明記: 更新は (a) 未設定 (b) 別の作業への切り替え (c) 実態との大きなずれ、のみ。**同一プラン内のサブタスク進行・レビュー対応では更新しない**
- `oretachi_get_worktree_status` に `path` / `description` を追加（自ワークツリーの特定・現状説明の確認用）

### 2. UserPromptSubmit フックによる逸脱確認リマインド
- `claude_plugin.rs`: hooks.json に UserPromptSubmit グループを追加（exec-form）
- サイドカー `oretachi-notify --prompt-context`: `/prompt-context` から現在の description を取得し、「範囲内なら更新不要、別作業への切り替え時のみ更新」という additionalContext を stdout 出力してコンテキスト注入。サーバ未起動・skip 時は無出力で exit 0（ベストエフォート）
- サーバ側 `/prompt-context`: ワークツリー単位で 10 分スロットル、期間内は `{skip:true}` を即返し

### 3. 競合ガード (`App.vue`)
- 既存の `set-worktree-description` イベントを `plan`（AI 要約）/ `description`（直接セット）の2経路に拡張
- **直接セットが常に勝つ**: 進行中の AI 要約をキャンセルし、完了済み要約が後から上書きしないようタイムスタンプで破棄判定
- ExitPlanMode の既存経路は無変更で共存

## テスト

- [x] `cargo check` / `pnpm run type-check`
- [x] `cargo test -p oretachi-notify` 18件パス（`--prompt-context` フラグ判定・additionalContext 組み立ての6件を新規追加）
- [x] hooks.json に UserPromptSubmit グループが生成されることを確認
- [x] `oretachi_set_description` でカード即時反映
- [x] prompt-context 注入の実動作確認（oretachi.log の `[prompt-context]` および実セッションへの注入を確認。description 未設定時の「未設定なのでセットせよ」バリエーションも確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)