### PR TITLE
feat(artifact): HOME/リポジトリ擬似ワークツリーでもアーティファクトを作成できるようにする

### DIFF
--- a/src-tauri/skills/domain-model-diagram/SKILL.md
+++ b/src-tauri/skills/domain-model-diagram/SKILL.md
@@ -21,14 +21,15 @@ $ARGUMENTS: <artifact-id> [--repo <repo>] [--branch <branch>]
 ```
 
 - `artifact-id`（必須）: 作成するアーティファクトID（例: `my-service-diagram`）
-- `--repo`（省略時: `oretachi`）: リポジトリ名
-- `--branch`（省略時: `git branch --show-current`）: ブランチ名
+- `--repo` / `--branch`（任意）: 保存先ワークツリーを明示したい場合のみ、両方セットで指定
 
 ## ワークフロー
 
 ### Step 1: パラメータ確定
 
-引数を解析する。`--branch` が省略された場合は `git branch --show-current` で現在ブランチを取得。
+引数を解析する。保存先ワークツリーは、artifact 系ツールに **`project_dir`（現在の作業ディレクトリ）を渡して解決させる**のが既定。HOME タブやリポジトリルートは git ワークツリーではないため `git branch --show-current` が使えず、`--repo`/`--branch` では特定できない。
+
+`--repo` と `--branch` が両方明示された場合のみ、`project_dir` の代わりにそれを渡す。`--repo` だけ与えられた場合は `git branch --show-current` でブランチを補う。
 
 ### Step 2: テンプレートを読み込む
 

--- a/src-tauri/skills/presentation/SKILL.md
+++ b/src-tauri/skills/presentation/SKILL.md
@@ -22,14 +22,15 @@ $ARGUMENTS: <artifact-id> [--repo <repo>] [--branch <branch>]
 ```
 
 - `artifact-id`（必須）: 作成するアーティファクトID（例: `kickoff-deck`）
-- `--repo`（省略時: `oretachi`）: リポジトリ名
-- `--branch`（省略時: `git branch --show-current`）: ブランチ名
+- `--repo` / `--branch`（任意）: 保存先ワークツリーを明示したい場合のみ、両方セットで指定
 
 ## ワークフロー
 
 ### Step 1: パラメータ確定
 
-引数を解析する。`--branch` が省略された場合は `git branch --show-current` で現在ブランチを取得。
+引数を解析する。保存先ワークツリーは、artifact 系ツールに **`project_dir`（現在の作業ディレクトリ）を渡して解決させる**のが既定。HOME タブやリポジトリルートは git ワークツリーではないため `git branch --show-current` が使えず、`--repo`/`--branch` では特定できない。
+
+`--repo` と `--branch` が両方明示された場合のみ、`project_dir` の代わりにそれを渡す。`--repo` だけ与えられた場合は `git branch --show-current` でブランチを補う。
 
 ### Step 2: テンプレートを読み込む
 

--- a/src-tauri/skills/wireframe/SKILL.md
+++ b/src-tauri/skills/wireframe/SKILL.md
@@ -21,14 +21,15 @@ $ARGUMENTS: <artifact-id> [--repo <repo>] [--branch <branch>]
 ```
 
 - `artifact-id`（必須）: 作成するアーティファクトID（例: `my-app-wireframe`）
-- `--repo`（省略時: `oretachi`）: リポジトリ名
-- `--branch`（省略時: `git branch --show-current`）: ブランチ名
+- `--repo` / `--branch`（任意）: 保存先ワークツリーを明示したい場合のみ、両方セットで指定
 
 ## ワークフロー
 
 ### Step 1: パラメータ確定
 
-引数を解析する。`--branch` が省略された場合は `git branch --show-current` で現在ブランチを取得。
+引数を解析する。保存先ワークツリーは、artifact 系ツールに **`project_dir`（現在の作業ディレクトリ）を渡して解決させる**のが既定。HOME タブやリポジトリルートは git ワークツリーではないため `git branch --show-current` が使えず、`--repo`/`--branch` では特定できない。
+
+`--repo` と `--branch` が両方明示された場合のみ、`project_dir` の代わりにそれを渡す。`--repo` だけ与えられた場合は `git branch --show-current` でブランチを補う。
 
 ### Step 2: テンプレートを読み込む
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -385,10 +385,14 @@ pub struct ArtifactParams {
     pub command: String,
     #[schemars(description = "アーティファクトを識別する一意なID")]
     pub id: String,
-    #[schemars(description = "リポジトリ名")]
-    pub repository: String,
-    #[schemars(description = "ブランチ名")]
-    pub branch: String,
+    #[schemars(description = "現在の作業ディレクトリ。これを渡すのが最も確実。HOMEタブやリポジトリルートで作業している場合は repository/branch では特定できないため必須")]
+    pub project_dir: Option<String>,
+    #[schemars(description = "対象ワークツリーID（project_dir で特定できない場合に指定）")]
+    pub worktree_id: Option<String>,
+    #[schemars(description = "リポジトリ名。project_dir を渡す場合は不要。指定する場合は branch と両方セットで")]
+    pub repository: Option<String>,
+    #[schemars(description = "ブランチ名。project_dir を渡す場合は不要。指定する場合は repository と両方セットで")]
+    pub branch: Option<String>,
     #[schemars(description = "コンテンツの種類 (create時必須): application/vnd.ant.code, text/markdown, text/html, image/svg+xml, application/vnd.ant.mermaid, application/vnd.ant.react (Tailwind CSSユーティリティクラス利用可), text/csv, text/tab-separated-values (1行目をヘッダとするテーブルビューアで表示)")]
     #[serde(rename = "type")]
     pub content_type: Option<String>,
@@ -425,10 +429,14 @@ struct ArtifactData {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SearchArtifactParams {
-    #[schemars(description = "リポジトリ名")]
-    pub repository: String,
-    #[schemars(description = "ブランチ名")]
-    pub branch: String,
+    #[schemars(description = "現在の作業ディレクトリ。これを渡すのが最も確実。HOMEタブやリポジトリルートで作業している場合は repository/branch では特定できないため必須")]
+    pub project_dir: Option<String>,
+    #[schemars(description = "対象ワークツリーID（project_dir で特定できない場合に指定）")]
+    pub worktree_id: Option<String>,
+    #[schemars(description = "リポジトリ名。project_dir を渡す場合は不要。指定する場合は branch と両方セットで")]
+    pub repository: Option<String>,
+    #[schemars(description = "ブランチ名。project_dir を渡す場合は不要。指定する場合は repository と両方セットで")]
+    pub branch: Option<String>,
     #[schemars(description = "検索キーワード (省略時は全件返却)。title, content, type, language を対象に部分一致検索")]
     pub query: Option<String>,
 }
@@ -439,10 +447,14 @@ pub struct ArtifactModuleParams {
     pub command: String,
     #[schemars(description = "アーティファクトID")]
     pub id: String,
-    #[schemars(description = "リポジトリ名")]
-    pub repository: String,
-    #[schemars(description = "ブランチ名")]
-    pub branch: String,
+    #[schemars(description = "現在の作業ディレクトリ。これを渡すのが最も確実。HOMEタブやリポジトリルートで作業している場合は repository/branch では特定できないため必須")]
+    pub project_dir: Option<String>,
+    #[schemars(description = "対象ワークツリーID（project_dir で特定できない場合に指定）")]
+    pub worktree_id: Option<String>,
+    #[schemars(description = "リポジトリ名。project_dir を渡す場合は不要。指定する場合は branch と両方セットで")]
+    pub repository: Option<String>,
+    #[schemars(description = "ブランチ名。project_dir を渡す場合は不要。指定する場合は repository と両方セットで")]
+    pub branch: Option<String>,
     #[schemars(description = "モジュール名 (例: \"components/Header\", \"screens/Login\")。list時は省略可")]
     pub module_name: Option<String>,
     #[schemars(description = "モジュールのソースコード (create/rewrite時必須)")]
@@ -591,12 +603,14 @@ impl NotifyService {
         }
     }
 
-    #[tool(description = "アーティファクトを操作する。create: 新規作成, update: 差分更新(old_str→new_str), rewrite: 全置換, get: 1件取得(offset/limitで行範囲指定可)", annotations(read_only_hint = true))]
+    #[tool(description = "アーティファクトを操作する。create: 新規作成, update: 差分更新(old_str→new_str), rewrite: 全置換, get: 1件取得(offset/limitで行範囲指定可)。保存先は project_dir(現在の作業ディレクトリ)で指定するのが最も確実。HOMEタブやリポジトリルートで作業している場合は repository/branch では特定できないため project_dir が必須", annotations(read_only_hint = true))]
     async fn artifact(
         &self,
         Parameters(ArtifactParams {
             command,
             id,
+            project_dir,
+            worktree_id: target_worktree_id,
             repository,
             branch,
             content_type,
@@ -611,19 +625,13 @@ impl NotifyService {
     ) -> Result<CallToolResult, McpError> {
         let settings_manager = self.app_handle.state::<SettingsManager>();
         let settings = settings_manager.get();
-        let wt = settings
-            .worktrees
-            .iter()
-            .find(|wt| wt.repository_name == repository && wt.branch_name == branch)
-            .ok_or_else(|| {
-                McpError::invalid_params(
-                    format!(
-                        "repository='{}', branch='{}' に一致するワークツリーが存在しません",
-                        repository, branch
-                    ),
-                    None,
-                )
-            })?;
+        let wt = resolve_artifact_worktree(
+            &settings,
+            target_worktree_id.as_deref(),
+            project_dir.as_deref(),
+            repository.as_deref(),
+            branch.as_deref(),
+        )?;
         let worktree_id = wt.id.clone();
 
         // artifact ID のパストラバーサル防止
@@ -809,11 +817,13 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "Reactアーティファクトのモジュールを操作する。大規模アーティファクトをファイル単位で管理するために使用。list: モジュール一覧(行数のみ), get: 1モジュール取得(offset/limitで行範囲指定可), create: 追加, update: 差分更新, rewrite: 全置換, delete: 削除", annotations(read_only_hint = true))]
+    #[tool(description = "Reactアーティファクトのモジュールを操作する。大規模アーティファクトをファイル単位で管理するために使用。list: モジュール一覧(行数のみ), get: 1モジュール取得(offset/limitで行範囲指定可), create: 追加, update: 差分更新, rewrite: 全置換, delete: 削除。対象は project_dir(現在の作業ディレクトリ)で指定するのが最も確実。HOMEタブやリポジトリルートで作業している場合は project_dir が必須", annotations(read_only_hint = true))]
     async fn artifact_module(
         &self,
         Parameters(ArtifactModuleParams {
-            command, id, repository, branch,
+            command, id,
+            project_dir, worktree_id: target_worktree_id,
+            repository, branch,
             module_name, content, old_str, new_str,
             offset, limit,
         }): Parameters<ArtifactModuleParams>,
@@ -830,14 +840,13 @@ impl NotifyService {
 
         let settings_manager = self.app_handle.state::<SettingsManager>();
         let settings = settings_manager.get();
-        let wt = settings
-            .worktrees
-            .iter()
-            .find(|wt| wt.repository_name == repository && wt.branch_name == branch)
-            .ok_or_else(|| McpError::invalid_params(
-                format!("repository='{}', branch='{}' に一致するワークツリーが存在しません", repository, branch),
-                None,
-            ))?;
+        let wt = resolve_artifact_worktree(
+            &settings,
+            target_worktree_id.as_deref(),
+            project_dir.as_deref(),
+            repository.as_deref(),
+            branch.as_deref(),
+        )?;
         let worktree_id = wt.id.clone();
 
         // artifact ID のパストラバーサル防止
@@ -1287,26 +1296,26 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "アーティファクトを検索する。queryを省略すると全件返却。title/content/type/languageを対象に部分一致検索。結果はcontentを除いたメタデータのみ", annotations(read_only_hint = true))]
+    #[tool(description = "アーティファクトを検索する。queryを省略すると全件返却。title/content/type/languageを対象に部分一致検索。結果はcontentを除いたメタデータのみ。検索対象は project_dir(現在の作業ディレクトリ)で指定するのが最も確実。HOMEタブやリポジトリルートで作業している場合は project_dir が必須", annotations(read_only_hint = true))]
     async fn search_artifact(
         &self,
-        Parameters(SearchArtifactParams { repository, branch, query }): Parameters<SearchArtifactParams>,
+        Parameters(SearchArtifactParams {
+            project_dir,
+            worktree_id: target_worktree_id,
+            repository,
+            branch,
+            query,
+        }): Parameters<SearchArtifactParams>,
     ) -> Result<CallToolResult, McpError> {
         let settings_manager = self.app_handle.state::<SettingsManager>();
         let settings = settings_manager.get();
-        let wt = settings
-            .worktrees
-            .iter()
-            .find(|wt| wt.repository_name == repository && wt.branch_name == branch)
-            .ok_or_else(|| {
-                McpError::invalid_params(
-                    format!(
-                        "repository='{}', branch='{}' に一致するワークツリーが存在しません",
-                        repository, branch
-                    ),
-                    None,
-                )
-            })?;
+        let wt = resolve_artifact_worktree(
+            &settings,
+            target_worktree_id.as_deref(),
+            project_dir.as_deref(),
+            repository.as_deref(),
+            branch.as_deref(),
+        )?;
         let worktree_id = wt.id.clone();
 
         let artifacts_dir = self
@@ -1803,6 +1812,75 @@ fn resolve_worktree_by_dir<'a>(settings: &'a AppSettings, dir: &str) -> Option<&
         .worktrees
         .iter()
         .find(|w| normalize_path_for_match(&w.path) == target)
+}
+
+/// artifact 系ツール（artifact / artifact_module / search_artifact）の保存先ワークツリーを解決する。
+/// 優先順位: worktree_id > project_dir 逆引き > repository + branch。
+/// HOME / リポジトリ擬似ワークツリーは repository_name / branch_name が空なので
+/// repository+branch では当たらない。project_dir(= エージェントの cwd) で解決させる。
+fn resolve_artifact_worktree<'a>(
+    settings: &'a AppSettings,
+    worktree_id: Option<&str>,
+    project_dir: Option<&str>,
+    repository: Option<&str>,
+    branch: Option<&str>,
+) -> Result<&'a WorktreeEntry, McpError> {
+    let available = || -> String {
+        settings
+            .worktrees
+            .iter()
+            .map(|w| w.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    if let Some(id) = worktree_id.map(str::trim).filter(|s| !s.is_empty()) {
+        return settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
+            McpError::invalid_params(format!("worktree id '{}' が存在しません", id), None)
+        });
+    }
+
+    if let Some(dir) = project_dir.map(str::trim).filter(|s| !s.is_empty()) {
+        return resolve_worktree_by_dir(settings, dir).ok_or_else(|| {
+            McpError::invalid_params(
+                format!(
+                    "project_dir '{}' に一致するワークツリーが存在しません。available: [{}]",
+                    dir,
+                    available()
+                ),
+                None,
+            )
+        });
+    }
+
+    let repository = repository.map(str::trim).filter(|s| !s.is_empty());
+    let branch = branch.map(str::trim).filter(|s| !s.is_empty());
+    match (repository, branch) {
+        (Some(repository), Some(branch)) => settings
+            .worktrees
+            .iter()
+            .find(|wt| wt.repository_name == repository && wt.branch_name == branch)
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    format!(
+                        "repository='{}', branch='{}' に一致するワークツリーが存在しません。HOMEタブやリポジトリルートで作業している場合は project_dir を指定してください",
+                        repository, branch
+                    ),
+                    None,
+                )
+            }),
+        (None, None) => Err(McpError::invalid_params(
+            format!(
+                "project_dir / worktree_id / repository+branch のいずれかを指定してください。available: [{}]",
+                available()
+            ),
+            None,
+        )),
+        _ => Err(McpError::invalid_params(
+            "repository と branch は両方セットで指定してください（片方のみでは解決できません）。作業ディレクトリが分かる場合は project_dir を指定してください",
+            None,
+        )),
+    }
 }
 
 /// ワークツリーの所属ワークグループを解決する。workgroup_id が未設定/不明な場合は


### PR DESCRIPTION
## 背景

HOME タブ（および リポジトリ擬似ワークツリー）でエージェントを動かしていると、アーティファクトを一切作成できなかった。

原因は MCP の artifact 系3ツールが、保存先ワークツリーを **`repositoryName` + `branchName` の完全一致でしか解決していない**こと。HOME 擬似ワークツリーは `repositoryName: ""` / `branchName: ""`（`src/utils/homeWorktree.ts`）なので、この検索に当たる術が実質なかった。加えて HOME の cwd は `worktreeBaseDir`（git ワークツリーではない）ため、skill が指示する `git branch --show-current` も失敗する。

表示側は既に対応済み（`App.vue` が home を含む全ワークツリーに `list_artifacts` を発行し、ホームカードにバッジが出てビューアが開く）で、**書き込み経路だけが欠けていた**。

## 変更内容

### `src-tauri/src/mcp_server.rs`

- `resolve_artifact_worktree()` を新設。解決優先順位は `worktree_id` > `project_dir` 逆引き（既存の `resolve_worktree_by_dir` を再利用）> `repository`+`branch`。これは `oretachi_set_description` が既に採っている解決パターンの踏襲。
- `ArtifactParams` / `SearchArtifactParams` / `ArtifactModuleParams` の `repository`/`branch` を `Option<String>` にし、`project_dir` / `worktree_id` を追加。
- 3ツールに重複していた完全一致検索ブロックを新ヘルパ呼び出しに統一。保存パス組み立て・`ARTIFACT_WRITE_LOCK`・`write_artifact_atomic`・`artifact-changed` emit・`report_db` 記録は未変更。
- `isHome` による拒否は入れていない（artifact は HOME でも正当な保存先）。

### `src-tauri/skills/{wireframe,presentation,domain-model-diagram}/SKILL.md`

`--repo`/`--branch` を任意扱いに落とし、既定を「`project_dir` を渡して解決させる」に変更。`git branch --show-current` は `--repo` のみ指定時のフォールバックに格下げ。

### フロントエンド

`artifactCounts` / `artifact-changed` 購読 / ビューア起動はすべて `worktreeId` ベースで home を既にカバーしているため無変更。

## 挙動変更（意図あり）

旧実装では `repository: ""`, `branch: ""` を渡せば偶然 HOME に当たっていたが、新実装は空文字をトリムして未指定扱いにするためエラーになる（`project_dir` を使う想定）。

## 検証

- `cargo check` — 通過
- `pnpm run type-check` — 通過

未実施（実機、再ビルド＆再起動が必要）:
- HOME タブのセッションから `artifact` を `project_dir: <worktreeBaseDir>` で create → `%LOCALAPPDATA%\com.ia.oretachi\artifacts\home\<id>.json` 生成 → ホームカードにバッジ → ビューア（ラベル `artifact-home`）が開く
- 通常ワークツリーでの `repository`+`branch` 後方互換（create/update/get/outline/search、`artifact_module` 各コマンド）
- `/oretachi:wireframe <id>` を HOME タブから `--repo`/`--branch` なしで完走

🤖 Generated with [Claude Code](https://claude.com/claude-code)
