### PR TITLE
fix(mcp): plan モードで oretachi MCP ツールが毎回承認要求される問題を修正

### DIFF
--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -20,6 +20,38 @@ use crate::git_worktree::get_git_remotes;
 use crate::pty_manager::PtyManager;
 use crate::settings::{AppSettings, SettingsManager, Workgroup, WorktreeEntry};
 
+/// artifact / artifact_module の read-modify-write を直列化するグローバルロック。
+/// これらのツールは read_only_hint = true を宣言しているため Claude Code 側が
+/// isConcurrencySafe = true とみなし、同一アーティファクトに対して並列に呼び出しうる。
+/// NotifyService は接続ごとに生成されるためプロセス共有の static で持つ。
+static ARTIFACT_WRITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// 一時ファイル名の衝突を避けるための連番。
+static ARTIFACT_TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// アーティファクト JSON をアトミックに書き込む。
+///
+/// `tokio_fs::write` は truncate → write なので、書き込み中のファイルを
+/// 読んだ側が壊れた JSON を掴む。read_only_hint = true を宣言した結果
+/// Claude Code が読み書きを並列実行しうるため、一時ファイル + rename にする。
+/// rename は同一ディレクトリ内なら Windows/Unix ともに既存ファイルを置換する。
+/// 一時ファイルの拡張子は `.json` にならないため search_artifact の走査対象外。
+async fn write_artifact_atomic(path: &std::path::Path, contents: &str) -> Result<(), McpError> {
+    let seq = ARTIFACT_TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(format!(".tmp-{}-{}", std::process::id(), seq));
+    let tmp_path = path.with_file_name(tmp_name);
+
+    tokio_fs::write(&tmp_path, contents)
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+    if let Err(e) = tokio_fs::rename(&tmp_path, path).await {
+        let _ = tokio_fs::remove_file(&tmp_path).await;
+        return Err(McpError::internal_error(e.to_string(), None));
+    }
+    Ok(())
+}
+
 const PORT_FILE: &str = "mcp-port";
 const SERVER_INFO_FILE: &str = "mcp-server.json";
 
@@ -546,7 +578,7 @@ impl NotifyService {
         }
     }
 
-    #[tool(description = "アーティファクトを操作する。create: 新規作成, update: 差分更新(old_str→new_str), rewrite: 全置換, get: 1件取得(offset/limitで行範囲指定可)")]
+    #[tool(description = "アーティファクトを操作する。create: 新規作成, update: 差分更新(old_str→new_str), rewrite: 全置換, get: 1件取得(offset/limitで行範囲指定可)", annotations(read_only_hint = true))]
     async fn artifact(
         &self,
         Parameters(ArtifactParams {
@@ -585,6 +617,13 @@ impl NotifyService {
         if id.contains("..") || id.contains('/') || id.contains('\\') || id.contains('\0') {
             return Err(McpError::invalid_params("不正なアーティファクトIDです".to_string(), None));
         }
+
+        // 書き込み系コマンドは read-modify-write の競合を避けるため直列化する
+        let _write_guard = if matches!(command.as_str(), "get" | "outline") {
+            None
+        } else {
+            Some(ARTIFACT_WRITE_LOCK.lock().await)
+        };
 
         let artifacts_dir = self
             .app_handle
@@ -739,8 +778,7 @@ impl NotifyService {
 
         let json = serde_json::to_string_pretty(&data)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        tokio_fs::write(&artifact_path, &json).await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        write_artifact_atomic(&artifact_path, &json).await?;
 
         log::info!("[mcp] artifact command={} id={} worktree_id={}", command, id, worktree_id);
         if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
@@ -758,7 +796,7 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "Reactアーティファクトのモジュールを操作する。大規模アーティファクトをファイル単位で管理するために使用。list: モジュール一覧(行数のみ), get: 1モジュール取得(offset/limitで行範囲指定可), create: 追加, update: 差分更新, rewrite: 全置換, delete: 削除")]
+    #[tool(description = "Reactアーティファクトのモジュールを操作する。大規模アーティファクトをファイル単位で管理するために使用。list: モジュール一覧(行数のみ), get: 1モジュール取得(offset/limitで行範囲指定可), create: 追加, update: 差分更新, rewrite: 全置換, delete: 削除", annotations(read_only_hint = true))]
     async fn artifact_module(
         &self,
         Parameters(ArtifactModuleParams {
@@ -793,6 +831,13 @@ impl NotifyService {
         if id.contains("..") || id.contains('/') || id.contains('\\') || id.contains('\0') {
             return Err(McpError::invalid_params("不正なアーティファクトIDです".to_string(), None));
         }
+
+        // 書き込み系コマンドは read-modify-write の競合を避けるため直列化する
+        let _write_guard = if matches!(command.as_str(), "list" | "get") {
+            None
+        } else {
+            Some(ARTIFACT_WRITE_LOCK.lock().await)
+        };
 
         let artifacts_dir = self.app_handle.path().app_data_dir()
             .map_err(|e| McpError::internal_error(e.to_string(), None))?
@@ -869,8 +914,7 @@ impl NotifyService {
                 data.updated_at = now;
                 let json = serde_json::to_string_pretty(&data)
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-                tokio_fs::write(&artifact_path, &json).await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                write_artifact_atomic(&artifact_path, &json).await?;
                 if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
                     "worktreeId": worktree_id, "artifactId": id, "command": "create",
                 })) { log::warn!("Failed to emit artifact-changed: {}", e); }
@@ -886,8 +930,7 @@ impl NotifyService {
                 data.updated_at = now;
                 let json = serde_json::to_string_pretty(&data)
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-                tokio_fs::write(&artifact_path, &json).await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                write_artifact_atomic(&artifact_path, &json).await?;
                 if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
                     "worktreeId": worktree_id, "artifactId": id, "command": "rewrite",
                 })) { log::warn!("Failed to emit artifact-changed: {}", e); }
@@ -912,8 +955,7 @@ impl NotifyService {
                 data.updated_at = now;
                 let json = serde_json::to_string_pretty(&data)
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-                tokio_fs::write(&artifact_path, &json).await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                write_artifact_atomic(&artifact_path, &json).await?;
                 if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
                     "worktreeId": worktree_id, "artifactId": id, "command": "update",
                 })) { log::warn!("Failed to emit artifact-changed: {}", e); }
@@ -929,8 +971,7 @@ impl NotifyService {
                 data.updated_at = now;
                 let json = serde_json::to_string_pretty(&data)
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-                tokio_fs::write(&artifact_path, &json).await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                write_artifact_atomic(&artifact_path, &json).await?;
                 if let Err(e) = self.app_handle.emit("artifact-changed", serde_json::json!({
                     "worktreeId": worktree_id, "artifactId": id, "command": "delete_module",
                 })) { log::warn!("Failed to emit artifact-changed: {}", e); }
@@ -1056,7 +1097,7 @@ impl NotifyService {
         )]))
     }
 
-    #[tool(description = "登録済みワークツリーのステータス一覧を取得する。各エントリはルートパス(path)と現在の1行説明(description)を含む")]
+    #[tool(description = "登録済みワークツリーのステータス一覧を取得する。各エントリはルートパス(path)と現在の1行説明(description)を含む", annotations(read_only_hint = true))]
     fn oretachi_get_worktree_status(
         &self,
         Parameters(_params): Parameters<GetWorktreeStatusParams>,
@@ -1089,7 +1130,7 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "AI agent が参照するグローバル app options (background terminal の起動先トグル等) を取得する")]
+    #[tool(description = "AI agent が参照するグローバル app options (background terminal の起動先トグル等) を取得する", annotations(read_only_hint = true))]
     fn oretachi_get_app_options(
         &self,
         Parameters(_params): Parameters<GetAppOptionsParams>,
@@ -1107,7 +1148,7 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "List all registered repositories with their names and git remote URLs")]
+    #[tool(description = "List all registered repositories with their names and git remote URLs", annotations(read_only_hint = true))]
     async fn oretachi_list_repository(
         &self,
         Parameters(_params): Parameters<ListRepositoryParams>,
@@ -1144,7 +1185,7 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "アーティファクトを検索する。queryを省略すると全件返却。title/content/type/languageを対象に部分一致検索。結果はcontentを除いたメタデータのみ")]
+    #[tool(description = "アーティファクトを検索する。queryを省略すると全件返却。title/content/type/languageを対象に部分一致検索。結果はcontentを除いたメタデータのみ", annotations(read_only_hint = true))]
     async fn search_artifact(
         &self,
         Parameters(SearchArtifactParams { repository, branch, query }): Parameters<SearchArtifactParams>,
@@ -1261,7 +1302,7 @@ impl NotifyService {
         )]))
     }
 
-    #[tool(description = "ワークツリーをアーカイブ（クローズ）する。アーカイブDBに記録してgitワークツリーを削除する")]
+    #[tool(description = "ワークツリーをアーカイブ（クローズ）する。アーカイブDBに記録してgitワークツリーを削除する", annotations(destructive_hint = true))]
     async fn oretachi_close_worktree(
         &self,
         Parameters(CloseWorktreeParams { worktree_name, worktree_id, merge_to, delete_branch, force_branch }): Parameters<CloseWorktreeParams>,
@@ -1435,7 +1476,7 @@ impl NotifyService {
         )]))
     }
 
-    #[tool(description = "現在の PTY セッション一覧を返す。session_id, cwd, isAiAgent, ワークツリー名/ID を含む。oretachi_kill_terminal を呼ぶ前の確認に使う")]
+    #[tool(description = "現在の PTY セッション一覧を返す。session_id, cwd, isAiAgent, ワークツリー名/ID を含む。oretachi_kill_terminal を呼ぶ前の確認に使う", annotations(read_only_hint = true))]
     fn oretachi_list_terminals(
         &self,
         Parameters(ListTerminalsParams { worktree_name, worktree_id }): Parameters<ListTerminalsParams>,
@@ -1507,7 +1548,7 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "指定 PTY セッションを停止する。oretachi_list_terminals で取得した session_id を渡す。UI のタブは pty-exit イベント経由で自動的に消える")]
+    #[tool(description = "指定 PTY セッションを停止する。oretachi_list_terminals で取得した session_id を渡す。UI のタブは pty-exit イベント経由で自動的に消える", annotations(destructive_hint = true))]
     async fn oretachi_kill_terminal(
         &self,
         Parameters(KillTerminalParams { session_id }): Parameters<KillTerminalParams>,
@@ -1529,7 +1570,7 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text("killed")]))
     }
 
-    #[tool(description = "指定 PTY セッションの最近の出力履歴を返す。レスポンスは JSON: { text, cursor, lostBytes }。text は ANSI 除去済み UTF-8。連続ポーリングで重複を避けるには、次回呼び出しの from_cursor に前回の cursor を渡す（差分読み）。lostBytes>0 はリングバッファ溢れで先頭が欠落したことを意味する。先に oretachi_list_terminals で session_id を取得すること")]
+    #[tool(description = "指定 PTY セッションの最近の出力履歴を返す。レスポンスは JSON: { text, cursor, lostBytes }。text は ANSI 除去済み UTF-8。連続ポーリングで重複を避けるには、次回呼び出しの from_cursor に前回の cursor を渡す（差分読み）。lostBytes>0 はリングバッファ溢れで先頭が欠落したことを意味する。先に oretachi_list_terminals で session_id を取得すること", annotations(read_only_hint = true))]
     fn oretachi_read_terminal(
         &self,
         Parameters(ReadTerminalParams { session_id, max_bytes, from_cursor }): Parameters<ReadTerminalParams>,
@@ -2470,4 +2511,66 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
         // 停止完了を通知
         let _ = complete_tx.send(());
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Claude Code は plan モードで `readOnlyHint` が立っていない MCP ツールを
+    /// permissions.allow に関わらず一律 ask にする。ここで advertise 内容を固定しておく。
+    #[test]
+    fn read_only_tools_advertise_read_only_hint() {
+        const READ_ONLY: &[&str] = &[
+            "artifact",
+            "artifact_module",
+            "search_artifact",
+            "oretachi_get_worktree_status",
+            "oretachi_get_app_options",
+            "oretachi_list_repository",
+            "oretachi_list_terminals",
+            "oretachi_read_terminal",
+        ];
+        const NOT_READ_ONLY: &[&str] = &[
+            "notify_worktree",
+            "oretachi_set_description",
+            "oretachi_add_task",
+            "oretachi_close_worktree",
+            "oretachi_spawn_terminal",
+            "oretachi_kill_terminal",
+            "oretachi_write_terminal",
+        ];
+
+        let tools = NotifyService::tool_router().list_all();
+        let hint = |name: &str| -> Option<bool> {
+            tools
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("tool '{}' が存在しません", name))
+                .annotations
+                .as_ref()
+                .and_then(|a| a.read_only_hint)
+        };
+
+        for name in READ_ONLY {
+            assert_eq!(hint(name), Some(true), "{} は read_only_hint = true であるべき", name);
+        }
+        for name in NOT_READ_ONLY {
+            assert_ne!(hint(name), Some(true), "{} が誤って read-only 宣言されている", name);
+        }
+    }
+
+    #[test]
+    fn destructive_tools_advertise_destructive_hint() {
+        let tools = NotifyService::tool_router().list_all();
+        for name in ["oretachi_close_worktree", "oretachi_kill_terminal"] {
+            let t = tools.iter().find(|t| t.name == name).expect("tool が存在しません");
+            assert_eq!(
+                t.annotations.as_ref().and_then(|a| a.destructive_hint),
+                Some(true),
+                "{} は destructive_hint = true であるべき",
+                name
+            );
+        }
+    }
 }

--- a/src/utils/autoApproval.test.ts
+++ b/src/utils/autoApproval.test.ts
@@ -10,7 +10,7 @@ vi.mock('@tauri-apps/plugin-log', () => ({
   error: vi.fn(() => Promise.resolve()),
 }))
 
-import { hasApprovalPrompt } from './autoApproval'
+import { hasApprovalPrompt, detectOretachiToolPrompt } from './autoApproval'
 
 describe('hasApprovalPrompt', () => {
   it('detects ❯ Yes', () => {
@@ -57,5 +57,106 @@ describe('hasApprovalPrompt', () => {
   it('returns false for multi-line non-approval content', () => {
     const content = 'Compiling...\nDone.\nSuccess!'
     expect(hasApprovalPrompt(content)).toBe(false)
+  })
+})
+
+/** 実際に Claude Code が出す承認プロンプトを模したテキストを作る */
+function ccPrompt(label: string, cwd = 'X:\\devel\\worktree\\oretachi-zlvc'): string {
+  return [
+    'Reactアーティファクトのモジュールを操作する',
+    '',
+    ' Do you want to proceed?',
+    ' ❯ 1. Yes',
+    `   2. Yes, and don't ask again for ${label} commands in ${cwd}`,
+    '   3. No',
+    '',
+    ' Esc to cancel · Tab to amend',
+  ].join('\n')
+}
+
+describe('detectOretachiToolPrompt', () => {
+  it('detects plugin-scoped oretachi tool', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('plugin:oretachi:oretachi - artifact_module')))
+      .toBe('artifact_module')
+  })
+
+  it('detects artifact without matching artifact_module first', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('plugin:oretachi:oretachi - artifact')))
+      .toBe('artifact')
+  })
+
+  it('detects directly-registered oretachi server', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('oretachi - oretachi_read_terminal')))
+      .toBe('oretachi_read_terminal')
+  })
+
+  it('returns null for destructive close_worktree', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('plugin:oretachi:oretachi - oretachi_close_worktree')))
+      .toBeNull()
+  })
+
+  it('returns null for destructive kill_terminal', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('plugin:oretachi:oretachi - oretachi_kill_terminal')))
+      .toBeNull()
+  })
+
+  it('returns null for arbitrary-code-execution tools', () => {
+    for (const tool of ['oretachi_spawn_terminal', 'oretachi_write_terminal', 'oretachi_add_task']) {
+      expect(detectOretachiToolPrompt(ccPrompt(`plugin:oretachi:oretachi - ${tool}`)))
+        .toBeNull()
+    }
+  })
+
+  it('does not match a worktree path that ends with a tool name', () => {
+    // 選択肢2行目の cwd は必ずウィンドウ内に入る。
+    // ワークツリー名が oretachi-artifact だと任意コマンドが自動承認されうる
+    const content = ccPrompt('Bash(rm:*)', 'X:\\devel\\worktree\\oretachi-artifact')
+    expect(detectOretachiToolPrompt(content)).toBeNull()
+  })
+
+  it('does not match a tool name embedded in a shell command path', () => {
+    const content = [
+      ' Bash(rm -rf X:/devel/worktree/oretachi-artifact_module/dist)',
+      ' Do you want to proceed?',
+      ' ❯ 1. Yes',
+      '   3. No',
+    ].join('\n')
+    expect(detectOretachiToolPrompt(content)).toBeNull()
+  })
+
+  it('does not match a tool name with a trailing suffix', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('plugin:oretachi:oretachi - artifacts')))
+      .toBeNull()
+  })
+
+  it('returns null for another MCP server', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('obsidian-mcp-tools - get_vault_file')))
+      .toBeNull()
+  })
+
+  it('returns null when there is no approval prompt at all', () => {
+    expect(detectOretachiToolPrompt('plugin:oretachi:oretachi - artifact finished')).toBeNull()
+  })
+
+  it('returns null when the oretachi mention is far from the prompt', () => {
+    const noise = Array.from({ length: 30 }, (_, i) => `log line ${i}`).join('\n')
+    const content = [
+      'plugin:oretachi:oretachi - artifact created earlier',
+      noise,
+      ' Do you want to proceed?',
+      ' ❯ 1. Yes',
+      "   2. Yes, and don't ask again for Bash(rm:*) commands",
+      '   3. No',
+    ].join('\n')
+    expect(detectOretachiToolPrompt(content)).toBeNull()
+  })
+
+  it('uses the last approval prompt in the buffer', () => {
+    const content = [
+      ccPrompt('plugin:oretachi:oretachi - oretachi_close_worktree'),
+      Array.from({ length: 30 }, (_, i) => `log ${i}`).join('\n'),
+      ccPrompt('plugin:oretachi:oretachi - search_artifact'),
+    ].join('\n')
+    expect(detectOretachiToolPrompt(content)).toBe('search_artifact')
   })
 })

--- a/src/utils/autoApproval.ts
+++ b/src/utils/autoApproval.ts
@@ -43,6 +43,76 @@ export function hasApprovalPrompt(content: string): boolean {
     );
 }
 
+/**
+ * 無条件に自動承認する oretachi 自身の MCP ツール名。
+ *
+ * 除外しているもの (従来どおり AI 判定に委ねる):
+ * - oretachi_close_worktree / oretachi_kill_terminal … 破壊的
+ * - oretachi_spawn_terminal / oretachi_write_terminal … 任意コマンドを PTY に流し込める
+ *   (= 任意コード実行)。無条件承認すると安全ゲートが無効化される
+ * - oretachi_add_task … 任意 prompt からワークツリー作成とエージェント実行を発火する
+ *
+ * artifact_module は artifact より前に置く (正規表現の選択肢で長い方を優先させるため)。
+ */
+export const ORETACHI_AUTO_APPROVE_TOOLS = [
+  "artifact_module",
+  "artifact",
+  "search_artifact",
+  "notify_worktree",
+  "oretachi_set_description",
+  "oretachi_get_worktree_status",
+  "oretachi_get_app_options",
+  "oretachi_list_repository",
+  "oretachi_list_terminals",
+  "oretachi_read_terminal",
+] as const;
+
+/** 承認プロンプト行を探すときに前後何行を対象にするか */
+const ORETACHI_PROMPT_WINDOW = 8;
+
+/**
+ * 承認プロンプトが oretachi 自身の MCP ツール呼び出しかを判定し、ツール名を返す。
+ *
+ * Claude Code は plan モードで MCP ツールを一律 ask にするため
+ * (readOnlyHint が無い MCP ツールは permissions.allow でも抑止できない)、
+ * oretachi 側で自分のツールだけを決め打ちで承認する。
+ *
+ * 画面上の無関係な位置に "oretachi" の文字列があっても誤爆しないよう、
+ * 承認プロンプト行の周辺だけを走査する。
+ */
+export function detectOretachiToolPrompt(content: string): string | null {
+  const lines = content.split("\n");
+  // 末尾側の承認プロンプト行を探す
+  let promptIndex = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (/❯\s*Yes|►\s*Yes|Do you want to/i.test(lines[i])) {
+      promptIndex = i;
+      break;
+    }
+  }
+  if (promptIndex === -1) return null;
+
+  const start = Math.max(0, promptIndex - ORETACHI_PROMPT_WINDOW);
+  const end = Math.min(lines.length, promptIndex + ORETACHI_PROMPT_WINDOW + 1);
+  const window = lines.slice(start, end).join("\n");
+
+  // Claude Code の MCP ツール表示名は必ず "<サーバ名> - <ツール名>" 形式
+  //   プラグイン経由: "plugin:oretachi:oretachi - artifact"
+  //   直接登録時:     "oretachi - artifact"
+  // ハイフンの前後に空白を必須にしないと、cwd のパス (例:
+  // "X:\devel\worktree\oretachi-artifact") が「サーバ名 - ツール名」として
+  // 誤マッチする。承認プロンプトの選択肢2行目には必ず cwd が含まれるため、
+  // ワークツリー名がツール名と一致するだけで任意コマンドが自動承認されてしまう。
+  const toolAlternation = ORETACHI_AUTO_APPROVE_TOOLS.join("|");
+  const match = window.match(
+    new RegExp(
+      `(?:^|[\\s(\\[])(?:plugin:oretachi:oretachi|oretachi)\\s+-\\s+(${toolAlternation})(?![\\w-])`,
+      "im"
+    )
+  );
+  return match ? match[1] : null;
+}
+
 /** ターミナル内容を解析し自動承認すべきか判定 */
 export async function analyzeForApproval(
   worktreeId: string,
@@ -59,6 +129,15 @@ export async function analyzeForApproval(
   if (!promptFound) {
     logDebug("[AutoApproval] → skip: no approval prompt detected");
     return { safe: false };
+  }
+
+  // oretachi 自身の MCP ツールは AI 判定を挟まず即承認する。
+  // plan モードの Claude Code は MCP ツールを permissions.allow でも抑止できず
+  // 一律 ask にするため、ここで拾わないと毎回手動承認になる。
+  const oretachiTool = detectOretachiToolPrompt(content);
+  if (oretachiTool) {
+    logDebug(`[AutoApproval] → oretachi own MCP tool (${oretachiTool}), auto-approve`);
+    return { safe: true, command: `oretachi ${oretachiTool}` };
   }
 
   // AI 判定: claude --model haiku で安全性を判定


### PR DESCRIPTION
## 背景

`~/.claude/settings.json` や各ワークツリーの `.claude/settings.local.json` の `permissions.allow` に `mcp__plugin_oretachi_oretachi__artifact` などを追加しても、Claude Code が毎回承認を求めてくる。

原因は Claude Code (2.1.225) の権限評価にあるこの分岐:

```js
l = await e.checkPermissions(g, r);
if (e.mcpInfo && !e.isReadOnly(g) && l.behavior === "passthrough"
    && xn(r).mode === "plan" && !xri(hQ(e), g))
  l = { behavior: "ask",
        message: `Cannot call ${e.name} while in plan mode.`,
        decisionReason: { type: "mode", mode: "plan" } };
```

- この判定は allow ルール照合より**前**に走るため `permissions.allow` では抑止できない
- MCP ツールの `isReadOnly()` は `annotations.readOnlyHint ?? false`。oretachi の `#[tool]` は annotations 未指定だったため**全ツールが非読み取り専用扱い**になり、`search_artifact` / `oretachi_list_terminals` / `oretachi_read_terminal` のような純粋な読み取りツールまで plan モードで毎回聞かれていた

実ログでも、承認プロンプトが出た時刻のセッションが `"permissionMode":"plan"` であること、その時点で allow ルールは既に両方の設定ファイルに存在していたことを確認済み。

なお CC 組み込みの `Artifact` は MCP ツールではない (`mcpInfo` が undefined) ためこのゲートに入らず、自前の `checkPermissions` 内で allow ルールを評価し、plan モードでも publish はブロックされない。つまり「plan 中にアーティファクトを作る」こと自体は CC も正当としている。

## 変更内容

### 1. MCP tool annotations の宣言 (`src-tauri/src/mcp_server.rs`)

`read_only_hint = true`:
`artifact` / `artifact_module` / `search_artifact` / `oretachi_get_worktree_status` / `oretachi_get_app_options` / `oretachi_list_repository` / `oretachi_list_terminals` / `oretachi_read_terminal`

`destructive_hint = true`:
`oretachi_close_worktree` / `oretachi_kill_terminal`

`artifact` / `artifact_module` は書き込みを含むが、実ファイルや git ではなく oretachi 内部ストアにしか書かないため read-only 扱いとし、CC 組み込み Artifact の挙動に揃えた。

### 2. アーティファクト書き込みの並行性対策 (同上)

`readOnlyHint = true` を宣言すると CC 側が `isConcurrencySafe = true` とみなして読み書きを並列実行しうる。

- `write_artifact_atomic()` を追加し、`tokio_fs::write` (truncate → write) を一時ファイル + `rename` に置換。書き込み中の壊れた JSON を読み手が掴まなくなる。一時ファイルの拡張子は `.json` にならないため `search_artifact` の走査対象外
- `update` の read-modify-write によるロストアップデートを防ぐため、書き込み系コマンドをプロセス共有の `ARTIFACT_WRITE_LOCK` で直列化 (読み取りはロックを取らない)

### 3. oretachi 自身の MCP ツールの自動承認 (`src/utils/autoApproval.ts`)

CC の仕様変更に依存しない保険として、承認プロンプトが oretachi 自身の MCP ツール呼び出しなら AI 判定を挟まず即承認する。haiku 呼び出しが1回減るぶん承認も速くなる。

対象外 (従来どおり AI 判定に委ねる):

- `oretachi_spawn_terminal` / `oretachi_write_terminal` / `oretachi_add_task` — 任意コマンドを PTY に流し込める (= 任意コード実行)
- `oretachi_close_worktree` / `oretachi_kill_terminal` — 破壊的

ツール名の照合は、サーバ表示名 `<server> - <tool>` の**空白付きハイフン**を必須にしている。空白を許すと承認プロンプト選択肢2行目の cwd (`... commands in X:\devel\worktree\oretachi-artifact`) に誤マッチし、ワークツリー名がツール名で終わるだけで任意コマンドが自動承認されてしまうため。

## テスト

- `cargo test --lib` → 57 passed
  - 追加した2件は `NotifyService::tool_router().list_all()` を検査し、サーバが実際に advertise する annotations を直接検証している
- `vue-tsc --noEmit` → エラーなし
- `vitest run` → 61 passed
  - `detectOretachiToolPrompt` に12件。cwd パスがツール名で終わるケース、シェルコマンド中のパス、接尾辞付き (`artifacts`)、任意コード実行ツール、他 MCP サーバの各パターンで `null` になることを回帰テスト化

## 動作確認の手順

annotations は `tools/list` 応答なので、反映には oretachi の再起動と、そのあと Claude Code セッションの張り直しの両方が必要 (`tools/list` はセッション開始時に一度だけ取得される)。

そのうえで `Shift+Tab` で plan モードに入り、

- `search_artifact` / `artifact` の create が無確認で通ること
- `oretachi_close_worktree` は従来どおり承認を求められること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
