### PR TITLE
feat(workgroup): グループ systemPrompt を SessionStart フックで Claude Code セッションに常時注入

### DIFF
--- a/src-tauri/notify/src/main.rs
+++ b/src-tauri/notify/src/main.rs
@@ -11,6 +11,9 @@
 //      ワークツリー名と kind の解決はサーバー側で project-dir / event から行う)
 //   oretachi-notify --set-description --project-dir "<dir>"
 //     (stdin の ExitPlanMode hook JSON を /set-description へ転送)
+//   oretachi-notify --session-context --project-dir "<dir>"
+//     (SessionStart フック用。/session-context からワークツリー所属グループの systemPrompt を
+//      取得し、SessionStart 用 JSON として stdout に出力する。失敗時は何も出力せず exit 0)
 //
 // hook からは userConfig ではなく CC 組み込み変数 ${CLAUDE_PROJECT_DIR} が --project-dir に渡る。
 // 未置換/空の場合はプロセスの current_dir (hook は worktree ディレクトリで実行される) にフォールバック。
@@ -40,6 +43,31 @@ fn main() {
         std::process::exit(0);
     }
 
+    // SessionStart フック (--session-context): /session-context からグループの systemPrompt を
+    // 取得し、SessionStart 用 JSON として stdout に出力する。
+    // oretachi 非稼働・未管理ディレクトリ・プロンプト未設定のいずれでも、claude 側に警告を
+    // 出さないよう何も出力せず必ず exit 0 する（--notify の exit(1) とは異なる方針）。
+    if has_flag(&args, "--session-context", "-c") {
+        let dir = resolve_project_dir(&args);
+        match fetch_session_context(&dir) {
+            Ok(Some(prompt)) => {
+                let out = serde_json::json!({
+                    "hookSpecificOutput": {
+                        "hookEventName": "SessionStart",
+                        "additionalContext": prompt
+                    }
+                });
+                println!("{}", out);
+            }
+            Ok(None) => {}
+            Err(_e) => {
+                #[cfg(debug_assertions)]
+                eprintln!("Session context fetch failed: {}", _e);
+            }
+        }
+        std::process::exit(0);
+    }
+
     // 通知 (--notify): stdin(hook JSON) を body として /notify へ送る。
     // ワークツリー名と kind はサーバー側で project-dir / event から解決する。
     if has_flag(&args, "--notify", "-n") {
@@ -57,7 +85,7 @@ fn main() {
     }
 
     #[cfg(debug_assertions)]
-    eprintln!("Usage: oretachi-notify --notify --project-dir <dir> --event <Event> [--agent <agent>]\n       oretachi-notify --set-description --project-dir <dir>");
+    eprintln!("Usage: oretachi-notify --notify --project-dir <dir> --event <Event> [--agent <agent>]\n       oretachi-notify --set-description --project-dir <dir>\n       oretachi-notify --session-context --project-dir <dir>");
     std::process::exit(2);
 }
 
@@ -158,6 +186,72 @@ fn send_set_description(project_dir: &str, hook_json: Option<&str>) -> Result<()
         payload["hookJson"] = serde_json::Value::String(j.to_string());
     }
     post_json("/set-description", &payload)
+}
+
+/// /session-context からワークツリー所属グループの systemPrompt を取得する。
+/// 未管理ディレクトリやプロンプト未設定の場合はサーバーが prompt: null を返すので Ok(None)。
+fn fetch_session_context(project_dir: &str) -> Result<Option<String>, String> {
+    let payload = serde_json::json!({ "projectDir": project_dir });
+    let body = post_json_read_body("/session-context", &payload)?;
+    let v: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| format!("Invalid response JSON: {}", e))?;
+    Ok(v.get("prompt")
+        .and_then(|p| p.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.trim().is_empty()))
+}
+
+/// mcp-server.json のポート/APIキーを読み、指定パスへ JSON を POST してレスポンスボディを返す。
+/// post_json と異なりボディまで読む（Connection: close なので EOF まで読み切る）。
+fn post_json_read_body(path: &str, payload: &serde_json::Value) -> Result<String, String> {
+    let (port, api_key) = read_server_info()?;
+    let payload_str = payload.to_string();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nContent-Type: application/json\r\nAuthorization: Bearer {api_key}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload_str}",
+        payload_str.len()
+    );
+
+    use std::io::{Read, Write};
+    use std::time::Duration;
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port)
+        .parse()
+        .map_err(|e| format!("Invalid address: {}", e))?;
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(3))
+        .map_err(|e| format!("Cannot connect to oretachi MCP server: {}", e))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .map_err(|e| format!("Failed to set write timeout: {}", e))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|e| format!("Failed to set read timeout: {}", e))?;
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| format!("Failed to send request: {}", e))?;
+    stream
+        .flush()
+        .map_err(|e| format!("Failed to flush: {}", e))?;
+
+    // Connection: close なので EOF まで読む。タイムアウト等のエラーはそこまでの受信分で判定する。
+    let mut response = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => response.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+
+    let text = String::from_utf8_lossy(&response).into_owned();
+    let (head, body) = text
+        .split_once("\r\n\r\n")
+        .ok_or_else(|| "Incomplete HTTP response".to_string())?;
+    let status_line = head.lines().next().unwrap_or_default();
+    if !status_line.starts_with("HTTP/") || !status_line.contains(" 200 ") {
+        return Err(format!("Server returned unexpected response: {}", status_line));
+    }
+    Ok(body.to_string())
 }
 
 /// mcp-server.json のポート/APIキーを読み、指定パスへ JSON を POST する。
@@ -264,6 +358,19 @@ mod tests {
     fn test_has_flag_absent() {
         let args = vec!["bin".to_string(), "--other".to_string()];
         assert!(!has_flag(&args, "--notify", "-n"));
+    }
+
+    #[test]
+    fn test_has_flag_session_context() {
+        let args = vec![
+            "bin".to_string(),
+            "--session-context".to_string(),
+            "--project-dir".to_string(),
+            "X:/wt/foo".to_string(),
+        ];
+        assert!(has_flag(&args, "--session-context", "-c"));
+        assert!(!has_flag(&args, "--notify", "-n"));
+        assert!(!has_flag(&args, "--set-description", "-d"));
     }
 
     #[test]

--- a/src-tauri/src/claude_plugin.rs
+++ b/src-tauri/src/claude_plugin.rs
@@ -242,6 +242,25 @@ fn build_hooks_json(notifier_path: &str) -> serde_json::Value {
         hooks.insert("PermissionRequest".to_string(), serde_json::json!([exit_plan_group]));
     }
 
+    // SessionStart フック: セッション開始（startup/resume/clear/compact）のたびにサイドカーを起動し、
+    // /session-context からワークツリー所属グループの systemPrompt を取得してコンテキストに注入する。
+    // 解決は毎回サーバー側で行うため、グループ設定の変更は次の SessionStart から自動反映される。
+    // アプリ非稼働時はサイドカーが何も出力せず exit 0 するため、単体起動の claude には影響しない。
+    hooks.insert(
+        "SessionStart".to_string(),
+        serde_json::json!([{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": notifier_path,
+                "args": [
+                    "--session-context",
+                    "--project-dir", "${CLAUDE_PROJECT_DIR}"
+                ]
+            }]
+        }]),
+    );
+
     serde_json::json!({ "hooks": hooks })
 }
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -18,7 +18,7 @@ use tokio::sync::{broadcast, oneshot, watch, RwLock};
 
 use crate::git_worktree::get_git_remotes;
 use crate::pty_manager::PtyManager;
-use crate::settings::{AppSettings, SettingsManager, WorktreeEntry};
+use crate::settings::{AppSettings, SettingsManager, Workgroup, WorktreeEntry};
 
 const PORT_FILE: &str = "mcp-port";
 const SERVER_INFO_FILE: &str = "mcp-server.json";
@@ -226,6 +226,13 @@ pub struct SetDescriptionPayload {
     /// ExitPlanMode フックが stdin で受け取った hook JSON 文字列（生）
     #[serde(rename = "hookJson")]
     pub hook_json: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SessionContextPayload {
+    /// SessionStart フックの oretachi-notify が送る ${CLAUDE_PROJECT_DIR}。
+    #[serde(default, rename = "projectDir")]
+    pub project_dir: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -1410,6 +1417,26 @@ fn resolve_worktree_by_dir<'a>(settings: &'a AppSettings, dir: &str) -> Option<&
         .find(|w| normalize_path_for_match(&w.path) == target)
 }
 
+/// ワークツリーの所属ワークグループを解決する。workgroup_id が未設定/不明な場合は
+/// 先頭グループにフォールバック（フロントの resolvedGroupId と同仕様）。
+fn resolve_workgroup<'a>(settings: &'a AppSettings, worktree: &WorktreeEntry) -> Option<&'a Workgroup> {
+    worktree
+        .workgroup_id
+        .as_ref()
+        .and_then(|id| settings.workgroups.iter().find(|g| &g.id == id))
+        .or_else(|| settings.workgroups.first())
+}
+
+/// リポジトリに通知フックが1件以上設定されているか。
+fn repo_has_notification_hooks(settings: &AppSettings, worktree: &WorktreeEntry) -> bool {
+    settings
+        .repositories
+        .iter()
+        .find(|r| r.id == worktree.repository_id)
+        .and_then(|r| r.notification_hooks.as_ref())
+        .map_or(false, |h| !h.is_empty())
+}
+
 /// イベント名の既定 kind。ユーザー設定 (repo.notification_hooks) が無い場合のフォールバック。
 fn default_kind_for_event(event: &str) -> &'static str {
     match event {
@@ -1458,6 +1485,18 @@ async fn notify_handler(
             }
         },
     };
+
+    // ライフサイクルフック由来（event 指定・kind 明示なし）の通知は、通知フックが1件も
+    // 設定されていないリポジトリでは破棄する。プラグインは全ワークツリーで無条件有効化される
+    // （SessionStart 注入用）ため、未設定リポジトリの通知挙動を従来（プラグイン無効=通知なし）
+    // と一致させる。kind 明示指定（旧形式/MCP 経由）は意図的な通知なので対象外。
+    if payload.kind.is_none() && payload.event.is_some() {
+        if let Some(w) = worktree {
+            if !repo_has_notification_hooks(&settings, w) {
+                return StatusCode::OK;
+            }
+        }
+    }
 
     // kind: 明示指定(旧形式/MCP) > event からの解決 > "general"
     let kind = if let Some(k) = payload.kind.clone() {
@@ -1603,6 +1642,33 @@ async fn set_description_handler(
             StatusCode::INTERNAL_SERVER_ERROR
         }
     }
+}
+
+// ─── Simple REST endpoint (/session-context) ─────────────────────────────────
+
+/// SessionStart フックから呼ばれ、ワークツリー所属グループの systemPrompt を返す。
+/// 解決を毎回ここで行うため、グループ設定の変更は次のセッション開始から自動反映される。
+/// 未解決（管理外ディレクトリ・プロンプト未設定）は prompt: null を返し、注入は行われない。
+async fn session_context_handler(
+    State(app_handle): State<AppHandle>,
+    Json(payload): Json<SessionContextPayload>,
+) -> Json<serde_json::Value> {
+    let settings = app_handle.state::<SettingsManager>().get();
+    let prompt = payload
+        .project_dir
+        .as_deref()
+        .and_then(|d| resolve_worktree_by_dir(&settings, d))
+        .and_then(|w| resolve_workgroup(&settings, w))
+        .and_then(|g| g.system_prompt.clone())
+        .filter(|s| !s.trim().is_empty());
+    if let Some(p) = &prompt {
+        log::info!(
+            "[session-context] projectDir={:?} prompt_len={}",
+            payload.project_dir,
+            p.len()
+        );
+    }
+    Json(serde_json::json!({ "prompt": prompt }))
 }
 
 // ─── API Key Authentication Middleware ───────────────────────────────────────
@@ -2025,6 +2091,7 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
             .nest_service("/mcp", service)
             .route("/notify", post(notify_handler))
             .route("/set-description", post(set_description_handler))
+            .route("/session-context", post(session_context_handler))
             .with_state(app_handle.clone())
             .layer(middleware::from_fn(move |mut req: Request, next: Next| {
                 let key = api_key_state.clone();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -72,6 +72,9 @@ pub struct Workgroup {
     pub claude_code_mode: Option<String>,
     #[serde(default)]
     pub exec_prompt: Option<String>,
+    /// Claude Code セッションに常時注入するプロンプト（SessionStart フック経由。/clear 後も維持）
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/App.vue
+++ b/src/App.vue
@@ -784,16 +784,16 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
     }
 
     // Claude Code プラグイン設定を settings.local.json に書き込む
-    if (repo?.notificationHooks?.length) {
-      try {
-        await invoke("write_claude_plugin_config", {
-          worktreePath: entry.path,
-          worktreeName: entry.name,
-          hooks: repo.notificationHooks,
-        });
-      } catch (e) {
-        await message(t("claudeHooksFailed", { error: e }), { kind: "warning" });
-      }
+    // 通知フック未設定でも無条件で有効化する（SessionStart フックによる systemPrompt 注入と
+    // MCP サーバーを全ワークツリーで使えるようにするため。未設定リポジトリの通知はサーバー側で drop）
+    try {
+      await invoke("write_claude_plugin_config", {
+        worktreePath: entry.path,
+        worktreeName: entry.name,
+        hooks: repo?.notificationHooks ?? [],
+      });
+    } catch (e) {
+      await message(t("claudeHooksFailed", { error: e }), { kind: "warning" });
     }
 
     // Claude Code セッションデータの引継ぎ

--- a/src/components/WorkgroupEditDialog.vue
+++ b/src/components/WorkgroupEditDialog.vue
@@ -32,6 +32,7 @@ const autoAssignHotkey = ref(props.group.autoAssignHotkey ?? false);
 const taskAddAgent = ref<AiAgentKind | "">(props.group.taskAddAgent ?? "");
 const claudeCodeMode = ref<ClaudeCodeMode>(props.group.claudeCodeMode ?? "plan");
 const execPrompt = ref(props.group.execPrompt ?? "");
+const systemPrompt = ref(props.group.systemPrompt ?? "");
 
 function save() {
   emit("save", {
@@ -41,6 +42,7 @@ function save() {
     taskAddAgent: taskAddAgent.value || undefined,
     claudeCodeMode: claudeCodeMode.value,
     execPrompt: execPrompt.value.trim() || undefined,
+    systemPrompt: systemPrompt.value.trim() || undefined,
   });
 }
 </script>
@@ -104,6 +106,12 @@ function save() {
         <label class="label">{{ t('execPrompt') }}</label>
         <textarea v-model="execPrompt" class="textarea" :placeholder="t('execPromptPlaceholder')" rows="4" />
         <p class="hint">{{ t('execPromptHint') }}</p>
+      </div>
+
+      <div class="field">
+        <label class="label">{{ t('systemPrompt') }}</label>
+        <textarea v-model="systemPrompt" class="textarea" :placeholder="t('systemPromptPlaceholder')" rows="4" />
+        <p class="hint">{{ t('systemPromptHint') }}</p>
       </div>
 
       <div class="dialog-actions">
@@ -330,6 +338,9 @@ function save() {
     "execPrompt": "Execution prompt",
     "execPromptPlaceholder": "e.g. Work on the following task.\n\n{'{{PROMPT}}'}",
     "execPromptHint": "{'{{PROMPT}}'} is replaced with the task prompt. Empty = task prompt only.",
+    "systemPrompt": "System prompt",
+    "systemPromptPlaceholder": "e.g. Always respond in Japanese.",
+    "systemPromptHint": "Injected into every Claude Code session in this group. Persists across /clear and restarts. Claude Code only.",
     "saveButton": "Save",
     "removeGroup": "Delete this group"
   },
@@ -347,6 +358,9 @@ function save() {
     "execPrompt": "実行プロンプト",
     "execPromptPlaceholder": "例: 以下のタスクに取り組んでください。\n\n{'{{PROMPT}}'}",
     "execPromptHint": "{'{{PROMPT}}'} がタスク実行プロンプトに置換されます。未指定ならプロンプトのみと等価。",
+    "systemPrompt": "システムプロンプト",
+    "systemPromptPlaceholder": "例: 常に日本語で応答してください。",
+    "systemPromptHint": "このグループの Claude Code セッションに常時注入されます。/clear や再起動後も維持。Claude Code のみ対応。",
     "saveButton": "保存",
     "removeGroup": "このグループを削除"
   }

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -298,16 +298,16 @@ export function useTaskExecution(deps: {
       }
 
       // Claude Code プラグイン設定を settings.local.json に書き込む
-      if (repo.notificationHooks?.length) {
-        try {
-          await invoke("write_claude_plugin_config", {
-            worktreePath: entry.path,
-            worktreeName: entry.name,
-            hooks: repo.notificationHooks,
-          });
-        } catch (e) {
-          await message(t("claudeHooksFailed", { error: e }), { kind: "warning" });
-        }
+      // 通知フック未設定でも無条件で有効化する（SessionStart フックによる systemPrompt 注入と
+      // MCP サーバーを全ワークツリーで使えるようにするため。未設定リポジトリの通知はサーバー側で drop）
+      try {
+        await invoke("write_claude_plugin_config", {
+          worktreePath: entry.path,
+          worktreeName: entry.name,
+          hooks: repo.notificationHooks ?? [],
+        });
+      } catch (e) {
+        await message(t("claudeHooksFailed", { error: e }), { kind: "warning" });
       }
 
       const pending = buildPendingCommand(repo, entry);
@@ -365,6 +365,22 @@ export function useTaskExecution(deps: {
     const terminal = wt.terminals[0];
     if (!terminal) {
       throw new Error(`ターミナルが見つかりません: ${wt.name}`);
+    }
+
+    // Claude Code プラグイン設定を settings.local.json に反映（冪等マージ）。
+    // 新規作成時だけでなくタスク実行時にも書くことで、プラグイン設定が書かれる前に
+    // 作成された既存ワークツリーにも SessionStart 注入を適用する。エージェント実行中の
+    // 追いプロンプト送信パスでも、次回の claude 手動再起動セッションに効くよう先に書く。
+    // 失敗してもタスクは続行。
+    const repoOfWt = settings.value.repositories.find((r) => r.id === wt.repositoryId);
+    try {
+      await invoke("write_claude_plugin_config", {
+        worktreePath: wt.path,
+        worktreeName: wt.name,
+        hooks: repoOfWt?.notificationHooks ?? [],
+      });
+    } catch (e) {
+      console.warn("[write_claude_plugin_config] failed:", e);
     }
 
     // sessionId を取得してエージェント実行中か判定

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -42,6 +42,7 @@ export interface Workgroup {
   taskAddAgent?: AiAgentKind;       // タスク実行エージェント（グループ単位）
   claudeCodeMode?: ClaudeCodeMode;  // Claude Code モード（既定: plan）
   execPrompt?: string;              // 実行プロンプトテンプレート（置換タグ {{PROMPT}}）
+  systemPrompt?: string;            // Claude Code セッションに常時注入（SessionStart フック経由。/clear 後も維持）
 }
 
 export interface TerminalSettings {


### PR DESCRIPTION
## 概要

グループの実行プロンプト（execPrompt）はタスク投入時の最初のメッセージに合成されるだけで、`/clear` や claude の手動再起動で振る舞いの指示が消えてしまう問題への対応。

ワークグループに新設定 **systemPrompt** を追加し、Claude Code の **SessionStart フック**（startup / resume / clear / compact で発火）経由でセッション開始のたびに動的注入する。これにより `/clear`・claude 手動再起動・compact 後も振る舞いが維持される。

## アーキテクチャ

```
claude セッション開始（/clear 含む）
  → SessionStart フック（plugin hooks.json, exec-form）
  → oretachi-notify --session-context --project-dir ${CLAUDE_PROJECT_DIR}
  → POST /session-context（Bearer 認証は既存 middleware）
  → サーバー: projectDir → WorktreeEntry → workgroupId → systemPrompt を解決
  → サイドカー: hookSpecificOutput.additionalContext として stdout 出力 → コンテキスト注入
```

解決は毎回サーバー側で行うため、グループ設定の変更は次のセッション開始から自動反映（ファイル再同期不要）。

## 変更内容

- **設定**: `Workgroup.systemPrompt` を追加（TS / Rust、execPrompt と併存）。WorkgroupEditDialog に textarea + ja/en i18n
- **プラグイン**: hooks.json に SessionStart フックを追加（既存イベントと同じ exec-form）
- **サイドカー**: `--session-context` モード追加。レスポンスボディを読む `post_json_read_body` を新設。失敗時（oretachi 非稼働・未管理ディレクトリ・プロンプト未設定）は何も出力せず exit 0 で、単体起動の claude に警告を出さない
- **サーバー**: `/session-context` エンドポイント追加。グループ解決はフロントの `resolvedGroupId` と同仕様（未設定/不明 ID は先頭グループへフォールバック）
- **プラグイン有効化の無条件化**: 全ワークツリーで settings.local.json を書き込み（新規作成時 + タスク実行時の冪等マージで既存 WT にも適用）。通知フック未設定リポジトリのライフサイクル通知はサーバー側で drop し、通知挙動は従来と同一に維持

## 検証

- cargo check / vue-tsc / cargo test（notify 14件）パス
- SessionStart の `hookSpecificOutput.additionalContext` 形式が CC 2.1.218 で注入されることを echo フックで実機確認
- /bug-review 実施済み（Critical/Warning 0件、Suggestion 1件対応）

## 注意

- systemPrompt は Claude Code 専用（gemini/codex/cline は対象外、UI にヒント表示）
- dev 環境では `ORETACHI_PLUGIN_OVERWRITE=false` だと hooks.json が再生成されない
- MCP ポートを本番インスタンスが占有していると dev インスタンスの /session-context が使えない点に注意（mcp-server.json の所有者が旧ビルドだと 404 → 注入されず無音でスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)