### PR TITLE
fix(worktree): ブランチ未存在時の close_worktree 失敗を解消

### DIFF
--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -238,12 +238,18 @@ pub fn merge_branch(repo_path: &str, source_branch: &str, target_branch: &str) -
         }
     } else {
         // target_branch がどのワークツリーにもチェックアウトされていない → repo_path で checkout して merge
-        let head_output = make_command("git")
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(repo_path)
-            .output()
-            .map_err(|e| format!("git command error: {}", e))?;
-        let original_branch = String::from_utf8_lossy(&head_output.stdout).trim().to_string();
+        // detached HEAD の場合はブランチ名が取れないため、戻り先としてコミットハッシュを使う
+        let original_branch = match current_branch(repo_path) {
+            Some(branch) => branch,
+            None => {
+                let head_output = make_command("git")
+                    .args(["rev-parse", "HEAD"])
+                    .current_dir(repo_path)
+                    .output()
+                    .map_err(|e| format!("git command error: {}", e))?;
+                String::from_utf8_lossy(&head_output.stdout).trim().to_string()
+            }
+        };
 
         let checkout_output = make_command("git")
             .args(["checkout", target_branch])
@@ -284,10 +290,61 @@ pub fn merge_branch(repo_path: &str, source_branch: &str, target_branch: &str) -
     Ok(())
 }
 
-pub fn delete_branch(repo_path: &str, branch_name: &str, force: bool) -> Result<(), String> {
+/// ローカルブランチが存在するか（refs/heads/<name> の有無で判定）
+pub fn branch_exists(repo_path: &str, branch_name: &str) -> bool {
+    let refname = format!("refs/heads/{}", branch_name);
+    make_command("git")
+        .args(["rev-parse", "--verify", "--quiet", &refname])
+        .current_dir(repo_path)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// ワークツリーがチェックアウトしているブランチ名（detached HEAD の場合は None）
+pub fn current_branch(worktree_path: &str) -> Option<String> {
+    let output = make_command("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(worktree_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() || name == "HEAD" {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+/// ブランチを削除する。戻り値は「実際に削除したか」（false = 既に存在せずスキップ）。
+/// ブランチが無い状態は目的の状態に到達済みなので成功として扱う（冪等）。
+pub fn delete_branch(repo_path: &str, branch_name: &str, force: bool) -> Result<bool, String> {
+    if !branch_exists(repo_path, branch_name) {
+        log::info!(
+            "[worktree] branch '{}' already absent in {}, skip delete",
+            branch_name, repo_path
+        );
+        return Ok(false);
+    }
+
     let flag = if force { "-D" } else { "-d" };
-    run_git_in(repo_path, &["branch", flag, branch_name])?;
-    Ok(())
+    match run_git_in(repo_path, &["branch", flag, branch_name]) {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            // 存在確認との競合（別プロセスが先に削除した等）は成功扱い
+            if e.contains("not found") {
+                log::info!(
+                    "[worktree] branch '{}' disappeared before delete in {}, treated as deleted",
+                    branch_name, repo_path
+                );
+                return Ok(false);
+            }
+            Err(e)
+        }
+    }
 }
 
 // ─── コードレビュー用 Git 関数 ───────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -367,8 +367,15 @@ async fn git_merge_branch(
 }
 
 #[tauri::command]
-async fn git_delete_branch(repo_path: String, branch_name: String, force: bool) -> Result<(), String> {
+/// ブランチを削除する。戻り値 false は「既に存在しなかったためスキップ」を表す（エラーではない）
+async fn git_delete_branch(repo_path: String, branch_name: String, force: bool) -> Result<bool, String> {
     run_git(move || git_worktree::delete_branch(&repo_path, &branch_name, force)).await
+}
+
+/// ワークツリーがチェックアウトしているブランチ名（detached HEAD の場合は null）
+#[tauri::command]
+async fn git_worktree_current_branch(worktree_path: String) -> Result<Option<String>, String> {
+    run_git(move || Ok::<_, String>(git_worktree::current_branch(&worktree_path))).await
 }
 
 #[tauri::command]
@@ -1300,6 +1307,7 @@ pub fn run() {
             git_worktree_remove,
             cancel_worktree_remove,
             git_worktree_restore,
+            git_worktree_current_branch,
             git_list_branches,
             detect_package_manager,
             read_gitignore,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -73,6 +73,8 @@ pub enum CloseWorktreeOutcome {
     Closed,
     /// ユーザーが削除リトライをキャンセルした（エラーではない）
     Cancelled,
+    /// 同じワークツリーのクローズ処理が既に進行中だった（エラーではない）
+    Busy,
     Failed(String),
 }
 
@@ -101,7 +103,7 @@ impl CloseWorktreeAckRegistry {
 }
 
 /// フロントエンドがワークツリークローズの成否を MCP ツールへ返す。
-/// status: "ok" | "cancelled" | それ以外は失敗扱い。
+/// status: "ok" | "cancelled" | "busy" | それ以外は失敗扱い。
 /// 該当 request_id が既にタイムアウト等で除去済みの場合は何もしない。
 #[tauri::command]
 pub fn mcp_close_worktree_result(
@@ -114,6 +116,7 @@ pub fn mcp_close_worktree_result(
         let outcome = match status.as_str() {
             "ok" => CloseWorktreeOutcome::Closed,
             "cancelled" => CloseWorktreeOutcome::Cancelled,
+            "busy" => CloseWorktreeOutcome::Busy,
             _ => CloseWorktreeOutcome::Failed(error.unwrap_or_else(|| "unknown error".to_string())),
         };
         let _ = tx.send(outcome);
@@ -1348,6 +1351,10 @@ impl NotifyService {
                 "ワークツリー '{}' のクローズはユーザー操作によりキャンセルされました。ワークツリーはそのまま残っています。",
                 target_name
             ))])),
+            Ok(Ok(CloseWorktreeOutcome::Busy)) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "ワークツリー '{}' は既にクローズ処理中です。再実行せず、oretachi_get_worktree_status で完了を確認してください。",
+                target_name
+            ))])),
             Ok(Ok(CloseWorktreeOutcome::Failed(msg))) => {
                 log::warn!("[mcp] oretachi_close_worktree failed: name={} error={}", worktree_name, msg);
                 Err(McpError::internal_error(
@@ -1362,7 +1369,7 @@ impl NotifyService {
             Err(_) => {
                 self.app_handle.state::<CloseWorktreeAckRegistry>().take(&request_id);
                 Ok(CallToolResult::success(vec![Content::text(
-                    "ワークツリーのクローズリクエストを送信しましたが、時間内に完了しませんでした。削除リトライ中（UI からキャンセル可能）か、メインウィンドウがまだ処理を受け付けていない可能性があります。oretachi_get_worktree_status で状態を確認してください。",
+                    "ワークツリーのクローズリクエストを送信しましたが、時間内に完了しませんでした。削除リトライ中（UI からキャンセル可能）か、メインウィンドウがまだ処理を受け付けていない可能性があります。このツールを再実行せず、oretachi_get_worktree_status で状態を確認してください（再実行しても処理中のクローズには影響しません）。",
                 )]))
             }
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1292,10 +1292,16 @@ onMounted(async () => {
       },
       async (result) => {
         // MCP 呼び出し元へ実際の成否を返す
+        let status = "ok";
+        let error: string | null = null;
+        if (!result.ok) {
+          status = result.cancelled ? "cancelled" : result.busy ? "busy" : "error";
+          if (status === "error") error = result.error;
+        }
         await invoke("mcp_close_worktree_result", {
           requestId: request_id,
-          status: result.ok ? "ok" : result.cancelled ? "cancelled" : "error",
-          error: result.ok || result.cancelled ? null : result.error,
+          status,
+          error,
         }).catch(() => { /* 呼び出し元がタイムアウト済みの場合は無視 */ });
       },
     );
@@ -2048,6 +2054,7 @@ onMounted(async () => {
     "duplicatingText": "Duplicating...",
     "copyWorkingChangesFailed": "Failed to copy working changes: {error}",
     "deleteFailed": "Delete failed: {error}",
+    "branchDeleteFailed": "The worktree was removed, but deleting its branch failed: {error}",
     "ideNotInstalled": "None of Cursor, VS Code, Antigravity are installed.",
     "ideNotInstalledTitle": "IDE not found",
     "ideLaunchFailed": "Failed to launch IDE: {error}",
@@ -2080,6 +2087,7 @@ onMounted(async () => {
     "duplicatingText": "複製中...",
     "copyWorkingChangesFailed": "作業中変更のコピーに失敗しました: {error}",
     "deleteFailed": "削除に失敗しました: {error}",
+    "branchDeleteFailed": "ワークツリーは削除しましたが、ブランチの削除に失敗しました: {error}",
     "ideNotInstalled": "Cursor、VS Code、Antigravity のいずれもインストールされていません。",
     "ideNotInstalledTitle": "IDE が見つかりません",
     "ideLaunchFailed": "IDE の起動に失敗しました: {error}",

--- a/src/composables/useWorktreeRemove.ts
+++ b/src/composables/useWorktreeRemove.ts
@@ -3,8 +3,9 @@ import type { Ref } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { message } from "@tauri-apps/plugin-dialog";
-import { useWorktrees } from "./useWorktrees";
+import { useWorktrees, BranchDeleteAfterRemoveError } from "./useWorktrees";
 import { cancelApproval } from "../utils/autoApproval";
+import { logWarn } from "../utils/log";
 import { saveArchive, deleteArchive } from "./useArchivePersistence";
 import type { Worktree } from "../types/worktree";
 
@@ -45,7 +46,15 @@ export type RemoveOptions = { mergeTo: string; deleteBranch: boolean; forceBranc
 /** 削除処理の最終結果。MCP 経由の呼び出し元へ成否を返すために使う */
 export type WorktreeRemoveResult =
   | { ok: true }
-  | { ok: false; cancelled: boolean; error: string };
+  | { ok: false; cancelled: boolean; error: string; busy?: boolean };
+
+/**
+ * 処理中のワークツリーID。同一ワークツリーへのクローズ要求が二重に走ると、
+ * 2回目はワークツリー実体が既に無い状態で git 操作を行い「ブランチが無い」等の
+ * 誤ったエラーになるため、モジュールスコープで多重実行を弾く。
+ * （MCP のackタイムアウト後のエージェント再実行、UI操作との競合などで発生しうる）
+ */
+const inFlightRemovals = new Set<string>();
 
 /** 結果が確定した時点で呼ばれるコールバック（エラーダイアログ表示より前に呼ばれる） */
 export type OnRemoveSettled = (result: WorktreeRemoveResult) => Promise<void>;
@@ -119,33 +128,53 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
       }
       return result;
     }
-    const failure = (e: unknown): WorktreeRemoveResult => ({
-      ok: false,
-      cancelled: String(e) === "cancelled",
-      error: String(e),
-    });
+    const failure = (e: unknown): WorktreeRemoveResult =>
+      e instanceof BranchDeleteAfterRemoveError
+        ? {
+            ok: false,
+            cancelled: false,
+            error: t("branchDeleteFailed", { error: e.reason }),
+          }
+        : {
+            ok: false,
+            cancelled: String(e) === "cancelled",
+            error: String(e),
+          };
 
     const worktree = worktrees.value.find((w) => w.id === worktreeId);
     if (!worktree) {
       return await settle({ ok: false, cancelled: false, error: `worktree ${worktreeId} not found` });
     }
 
-    clearNotification(worktreeId);
-
-    // UI 破壊的操作の前に事前処理（アーカイブ保存など）を実行する。
-    // ここで失敗した場合はワークツリーに何も手を加えずエラーを表示して終了する。
-    if (beforeRemove) {
-      try {
-        await beforeRemove(worktree);
-      } catch (e) {
-        const result = await settle(failure(e));
-        await message(t("deleteFailed", { error: e }), { kind: "error" });
-        return result;
-      }
+    // 同一ワークツリーのクローズが既に進行中なら何もしない（ダイアログも出さない）
+    if (inFlightRemovals.has(worktreeId)) {
+      logWarn(`[worktree] close already in progress for ${worktreeId}, ignoring duplicate request`);
+      return await settle({
+        ok: false,
+        cancelled: false,
+        busy: true,
+        error: "close already in progress",
+      });
     }
-
+    // 多重実行ガードとローディング表示は同時に立てる（この間にカードの削除ボタンから
+    // 再操作されると、無音のまま何も起きないため）。以降の解除は末尾の finally で行う。
+    inFlightRemovals.add(worktreeId);
     loadingWorktrees.set(worktreeId, loadingText);
     try {
+      clearNotification(worktreeId);
+
+      // UI 破壊的操作の前に事前処理（アーカイブ保存など）を実行する。
+      // ここで失敗した場合はワークツリーに何も手を加えずエラーを表示して終了する。
+      if (beforeRemove) {
+        try {
+          await beforeRemove(worktree);
+        } catch (e) {
+          const result = await settle(failure(e));
+          await message(t("deleteFailed", { error: e }), { kind: "error" });
+          return result;
+        }
+      }
+
       if (isDetached(worktreeId)) {
         await moveToMainWindow(worktreeId);
         subWindowFocusMap.delete(worktreeId);
@@ -202,7 +231,12 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
         await settle(failure(e));
         // "cancelled" はユーザー操作によるキャンセルなのでエラーダイアログを出さない
         if (String(e) !== "cancelled") {
-          await message(t("deleteFailed", { error: e }), { kind: "error" });
+          // ワークツリーは削除済みでブランチ削除だけ失敗した場合は、その旨を明示する
+          if (e instanceof BranchDeleteAfterRemoveError) {
+            await message(t("branchDeleteFailed", { error: e.reason }), { kind: "warning" });
+          } else {
+            await message(t("deleteFailed", { error: e }), { kind: "error" });
+          }
         }
       } finally {
         homeViewRef.value?.unhideCard(worktreeId);
@@ -221,6 +255,7 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
     } finally {
       loadingWorktrees.delete(worktreeId);
       cancellableWorktrees.delete(worktreeId);
+      inFlightRemovals.delete(worktreeId);
     }
 
     // ここに到達して結果が未確定なのは想定外（通常発生しない）。安全側に倒して不明=失敗として返す

--- a/src/composables/useWorktrees.ts
+++ b/src/composables/useWorktrees.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { Worktree, WorktreeTerminal, SavedTerminal, TerminalSessionFile } from "../types/worktree";
 import type { WorktreeEntry } from "../types/settings";
 import { useSettings } from "./useSettings";
+import { logWarn } from "../utils/log";
 
 const worktrees = ref<Worktree[]>([]);
 let terminalCounter = 0;
@@ -73,6 +74,19 @@ function rollbackWorktree(worktreeId: string): void {
   }
 }
 
+/**
+ * ワークツリー自体の削除は完了したが、そのあとのブランチ削除に失敗したことを表すエラー。
+ * 呼び出し側はこれを「部分的失敗」として扱い、専用のメッセージを表示する。
+ */
+export class BranchDeleteAfterRemoveError extends Error {
+  readonly reason: unknown;
+  constructor(reason: unknown) {
+    super(String(reason));
+    this.name = "BranchDeleteAfterRemoveError";
+    this.reason = reason;
+  }
+}
+
 interface RemoveWorktreeOptions {
   mergeTo?: string;
   deleteBranch?: boolean;
@@ -91,6 +105,24 @@ async function removeWorktree(worktreeId: string, options?: RemoveWorktreeOption
     (r) => r.id === worktree.repositoryId
   );
   if (repoEntry) {
+    // 診断用: settings の branchName とワークツリーの実 HEAD が食い違っていないかを
+    // ワークツリー削除前（パスがまだ存在するうち）に確認する。削除対象は settings の値のまま
+    // （ユーザーが意図的に別ブランチへ切り替えている場合に別ブランチを消さないため）。
+    if (options?.deleteBranch) {
+      try {
+        const actualBranch = await invoke<string | null>("git_worktree_current_branch", {
+          worktreePath: worktree.path,
+        });
+        if (actualBranch !== null && actualBranch !== worktree.branchName) {
+          logWarn(
+            `[worktree] branch mismatch: settings=${worktree.branchName} actual=${actualBranch} path=${worktree.path}`
+          );
+        }
+      } catch {
+        // 取得失敗（既にパスが無い等）は診断目的なので無視
+      }
+    }
+
     if (options?.mergeTo) {
       await invoke("git_merge_branch", {
         repoPath: repoEntry.path,
@@ -110,11 +142,15 @@ async function removeWorktree(worktreeId: string, options?: RemoveWorktreeOption
     let branchDeleteError: unknown = null;
     if (options?.deleteBranch) {
       try {
-        await invoke("git_delete_branch", {
+        // 戻り値 false = ブランチが既に存在せずスキップ（成功扱い・UI には出さない）
+        const deleted = await invoke<boolean>("git_delete_branch", {
           repoPath: repoEntry.path,
           branchName: worktree.branchName,
           force: options.forceBranch ?? false,
         });
+        if (!deleted) {
+          logWarn(`[worktree] branch ${worktree.branchName} was already absent, skipped delete`);
+        }
       } catch (e) {
         // ワークツリーを復元して、削除前の状態に戻す
         let restored = false;
@@ -136,7 +172,11 @@ async function removeWorktree(worktreeId: string, options?: RemoveWorktreeOption
       }
     }
 
-    if (onBeforeSplice) await onBeforeSplice();
+    // カード演出などの UI 処理。ここでの失敗が「ブランチだけ削除済みでエントリが残る」
+    // 中途半端な状態を生まないよう、例外は握りつぶす。
+    if (onBeforeSplice) {
+      try { await onBeforeSplice(); } catch { /* アニメーション失敗は削除の成否に影響させない */ }
+    }
     worktrees.value.splice(index, 1);
     settings.value.worktrees = settings.value.worktrees.filter(
       (w) => w.id !== worktreeId
@@ -148,11 +188,14 @@ async function removeWorktree(worktreeId: string, options?: RemoveWorktreeOption
     try { await invoke("delete_artifacts", { worktreeId }); } catch { /* 存在しない場合は無視 */ }
 
     // クリーンアップ完了後にブランチ削除エラーを伝播
-    if (branchDeleteError) throw branchDeleteError;
+    // （ワークツリーは削除済みなので、呼び出し側が部分的失敗として扱えるようマークする）
+    if (branchDeleteError) throw new BranchDeleteAfterRemoveError(branchDeleteError);
     return;
   }
 
-  if (onBeforeSplice) await onBeforeSplice();
+  if (onBeforeSplice) {
+    try { await onBeforeSplice(); } catch { /* アニメーション失敗は削除の成否に影響させない */ }
+  }
 
   worktrees.value.splice(index, 1);
   settings.value.worktrees = settings.value.worktrees.filter(


### PR DESCRIPTION
## 背景

Claude Code のセッションから `oretachi_close_worktree` で自己クローズさせると、次のエラーダイアログが出ることがある。

```
削除に失敗しました: git branch -D <branch> failed: error: branch '<branch>' not found
```

この時点でワークツリーは既に削除済み・ブランチも存在しない＝**目的の状態には到達している**のに、UI にはエラーダイアログが出て MCP 呼び出し元にも `McpError` が返っていた。直前の #107 は `-d` → `-D` の既定値問題を直しただけで、「ブランチがそもそも存在しない」ケースは未対応だった。

## 「ブランチが無い」状態に至る経路

| | 経路 |
|---|---|
| A | **二重クローズ**。同一ワークツリーへのクローズ要求を弾くガードが無い。MCP の ack タイムアウト(45秒)を超えるとツールが「時間内に完了しませんでした」と返し、エージェントが再実行しがち。自己クローズは自分の端末 kill を含むため遅くなりやすい。2回目はワークツリー実体が無いため `worktree_remove` がフォールバック経路で `Ok` を返し、`branch -D` だけが not found で落ちる |
| B | ブランチが外部で既に削除済み（PR マージ後の掃除、セッション内で `git branch -d` など） |
| C | settings の `branchName` とワークツリーの実 HEAD の乖離（ワークツリー内で `git switch` / `git branch -m`）|
| D | 前回クローズがカード演出(`onBeforeSplice`)の例外で中断し、ブランチだけ削除済みでエントリが残る |

共通の欠陥は「**ブランチが存在しない＝達成済み**なのに hard error にしている」こと。ここを直したうえで、A・D の発生源も塞いだ。

## 変更内容

### Rust
- `delete_branch()` を冪等化。`branch_exists()`（`rev-parse --verify --quiet refs/heads/<name>`）で事前確認し、無ければ `log::info!` を残して `Ok(false)`。実行後に not found で落ちた場合（存在確認とのレース）も同様。`not fully merged` 等は従来どおりエラー
- `current_branch(worktree_path)` を追加。`merge_branch()` 内の重複していた `rev-parse --abbrev-ref HEAD` をこれに寄せた。detached HEAD 時にコミットハッシュへ正しく戻るようになり、旧実装が `git checkout HEAD` でマージ先の先端に detach していた挙動も解消
- `git_delete_branch` コマンドの戻り値を `bool` に変更、`git_worktree_current_branch` を追加
- `CloseWorktreeOutcome::Busy` を追加（エラーではなく成功メッセージで返す）。ack タイムアウト時の文言に「再実行せず `oretachi_get_worktree_status` で確認」を明記

### フロント
- 同一ワークツリーへの二重クローズを弾く in-flight ガード。2回目はダイアログを出さず `busy` を返す。ガードとローディング表示は同時に立て、以降を try/finally で完全に覆っている
- 削除前に settings の `branchName` とワークツリーの実 HEAD の食い違いを検知してログに残す（削除対象は settings の値のまま。意図的にブランチを切り替えている場合に別ブランチを消さないため）
- `onBeforeSplice`（カード演出）の例外を握りつぶし、「ブランチだけ削除済みでエントリが残る」中途半端な状態を防止
- ワークツリー削除後にブランチ削除だけ失敗したケースを `BranchDeleteAfterRemoveError` として区別し、`branchDeleteFailed`（ja/en）で「ワークツリーは削除しましたが、ブランチの削除に失敗しました」と表示

ブランチが無くてスキップした場合、UI には何も出さずログのみ残す方針。

## 確認

- `cargo check` / `pnpm run type-check` パス
- `git rev-parse --verify --quiet refs/heads/<name>` の終了コード（存在=0 / 不在=1）を実リポジトリで確認
- アプリを起動しての end-to-end 確認は未実施。次のビルド更新時に以下を確認したい
  - 事前に `git branch -D` してからクローズ → ダイアログ無しで成功、ログに skip 行
  - 通常クローズ → 従来どおりワークツリーもブランチも消える
  - `force_branch=false` で未マージ → 従来どおり失敗しワークツリーは復元される
  - 同一ワークツリーへ連続 2 回クローズ → 2回目は「既にクローズ処理中」でエラーダイアログなし
  - MCP 経由の自己クローズ → エラーダイアログが出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
