### PR TITLE
fix(mcp): close_worktree のブランチ削除失敗を修正し結果を呼び出し元へ返す

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1277,6 +1277,7 @@ pub fn run() {
         .manage(mcp_server::McpServerManager::new())
         .manage(mcp_server::McpPeerRegistry(std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()))))
         .manage(mcp_server::DetachedWorktreeRegistry::default())
+        .manage(mcp_server::CloseWorktreeAckRegistry::default())
         .manage(ai_judge::ApprovalManager::new())
         .manage(ai_commit_message::CommitMessageManager::new())
         .manage(ai_description::DescriptionManager::new())
@@ -1329,6 +1330,7 @@ pub fn run() {
             regenerate_mcp_api_key,
             mcp_server::register_detached_worktree,
             mcp_server::unregister_detached_worktree,
+            mcp_server::mcp_close_worktree_result,
             download_and_install_update,
             ai_judge::judge_approval,
             ai_judge::cancel_approval,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -68,7 +68,65 @@ pub fn unregister_detached_worktree(
     }
 }
 
+/// ワークツリークローズの最終結果。フロントエンドの status 文字列に対応する。
+pub enum CloseWorktreeOutcome {
+    Closed,
+    /// ユーザーが削除リトライをキャンセルした（エラーではない）
+    Cancelled,
+    Failed(String),
+}
+
+/// oretachi_close_worktree の処理結果をフロントエンドから受け取るための oneshot 送信側を保持する。
+/// MCP ツールは request_id ごとに receiver を待ち、フロント側が
+/// mcp_close_worktree_result コマンドで実際の成否を返す。
+#[derive(Default)]
+pub struct CloseWorktreeAckRegistry(pub Mutex<HashMap<String, oneshot::Sender<CloseWorktreeOutcome>>>);
+
+impl CloseWorktreeAckRegistry {
+    fn register(&self, request_id: String) -> oneshot::Receiver<CloseWorktreeOutcome> {
+        let (tx, rx) = oneshot::channel();
+        match self.0.lock() {
+            Ok(mut g) => { g.insert(request_id, tx); }
+            Err(e) => { e.into_inner().insert(request_id, tx); }
+        }
+        rx
+    }
+
+    fn take(&self, request_id: &str) -> Option<oneshot::Sender<CloseWorktreeOutcome>> {
+        match self.0.lock() {
+            Ok(mut g) => g.remove(request_id),
+            Err(e) => e.into_inner().remove(request_id),
+        }
+    }
+}
+
+/// フロントエンドがワークツリークローズの成否を MCP ツールへ返す。
+/// status: "ok" | "cancelled" | それ以外は失敗扱い。
+/// 該当 request_id が既にタイムアウト等で除去済みの場合は何もしない。
+#[tauri::command]
+pub fn mcp_close_worktree_result(
+    request_id: String,
+    status: String,
+    error: Option<String>,
+    registry: tauri::State<'_, CloseWorktreeAckRegistry>,
+) {
+    if let Some(tx) = registry.take(&request_id) {
+        let outcome = match status.as_str() {
+            "ok" => CloseWorktreeOutcome::Closed,
+            "cancelled" => CloseWorktreeOutcome::Cancelled,
+            _ => CloseWorktreeOutcome::Failed(error.unwrap_or_else(|| "unknown error".to_string())),
+        };
+        let _ = tx.send(outcome);
+    }
+}
+
 static PEER_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+static CLOSE_WORKTREE_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// クローズ結果を待つ上限。worktree remove はロックエラー時にキャンセルまで無限リトライする
+/// (git_worktree::worktree_remove_persistent) ため、タイムアウトしても失敗とは断定せず
+/// 「継続中」として返す。MCP クライアント側のツールタイムアウト(既定 60 秒前後)に
+/// 先んじて応答を返せるよう、それより短く設定する。
+const CLOSE_WORKTREE_ACK_TIMEOUT_SECS: u64 = 45;
 
 // ─── MCP Server Manager ───────────────────────────────────────────────────────
 
@@ -397,12 +455,13 @@ pub struct CloseWorktreeParams {
     pub merge_to: Option<String>,
     #[schemars(description = "ワークツリー削除後にブランチを削除するか（省略時は false）")]
     pub delete_branch: Option<bool>,
-    #[schemars(description = "未マージでもブランチを強制削除するか（省略時は false）")]
+    #[schemars(description = "未マージでもブランチを強制削除（git branch -D）するか。省略時は delete_branch と同じ値（削除するなら強制削除。UI の手動削除と同じ挙動）。false を明示するとマージ済み確認つき（git branch -d）になり、未マージのブランチではクローズが失敗する")]
     pub force_branch: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Clone)]
 struct CloseWorktreeEvent {
+    request_id: String,
     worktree_id: String,
     worktree_name: String,
     merge_to: String,
@@ -1200,7 +1259,7 @@ impl NotifyService {
     }
 
     #[tool(description = "ワークツリーをアーカイブ（クローズ）する。アーカイブDBに記録してgitワークツリーを削除する")]
-    fn oretachi_close_worktree(
+    async fn oretachi_close_worktree(
         &self,
         Parameters(CloseWorktreeParams { worktree_name, worktree_id, merge_to, delete_branch, force_branch }): Parameters<CloseWorktreeParams>,
     ) -> Result<CallToolResult, McpError> {
@@ -1209,50 +1268,104 @@ impl NotifyService {
             return Err(McpError::invalid_params("worktree_name must not be empty", None));
         }
 
-        let settings_manager = self.app_handle.state::<SettingsManager>();
-        let settings = settings_manager.get();
+        // await をまたいで State / settings の参照を保持しないよう、ここで所有権のある値へ確定させる
+        let (target_id, target_name) = {
+            let settings_manager = self.app_handle.state::<SettingsManager>();
+            let settings = settings_manager.get();
 
-        let wt = if let Some(id) = worktree_id.as_deref() {
-            // IDが指定されている場合はIDで特定
-            settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
-                McpError::invalid_params(format!("worktree id '{}' not found", id), None)
-            })?
-        } else {
-            // 名前で特定（同名が複数ある場合はエラー）
-            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == worktree_name).collect();
-            match matches.len() {
-                0 => {
-                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("worktree '{}' not found. available: [{}]", worktree_name, names.join(", ")),
-                        None,
-                    ));
+            let wt = if let Some(id) = worktree_id.as_deref() {
+                // IDが指定されている場合はIDで特定
+                settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
+                    McpError::invalid_params(format!("worktree id '{}' not found", id), None)
+                })?
+            } else {
+                // 名前で特定（同名が複数ある場合はエラー）
+                let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == worktree_name).collect();
+                match matches.len() {
+                    0 => {
+                        let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
+                        return Err(McpError::invalid_params(
+                            format!("worktree '{}' not found. available: [{}]", worktree_name, names.join(", ")),
+                            None,
+                        ));
+                    }
+                    1 => matches[0],
+                    _ => {
+                        let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
+                        return Err(McpError::invalid_params(
+                            format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", worktree_name, ids.join(", ")),
+                            None,
+                        ));
+                    }
                 }
-                1 => matches[0],
-                _ => {
-                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", worktree_name, ids.join(", ")),
-                        None,
-                    ));
-                }
-            }
+            };
+            (wt.id.clone(), wt.name.clone())
         };
+
+        // フロント側の処理結果を受け取るための oneshot を先に登録してから emit する
+        let request_id = format!(
+            "close-{}",
+            CLOSE_WORKTREE_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        let rx = {
+            let registry = self.app_handle.state::<CloseWorktreeAckRegistry>();
+            registry.register(request_id.clone())
+        };
+
+        // force_branch 省略時は delete_branch と同じ値にする（UI の手動削除と同じ意味論）。
+        // git branch -d は「現在の HEAD またはその upstream にマージ済みか」しか見ないため、
+        // 未マージブランチはもちろん、merge_to を指定して別ワークツリーでマージした場合でも
+        // メインリポジトリの HEAD 基準では未マージ判定になり失敗する。
+        // ここで Option を潰すため、明示的な false は尊重される（-d でのマージ済み確認）。
+        let delete_branch = delete_branch.unwrap_or(false);
+        let force_branch = force_branch.unwrap_or(delete_branch);
 
         let event = CloseWorktreeEvent {
-            worktree_id: wt.id.clone(),
-            worktree_name: wt.name.clone(),
+            request_id: request_id.clone(),
+            worktree_id: target_id,
+            worktree_name: target_name.clone(),
             merge_to: merge_to.unwrap_or_default(),
-            delete_branch: delete_branch.unwrap_or(false),
-            force_branch: force_branch.unwrap_or(false),
+            delete_branch,
+            force_branch,
         };
-        self.app_handle
-            .emit("mcp-close-worktree", &event)
-            .map_err(|e: tauri::Error| McpError::internal_error(e.to_string(), None))?;
-        log::info!("[mcp] oretachi_close_worktree: name={}", worktree_name);
-        Ok(CallToolResult::success(vec![Content::text(
-            "ワークツリーのクローズリクエストを送信しました。処理は非同期に行われます。",
-        )]))
+        if let Err(e) = self.app_handle.emit("mcp-close-worktree", &event) {
+            self.app_handle.state::<CloseWorktreeAckRegistry>().take(&request_id);
+            return Err(McpError::internal_error(e.to_string(), None));
+        }
+        log::info!("[mcp] oretachi_close_worktree: name={} request_id={}", worktree_name, request_id);
+
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(CLOSE_WORKTREE_ACK_TIMEOUT_SECS),
+            rx,
+        )
+        .await
+        {
+            Ok(Ok(CloseWorktreeOutcome::Closed)) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "ワークツリー '{}' をクローズしました。",
+                target_name
+            ))])),
+            Ok(Ok(CloseWorktreeOutcome::Cancelled)) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "ワークツリー '{}' のクローズはユーザー操作によりキャンセルされました。ワークツリーはそのまま残っています。",
+                target_name
+            ))])),
+            Ok(Ok(CloseWorktreeOutcome::Failed(msg))) => {
+                log::warn!("[mcp] oretachi_close_worktree failed: name={} error={}", worktree_name, msg);
+                Err(McpError::internal_error(
+                    format!("ワークツリー '{}' のクローズに失敗しました: {}", target_name, msg),
+                    None,
+                ))
+            }
+            // 送信側が take 済みで drop された（通常発生しない）
+            Ok(Err(_)) => Ok(CallToolResult::success(vec![Content::text(
+                "ワークツリーのクローズリクエストを送信しましたが、結果を受け取れませんでした。oretachi_get_worktree_status で確認してください。",
+            )])),
+            Err(_) => {
+                self.app_handle.state::<CloseWorktreeAckRegistry>().take(&request_id);
+                Ok(CallToolResult::success(vec![Content::text(
+                    "ワークツリーのクローズリクエストを送信しましたが、時間内に完了しませんでした。削除リトライ中（UI からキャンセル可能）か、メインウィンドウがまだ処理を受け付けていない可能性があります。oretachi_get_worktree_status で状態を確認してください。",
+                )]))
+            }
+        }
     }
 
     #[tool(description = "指定ワークツリーに新しいターミナルタブを追加し、与えられたコマンドを流し込む。pnpm dev / tauri dev / vite / next dev など長時間常駐するバックグラウンドコマンドを oretachi UI 上で起動するために使う")]

--- a/src/App.vue
+++ b/src/App.vue
@@ -1280,13 +1280,25 @@ onMounted(async () => {
   });
 
   // MCPからのワークツリークローズ（アーカイブ）
-  await listen<{ worktree_id: string; worktree_name: string; merge_to: string; delete_branch: boolean; force_branch: boolean }>("mcp-close-worktree", async (event) => {
-    const { worktree_id, merge_to, delete_branch, force_branch } = event.payload;
-    await archiveWorktree(worktree_id, {
-      mergeTo: merge_to,
-      deleteBranch: delete_branch,
-      forceBranch: force_branch,
-    });
+  await listen<{ request_id: string; worktree_id: string; worktree_name: string; merge_to: string; delete_branch: boolean; force_branch: boolean }>("mcp-close-worktree", async (event) => {
+    const { request_id, worktree_id, merge_to, delete_branch, force_branch } = event.payload;
+    // force_branch の既定値は Rust 側（Option が残っている mcp_server.rs）で導出済み
+    await archiveWorktree(
+      worktree_id,
+      {
+        mergeTo: merge_to,
+        deleteBranch: delete_branch,
+        forceBranch: force_branch,
+      },
+      async (result) => {
+        // MCP 呼び出し元へ実際の成否を返す
+        await invoke("mcp_close_worktree_result", {
+          requestId: request_id,
+          status: result.ok ? "ok" : result.cancelled ? "cancelled" : "error",
+          error: result.ok || result.cancelled ? null : result.error,
+        }).catch(() => { /* 呼び出し元がタイムアウト済みの場合は無視 */ });
+      },
+    );
   });
 
   // MCPからの新規ターミナル追加（pnpm dev など長時間バックグラウンドコマンド用）

--- a/src/composables/useRemoveWorktreeDialog.ts
+++ b/src/composables/useRemoveWorktreeDialog.ts
@@ -40,7 +40,7 @@ export function useRemoveWorktreeDialog(core: ReturnType<typeof useWorktreeRemov
   /** ダイアログ確認後の共通処理: state をクリアしてコア処理に委譲する */
   async function _confirm(
     removeOptions: RemoveOptions,
-    execute: (worktreeId: string, removeOptions: RemoveOptions) => Promise<void>,
+    execute: (worktreeId: string, removeOptions: RemoveOptions) => Promise<unknown>,
   ): Promise<void> {
     if (!removeTargetWorktree.value) return;
     const { id: worktreeId } = removeTargetWorktree.value;

--- a/src/composables/useWorktreeRemove.ts
+++ b/src/composables/useWorktreeRemove.ts
@@ -42,6 +42,14 @@ export type WorktreeRemoveOptions = {
 
 export type RemoveOptions = { mergeTo: string; deleteBranch: boolean; forceBranch: boolean };
 
+/** 削除処理の最終結果。MCP 経由の呼び出し元へ成否を返すために使う */
+export type WorktreeRemoveResult =
+  | { ok: true }
+  | { ok: false; cancelled: boolean; error: string };
+
+/** 結果が確定した時点で呼ばれるコールバック（エラーダイアログ表示より前に呼ばれる） */
+export type OnRemoveSettled = (result: WorktreeRemoveResult) => Promise<void>;
+
 export function useWorktreeRemove(options: WorktreeRemoveOptions) {
   const {
     loadingWorktrees,
@@ -90,6 +98,7 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
    *  beforeRemove: git 操作前に呼ぶ任意の非同期処理（アーカイブ保存など）
    *  onRemoveFailed: git 操作失敗時に beforeRemove の副作用をロールバックするコールバック
    *  afterRemove: git 操作成功後に呼ぶ任意の非同期処理（MCP通知など）
+   *  onSettled: 成否が確定した時点（エラーダイアログ表示より前）に呼ぶ任意の非同期処理
    */
   async function _execute(
     worktreeId: string,
@@ -98,9 +107,28 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
     beforeRemove?: (worktree: Worktree) => Promise<void>,
     onRemoveFailed?: (worktree: Worktree) => Promise<void>,
     afterRemove?: (worktree: Worktree) => Promise<void>,
-  ): Promise<void> {
+    onSettled?: OnRemoveSettled,
+  ): Promise<WorktreeRemoveResult> {
+    // 結果は必ず一度だけ確定・通知する（エラーダイアログは await でブロックするため通知はその前に行う）
+    let settledResult: WorktreeRemoveResult | null = null;
+    async function settle(result: WorktreeRemoveResult): Promise<WorktreeRemoveResult> {
+      if (settledResult) return settledResult;
+      settledResult = result;
+      if (onSettled) {
+        try { await onSettled(result); } catch { /* 通知失敗は削除の成否に影響しない */ }
+      }
+      return result;
+    }
+    const failure = (e: unknown): WorktreeRemoveResult => ({
+      ok: false,
+      cancelled: String(e) === "cancelled",
+      error: String(e),
+    });
+
     const worktree = worktrees.value.find((w) => w.id === worktreeId);
-    if (!worktree) return;
+    if (!worktree) {
+      return await settle({ ok: false, cancelled: false, error: `worktree ${worktreeId} not found` });
+    }
 
     clearNotification(worktreeId);
 
@@ -110,8 +138,9 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
       try {
         await beforeRemove(worktree);
       } catch (e) {
+        const result = await settle(failure(e));
         await message(t("deleteFailed", { error: e }), { kind: "error" });
-        return;
+        return result;
       }
     }
 
@@ -161,6 +190,7 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
         if (afterRemove) {
           try { await afterRemove(worktree); } catch { /* 通知失敗はワークツリー削除の成否に影響しない */ }
         }
+        await settle({ ok: true });
         await nextTick();
         if (savedPositions) homeViewRef.value?.animateAfterRemove(savedPositions);
       } catch (e) {
@@ -169,6 +199,7 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
         if (onRemoveFailed) {
           try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
         }
+        await settle(failure(e));
         // "cancelled" はユーザー操作によるキャンセルなのでエラーダイアログを出さない
         if (String(e) !== "cancelled") {
           await message(t("deleteFailed", { error: e }), { kind: "error" });
@@ -183,6 +214,7 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
       if (onRemoveFailed) {
         try { await onRemoveFailed(worktree); } catch { /* ロールバック失敗は無視 */ }
       }
+      await settle(failure(e));
       if (String(e) !== "cancelled") {
         await message(t("deleteFailed", { error: e }), { kind: "error" });
       }
@@ -190,11 +222,18 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
       loadingWorktrees.delete(worktreeId);
       cancellableWorktrees.delete(worktreeId);
     }
+
+    // ここに到達して結果が未確定なのは想定外（通常発生しない）。安全側に倒して不明=失敗として返す
+    return settledResult ?? (await settle({ ok: false, cancelled: false, error: "unknown" }));
   }
 
   /** アーカイブDBに保存してワークツリーを削除する（ダイアログ経由・MCP経由の共通処理） */
-  async function archiveWorktree(worktreeId: string, removeOptions: RemoveOptions): Promise<void> {
-    await _execute(
+  async function archiveWorktree(
+    worktreeId: string,
+    removeOptions: RemoveOptions,
+    onSettled?: OnRemoveSettled,
+  ): Promise<WorktreeRemoveResult> {
+    return await _execute(
       worktreeId,
       removeOptions,
       t("archivingText"),
@@ -236,12 +275,17 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
           branchName: worktree.branchName,
         });
       },
+      onSettled,
     );
   }
 
   /** アーカイブDBへの保存なしでワークツリーを削除する */
-  async function removeWorktreeNoArchive(worktreeId: string, removeOptions: RemoveOptions): Promise<void> {
-    await _execute(worktreeId, removeOptions, t("deletingText"));
+  async function removeWorktreeNoArchive(
+    worktreeId: string,
+    removeOptions: RemoveOptions,
+    onSettled?: OnRemoveSettled,
+  ): Promise<WorktreeRemoveResult> {
+    return await _execute(worktreeId, removeOptions, t("deletingText"), undefined, undefined, undefined, onSettled);
   }
 
   return {


### PR DESCRIPTION
## 背景

セッション内から `oretachi_close_worktree` を呼んで自分のワークツリーをクローズしようとすると、未コミットファイルが無くても以下で失敗していた。

```
削除に失敗しました: git branch -d <branch> failed: error: the branch '<branch>' is not fully merged
```

原因は 2 つ。

1. **MCP 経路だけ `-d` が走る**: UI 手動削除は `forceBranch = deleteBranch && !mergeTo`（`RemoveWorktreeDialog.vue`）、ワークグループ一括削除は `forceBranch: true` 固定で強制削除だが、MCP 経路にはこの導出が無く `force_branch` 既定 `false` のまま `git branch -d` が実行されていた。`-d` は現在の HEAD（またはその upstream）へのマージ済みしか見ないため、未マージ／squash・rebase マージ済みブランチでは必ず失敗する。その後 `git_worktree_restore` でワークツリーが復元されるためクローズが何も進まない。
2. **失敗が呼び出し元に返らない**: ツールは emit 直後に「クローズリクエストを送信しました」を成功として返すだけで、実際の成否はフロントのエラーダイアログにしか出ず、エージェントが失敗を検知できなかった。

## 変更内容

### 1. force 導出を MCP 経路にも入れる（根本修正）

`force_branch` 省略時は `delete_branch` と同じ値に導出する。`Option` が残っている `mcp_server.rs` 側で行うため、**明示的な `force_branch: false` は `-d`（マージ済み確認）として尊重される**。

`merge_to` を指定した場合も、`merge_branch` は別ワークツリーでマージするか checkout を元に戻すため、その後の `git branch -d` はメインリポジトリの HEAD 基準で未マージ判定になり失敗しうる。この導出でそのケースも解消する。`force_branch` / `merge_to` の schemars description も実挙動に合わせて更新。

### 2. 実際の成否を MCP ツールの戻り値にする

- `mcp_server.rs`: `CloseWorktreeAckRegistry`（oneshot 送信側の保管）と Tauri コマンド `mcp_close_worktree_result` を追加。`oretachi_close_worktree` を `async fn` にし、`request_id` 付きで emit → 最大 45 秒 ack を待つ。
  - 成功 → 「クローズしました」
  - キャンセル → 「ユーザー操作によりキャンセルされました」（成功レスポンス。UI でもキャンセルはエラー扱いしないため意味論を揃えた）
  - 失敗 → git のエラー文字列を含む `McpError`
  - タイムアウト → 削除リトライ中／メインウィンドウ未応答の可能性を伝え、`oretachi_get_worktree_status` での確認を促す（`worktree_remove_persistent` はロックエラー時にキャンセルまで無限リトライするため、タイムアウトを失敗と断定しない）
- `useWorktreeRemove.ts`: `_execute` が `WorktreeRemoveResult` を返し、`onSettled` コールバックを**エラーダイアログ表示より前**に一度だけ呼ぶ（ダイアログは `await` でブロックするため）。`archiveWorktree` / `removeWorktreeNoArchive` が `onSettled` を透過。既存の UI 経路は戻り値を無視するだけで挙動不変。

## 既知の制約 / スコープ外

- 自己クローズでは git 操作前に自分の PTY が kill されるため、ack がエージェントプロセスに届かない場合がある（通知経路は UI ダイアログ）。自己クローズについては 1. で失敗しなくなるのが主眼で、ack が効くのは他ワークツリーのクローズ時。
- UI 手動削除も「マージ先を指定 + ブランチ削除」で同じ `-d` 失敗を起こしうるが、ダイアログの強制削除警告の表示条件にも影響するため今回のスコープ外。
- `git_worktree_remove` 成功 → branch 削除失敗 → `git_worktree_restore` も失敗という部分的失敗では、アプリ内部はアーカイブ済み扱いなのに MCP には失敗を返す不整合が残る（発生条件が狭いため未対応）。

## 検証

- `cd src-tauri && cargo check` OK
- `pnpm run type-check` OK
- `pnpm vitest run` OK（48 tests）
- 実機 E2E は未実施。dev ビルドは single-instance を登録しないため `pnpm run tauri dev` は起動できるが、稼働中の本番インスタンスと settings / MCP ポートファイルを共有するため未実行。確認手順:
  1. 未マージコミットを 1 件持つ捨てワークツリーを作る
  2. そのセッションから `oretachi_close_worktree { worktree_name, delete_branch: true }` を呼ぶ → `-D` で削除完了しカードが消える
  3. 別ワークツリーから同様に呼び、ツールの戻り値が「クローズしました」になる
  4. `merge_to` に存在しないブランチを渡すと `McpError` で git のエラーが返り、ワークツリーは UI に残る
  5. UI の「アーカイブ」「削除」ボタン（マージ先あり／なし）とワークグループ一括削除が従来どおり動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
