### PR TITLE
feat(artifact): URL 型アーティファクトを追加

### DIFF
--- a/src-tauri/src/artifact_url.rs
+++ b/src-tauri/src/artifact_url.rs
@@ -1,0 +1,667 @@
+//! URL アーティファクト (`text/uri-list`) の抽出・正規化・登録。
+//!
+//! Claude Code のライフサイクルフック (PreToolUse / PostToolUse) が `/notify` に運んでくる
+//! hook JSON から URL を拾い、ワークツリーのアーティファクトとして登録する。
+//! 保存形式は他のアーティファクトと同じ `artifacts/<worktreeId>/<id>.json`。
+
+use std::path::PathBuf;
+
+use tauri::{AppHandle, Emitter, Manager};
+
+/// URL アーティファクトの content_type。フロント側の定数は
+/// `src/types/artifact.ts` の `URL_ARTIFACT_CONTENT_TYPE` と対応する。
+pub const URL_ARTIFACT_CONTENT_TYPE: &str = "text/uri-list";
+
+/// URL 末尾に紛れ込みやすい区切り文字。Markdown の `(...)` や JSON の `"` を落とす。
+const TRAILING_TRIM: &[char] = &['.', ',', ';', ':', '!', '?', ')', ']', '}', '\'', '"', '<', '>', '\\'];
+
+/// テキスト中の http(s) URL を出現順に抽出する（重複は除去）。
+pub fn extract_urls(text: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let rest = &text[i..];
+        let scheme_len = if rest.starts_with("https://") {
+            8
+        } else if rest.starts_with("http://") {
+            7
+        } else {
+            // 次のバイト境界へ進む
+            i += 1;
+            while i < bytes.len() && !text.is_char_boundary(i) {
+                i += 1;
+            }
+            continue;
+        };
+
+        let end = rest
+            .find(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == '`' || c == '<' || c == '>')
+            .unwrap_or(rest.len());
+        let raw = &rest[..end];
+        let trimmed = raw.trim_end_matches(TRAILING_TRIM);
+        // スキーマだけ（ホスト無し）は URL とみなさない
+        if trimmed.len() > scheme_len {
+            let normalized = normalize_url(trimmed);
+            if !out.contains(&normalized) {
+                out.push(normalized);
+            }
+        }
+        i += end.max(1);
+    }
+    out
+}
+
+/// 重複判定に使う正規化。末尾スラッシュを落とすだけの控えめな正規化に留める
+/// （クエリやフラグメントは意味を持ちうるので保持する）。
+pub fn normalize_url(url: &str) -> String {
+    let t = url.trim();
+    let t = t.trim_end_matches('/');
+    t.to_string()
+}
+
+/// git remote URL / GitHub の web URL から `owner/repo` を取り出す。
+/// 対応形式: `git@github.com:o/r.git`, `ssh://git@github.com/o/r.git`,
+/// `https://github.com/o/r(.git)`, `https://github.com/o/r/issues/1`
+pub fn parse_github_owner_repo(url: &str) -> Option<(String, String)> {
+    let s = url.trim();
+    // scp 形式: [user@]host:owner/repo
+    let path = if let Some(rest) = s.strip_prefix("git@") {
+        let (host, p) = rest.split_once(':')?;
+        if !host.eq_ignore_ascii_case("github.com") {
+            return None;
+        }
+        p.to_string()
+    } else {
+        let after_scheme = s
+            .strip_prefix("https://")
+            .or_else(|| s.strip_prefix("http://"))
+            .or_else(|| s.strip_prefix("ssh://"))
+            .or_else(|| s.strip_prefix("git://"))?;
+        // authority を先に切り出す。パス側に '@' があっても authority と誤認しないよう、
+        // 認証情報の除去は authority の中だけで行う。
+        let (authority, p) = after_scheme.split_once('/')?;
+        let host = authority.rsplit_once('@').map_or(authority, |(_, r)| r);
+        // ポート付きホストも許容
+        let host = host.split(':').next().unwrap_or(host);
+        if !host.eq_ignore_ascii_case("github.com") {
+            return None;
+        }
+        p.to_string()
+    };
+
+    let mut parts = path.split('/').filter(|s| !s.is_empty());
+    let owner = parts.next()?;
+    let repo = parts.next()?.trim_end_matches(".git");
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_ascii_lowercase(), repo.to_ascii_lowercase()))
+}
+
+/// GitHub の issue / PR URL を `(owner, repo, number)` に分解する。
+pub fn parse_github_issue_or_pr(url: &str) -> Option<(String, String, u64)> {
+    let after_scheme = url
+        .trim()
+        .strip_prefix("https://")
+        .or_else(|| url.trim().strip_prefix("http://"))?;
+    let (host, path) = after_scheme.split_once('/')?;
+    if !host.eq_ignore_ascii_case("github.com") {
+        return None;
+    }
+    let mut parts = path.split('/').filter(|s| !s.is_empty());
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    let kind = parts.next()?;
+    if kind != "issues" && kind != "pull" {
+        return None;
+    }
+    // `/issues/113#issuecomment-1` や `/issues/113?x=1` のようにクエリ・フラグメントが
+    // 付いていても番号を取り出せるようにする
+    let number_part = parts.next()?;
+    let number_part = number_part.split(['#', '?']).next().unwrap_or(number_part);
+    let number: u64 = number_part.parse().ok()?;
+    Some((owner.to_ascii_lowercase(), repo.to_ascii_lowercase(), number))
+}
+
+/// アーティファクトのタイトル。GitHub の issue/PR は `owner/repo#123`、
+/// それ以外は URL をそのまま使う。
+pub fn derive_title(url: &str) -> String {
+    match parse_github_issue_or_pr(url) {
+        Some((owner, repo, number)) => format!("{}/{}#{}", owner, repo, number),
+        None => url.to_string(),
+    }
+}
+
+/// 正規化 URL から決定的なアーティファクト ID を作る。
+/// 同じ URL は必ず同じ ID になるため、ファイル存在チェックだけで重複登録を防げる。
+pub fn artifact_id_for(url: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(normalize_url(url).as_bytes());
+    let hex: String = digest.iter().take(8).map(|b| format!("{:02x}", b)).collect();
+    format!("url-{}", hex)
+}
+
+fn artifacts_dir(app: &AppHandle, worktree_id: &str) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("artifacts")
+        .join(worktree_id))
+}
+
+/// 同じ URL の `text/uri-list` アーティファクトが既にあるか。
+///
+/// ID だけの判定では不十分。MCP の `artifact` ツールは任意 ID でアーティファクトを
+/// 作れるため、同じ URL が別 ID（例 `issue-113`）で先に登録されていることがある。
+/// issue #113 の「URL が重複する時は登録をスキップする」を満たすには内容で突き合わせる。
+fn url_already_registered(dir: &std::path::Path, url: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        if val.get("type").and_then(|v| v.as_str()) != Some(URL_ARTIFACT_CONTENT_TYPE) {
+            continue;
+        }
+        let existing = val
+            .get("content")
+            .and_then(|v| v.as_str())
+            .map(|c| normalize_url(c.lines().next().unwrap_or("")))
+            .unwrap_or_default();
+        if existing == url {
+            return true;
+        }
+    }
+    false
+}
+
+/// URL アーティファクトを登録する。既に同じ URL が登録済みなら何もせず `false` を返す。
+pub async fn register_url_artifact(
+    app: &AppHandle,
+    worktree_id: &str,
+    url: &str,
+) -> Result<bool, String> {
+    let url = normalize_url(url);
+    let id = artifact_id_for(&url);
+    let dir = artifacts_dir(app, worktree_id)?;
+    let path = dir.join(format!("{}.json", id));
+
+    // ロック取得前の早期判定（大半のケースはここで抜ける）
+    if path.exists() {
+        return Ok(false);
+    }
+
+    let _guard = crate::mcp_server::ARTIFACT_WRITE_LOCK.lock().await;
+    // ID 一致に加えて内容一致も見る。ロック取得待ちの間に他スレッドが書いた場合も
+    // ここで拾えるため、path.exists() の再チェックは不要。
+    {
+        let dir = dir.clone();
+        let url = url.clone();
+        let exists = tokio::task::spawn_blocking(move || url_already_registered(&dir, &url))
+            .await
+            .map_err(|e| e.to_string())?;
+        if exists {
+            return Ok(false);
+        }
+    }
+
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let json = serde_json::to_string_pretty(&serde_json::json!({
+        "id": id,
+        "type": URL_ARTIFACT_CONTENT_TYPE,
+        "title": derive_title(&url),
+        "content": url,
+        "created_at": now,
+        "updated_at": now,
+    }))
+    .map_err(|e| e.to_string())?;
+
+    crate::mcp_server::write_artifact_atomic(&path, &json)
+        .await
+        .map_err(|e| e.to_string())?;
+    drop(_guard);
+
+    log::info!("[url-artifact] registered id={} worktree_id={} url={}", id, worktree_id, url);
+
+    // autoOpen: false — フックによる自動登録は副作用なので、AI が明示的に作った
+    // アーティファクトと違いビューアウィンドウを開いてユーザーの作業に割り込まない。
+    if let Err(e) = app.emit(
+        "artifact-changed",
+        serde_json::json!({
+            "worktreeId": worktree_id,
+            "artifactId": id,
+            "command": "create",
+            "autoOpen": false,
+        }),
+    ) {
+        log::warn!("Failed to emit artifact-changed: {}", e);
+    }
+    if let Some(pool) = app.try_state::<crate::report_db::ReportPool>() {
+        let _ = crate::report_db::insert(&pool.inner().0, "artifact_change:create", &id).await;
+    }
+
+    Ok(true)
+}
+
+// ─── フック (PreToolUse / PostToolUse) からの自動登録 ─────────────────────────
+
+/// フック処理に必要なワークツリー情報。`AppSettings` の借用を跨いで
+/// `tokio::spawn` へ渡すため値でコピーして持つ。
+#[derive(Debug, Clone)]
+pub struct HookWorktree {
+    pub id: String,
+    pub repository_name: String,
+    pub branch_name: String,
+    pub path: String,
+}
+
+/// 直近何件のタスクを URL 突合の対象にするか。
+const TASK_PROMPT_SCAN_LIMIT: i64 = 200;
+
+/// タスクプロンプト URL キャッシュの有効期間。
+/// PreToolUse は「http を含む全ツール呼び出し」で走るため、毎回 tasks.db を
+/// 200 件走査すると無駄が大きい。タスクの追加は稀なので短い TTL で十分。
+const PROMPT_URL_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+type PromptUrlCache =
+    std::collections::HashMap<String, (std::time::Instant, std::collections::HashSet<String>)>;
+
+/// `"<repository>\0<branch>"` → (取得時刻, プロンプト中の URL 集合)
+static PROMPT_URL_CACHE: std::sync::Mutex<Option<PromptUrlCache>> = std::sync::Mutex::new(None);
+
+fn cached_prompt_urls(key: &str) -> Option<std::collections::HashSet<String>> {
+    let guard = PROMPT_URL_CACHE.lock().ok()?;
+    let (fetched_at, urls) = guard.as_ref()?.get(key)?;
+    if fetched_at.elapsed() > PROMPT_URL_CACHE_TTL {
+        return None;
+    }
+    Some(urls.clone())
+}
+
+fn store_prompt_urls(key: &str, urls: &std::collections::HashSet<String>) {
+    if let Ok(mut guard) = PROMPT_URL_CACHE.lock() {
+        guard
+            .get_or_insert_with(Default::default)
+            .insert(key.to_string(), (std::time::Instant::now(), urls.clone()));
+    }
+}
+
+/// JSON 値に含まれる文字列リーフを再帰的に集める。
+///
+/// `Value::to_string()` を直接 `extract_urls` に渡すと、改行が `\n` という
+/// 2 文字のエスケープ列として URL の直後に残り、URL の末尾に混入する
+/// （`gh issue create` の stdout がまさにこの形）。エスケープを解いた
+/// 生の文字列単位で走査するために使う。
+fn collect_strings(value: &serde_json::Value, out: &mut Vec<String>) {
+    match value {
+        serde_json::Value::String(s) => out.push(s.clone()),
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                collect_strings(v, out);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for v in map.values() {
+                collect_strings(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// JSON 値に含まれる全文字列から URL を抽出する（重複は除去）。
+fn extract_urls_from_json(value: &serde_json::Value) -> Vec<String> {
+    let mut strings = Vec::new();
+    collect_strings(value, &mut strings);
+    let mut out: Vec<String> = Vec::new();
+    for s in strings {
+        for url in extract_urls(&s) {
+            if !out.contains(&url) {
+                out.push(url);
+            }
+        }
+    }
+    out
+}
+
+/// Claude Code のツールフック JSON を見て、条件に一致する URL を自動登録する。
+/// `/notify` から `tokio::spawn` で呼ばれる（通知パスをブロックしない）。
+pub async fn handle_tool_hook(app: AppHandle, wt: HookWorktree, event: String, body: String) {
+    let Ok(hook) = serde_json::from_str::<serde_json::Value>(&body) else {
+        return;
+    };
+    match event.as_str() {
+        "PreToolUse" => handle_pre_tool_use(&app, &wt, &hook).await,
+        "PostToolUse" => handle_post_tool_use(&app, &wt, &hook).await,
+        _ => {}
+    }
+}
+
+/// issue を開く: ツール入力に現れた URL が、このワークツリー宛タスクの
+/// プロンプトに含まれる URL と一致する時だけ登録する。
+async fn handle_pre_tool_use(app: &AppHandle, wt: &HookWorktree, hook: &serde_json::Value) {
+    let Some(tool_input) = hook.get("tool_input") else {
+        return;
+    };
+    let urls = extract_urls_from_json(tool_input);
+    if urls.is_empty() {
+        return;
+    }
+
+    let cache_key = format!("{}\0{}", wt.repository_name, wt.branch_name);
+    let prompt_urls = match cached_prompt_urls(&cache_key) {
+        Some(urls) => urls,
+        None => {
+            let Some(pool) = app.try_state::<crate::task_db::TaskPool>() else {
+                return;
+            };
+            let prompts = match crate::task_db::list_prompts_for_worktree(
+                &pool.inner().0,
+                &wt.repository_name,
+                &wt.branch_name,
+                TASK_PROMPT_SCAN_LIMIT,
+            )
+            .await
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    log::warn!("[url-artifact] failed to load task prompts: {}", e);
+                    return;
+                }
+            };
+            let urls: std::collections::HashSet<String> =
+                prompts.iter().flat_map(|p| extract_urls(p)).collect();
+            store_prompt_urls(&cache_key, &urls);
+            urls
+        }
+    };
+    if prompt_urls.is_empty() {
+        return;
+    }
+
+    for url in urls.into_iter().filter(|u| prompt_urls.contains(u)) {
+        if let Err(e) = register_url_artifact(app, &wt.id, &url).await {
+            log::warn!("[url-artifact] register failed url={} error={}", url, e);
+        }
+    }
+}
+
+/// issue / PR を作成する: `gh issue create` / `gh pr create` の出力に現れた
+/// GitHub URL が、このワークツリーのリポジトリと一致する時だけ登録する。
+async fn handle_post_tool_use(app: &AppHandle, wt: &HookWorktree, hook: &serde_json::Value) {
+    if hook.get("tool_name").and_then(|v| v.as_str()) != Some("Bash") {
+        return;
+    }
+    let command = hook
+        .get("tool_input")
+        .and_then(|v| v.get("command"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    if !is_gh_create_command(command) {
+        return;
+    }
+    let Some(response) = hook.get("tool_response") else {
+        return;
+    };
+
+    let candidates: Vec<(String, String, String)> = extract_urls_from_json(response)
+        .into_iter()
+        .filter_map(|url| {
+            parse_github_issue_or_pr(&url).map(|(owner, repo, _)| (url, owner, repo))
+        })
+        .collect();
+    if candidates.is_empty() {
+        return;
+    }
+
+    let repo_path = wt.path.clone();
+    let remotes = match tokio::task::spawn_blocking(move || {
+        crate::git_worktree::get_git_remotes(&repo_path)
+    })
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!("[url-artifact] failed to read git remotes: {}", e);
+            return;
+        }
+    };
+    let owned: std::collections::HashSet<(String, String)> = remotes
+        .iter()
+        .filter_map(|r| r.get("url").and_then(|v| v.as_str()))
+        .filter_map(parse_github_owner_repo)
+        .collect();
+    if owned.is_empty() {
+        return;
+    }
+
+    for (url, owner, repo) in candidates {
+        if !owned.contains(&(owner, repo)) {
+            continue;
+        }
+        if let Err(e) = register_url_artifact(app, &wt.id, &url).await {
+            log::warn!("[url-artifact] register failed url={} error={}", url, e);
+        }
+    }
+}
+
+/// `gh issue create` / `gh pr create` を含むシェルコマンドか。
+/// `cd x && gh pr create ...` のような連結にも当たるよう部分一致で見る。
+pub fn is_gh_create_command(command: &str) -> bool {
+    let normalized = command.split_whitespace().collect::<Vec<_>>().join(" ");
+    normalized.contains("gh issue create") || normalized.contains("gh pr create")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_urls_picks_http_and_https() {
+        let text = r#"see https://github.com/o/r/issues/1 and http://example.com/a."#;
+        assert_eq!(
+            extract_urls(text),
+            vec![
+                "https://github.com/o/r/issues/1".to_string(),
+                "http://example.com/a".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_urls_strips_json_quotes_and_dedupes() {
+        let text = r#"{"command":"gh issue view https://github.com/o/r/issues/7","x":"https://github.com/o/r/issues/7/"}"#;
+        assert_eq!(
+            extract_urls(text),
+            vec!["https://github.com/o/r/issues/7".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_urls_ignores_bare_scheme() {
+        assert!(extract_urls("https:// and http://").is_empty());
+    }
+
+    #[test]
+    fn extract_urls_handles_multibyte_text() {
+        let text = "日本語の説明 https://github.com/o/r/pull/12 を参照";
+        assert_eq!(
+            extract_urls(text),
+            vec!["https://github.com/o/r/pull/12".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_github_owner_repo_scp_form() {
+        assert_eq!(
+            parse_github_owner_repo("git@github.com:Ishida-Supsys/Oretachi.git"),
+            Some(("ishida-supsys".to_string(), "oretachi".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_github_owner_repo_https_form() {
+        assert_eq!(
+            parse_github_owner_repo("https://github.com/o/r.git"),
+            Some(("o".to_string(), "r".to_string()))
+        );
+        assert_eq!(
+            parse_github_owner_repo("https://user:token@github.com/o/r"),
+            Some(("o".to_string(), "r".to_string()))
+        );
+        assert_eq!(
+            parse_github_owner_repo("ssh://git@github.com/o/r.git"),
+            Some(("o".to_string(), "r".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_github_owner_repo_rejects_other_hosts() {
+        assert_eq!(parse_github_owner_repo("git@gitlab.com:o/r.git"), None);
+        assert_eq!(parse_github_owner_repo("https://example.com/o/r"), None);
+    }
+
+    #[test]
+    fn parse_github_issue_or_pr_works() {
+        assert_eq!(
+            parse_github_issue_or_pr("https://github.com/o/r/issues/113"),
+            Some(("o".to_string(), "r".to_string(), 113))
+        );
+        assert_eq!(
+            parse_github_issue_or_pr("https://github.com/o/r/pull/9"),
+            Some(("o".to_string(), "r".to_string(), 9))
+        );
+        assert_eq!(parse_github_issue_or_pr("https://github.com/o/r"), None);
+    }
+
+    #[test]
+    fn parse_github_issue_or_pr_tolerates_query_and_fragment() {
+        assert_eq!(
+            parse_github_issue_or_pr("https://github.com/o/r/issues/113#issuecomment-1"),
+            Some(("o".to_string(), "r".to_string(), 113))
+        );
+        assert_eq!(
+            parse_github_issue_or_pr("https://github.com/o/r/pull/9?w=1"),
+            Some(("o".to_string(), "r".to_string(), 9))
+        );
+    }
+
+    #[test]
+    fn parse_github_owner_repo_ignores_at_in_path() {
+        // '@' がパス側にあるだけの他ホスト URL を github.com と誤認しない
+        assert_eq!(
+            parse_github_owner_repo("https://evil.com/p@github.com/o/r"),
+            None
+        );
+    }
+
+    #[test]
+    fn url_already_registered_matches_by_content_not_id() {
+        let dir = std::env::temp_dir().join(format!("oretachi-url-artifact-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // MCP の artifact ツールで付けられた任意 ID。ハッシュ ID とは一致しない。
+        std::fs::write(
+            dir.join("issue-113.json"),
+            r#"{"id":"issue-113","type":"text/uri-list","title":"x","content":"https://github.com/o/r/issues/113"}"#,
+        )
+        .unwrap();
+
+        assert!(url_already_registered(&dir, "https://github.com/o/r/issues/113"));
+        // 末尾スラッシュ違いも正規化して同一とみなす
+        assert!(url_already_registered(
+            &dir,
+            &normalize_url("https://github.com/o/r/issues/113/")
+        ));
+        assert!(!url_already_registered(&dir, "https://github.com/o/r/issues/114"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn url_already_registered_ignores_other_content_types() {
+        let dir = std::env::temp_dir()
+            .join(format!("oretachi-url-artifact-other-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("doc.json"),
+            r#"{"id":"doc","type":"text/markdown","title":"x","content":"https://github.com/o/r/issues/113"}"#,
+        )
+        .unwrap();
+
+        assert!(!url_already_registered(&dir, "https://github.com/o/r/issues/113"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn derive_title_formats_issue() {
+        assert_eq!(derive_title("https://github.com/o/r/issues/113"), "o/r#113");
+        assert_eq!(derive_title("https://example.com/x"), "https://example.com/x");
+    }
+
+    #[test]
+    fn extract_urls_from_json_unescapes_before_scanning() {
+        // gh の stdout は末尾に改行が付く。JSON を to_string() してから走査すると
+        // エスケープ列 "\n" が URL に食い込むため、文字列リーフ単位で走査する。
+        let response: serde_json::Value = serde_json::from_str(
+            r#"{"stdout":"https://github.com/o/r/issues/5\n","stderr":"","interrupted":false}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            extract_urls_from_json(&response),
+            vec!["https://github.com/o/r/issues/5".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_urls_from_json_walks_nested_values() {
+        let input: serde_json::Value = serde_json::from_str(
+            r#"{"a":{"b":["https://e.com/1"]},"c":"https://e.com/2","d":1}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            extract_urls_from_json(&input),
+            vec!["https://e.com/1".to_string(), "https://e.com/2".to_string()]
+        );
+    }
+
+    #[test]
+    fn is_gh_create_command_matches_variants() {
+        assert!(is_gh_create_command("gh issue create --title x"));
+        assert!(is_gh_create_command("cd /repo && gh pr create --fill"));
+        assert!(is_gh_create_command("gh  pr   create"));
+        assert!(!is_gh_create_command("gh issue view 113"));
+        assert!(!is_gh_create_command("gh pr list"));
+    }
+
+    #[test]
+    fn artifact_id_is_stable_and_normalized() {
+        let a = artifact_id_for("https://github.com/o/r/issues/1");
+        let b = artifact_id_for("https://github.com/o/r/issues/1/");
+        assert_eq!(a, b);
+        assert!(a.starts_with("url-"));
+        assert_ne!(a, artifact_id_for("https://github.com/o/r/issues/2"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod ai_description;
 mod ai_judge;
 mod ai_provider;
 mod archive_db;
+mod artifact_url;
 mod claude_plugin;
 mod claude_plugin_skills;
 mod fs_watcher;
@@ -730,6 +731,8 @@ fn resolve_worktree_repository(
 
 /// リポジトリのアーティファクト一覧を返す。
 /// 一覧・件数バッジ用途のため content / modules は落としてメタのみ返す。
+/// 例外は URL アーティファクト（`text/uri-list`）で、content が URL 1 行しかなく
+/// アイコン隣のドロップダウンがこの値を必要とするため落とさない。
 #[tauri::command]
 async fn list_repo_artifacts(
     app_handle: tauri::AppHandle,
@@ -764,7 +767,11 @@ async fn list_repo_artifacts(
                 }
             };
             if let Some(obj) = val.as_object_mut() {
-                obj.remove("content");
+                let is_url_artifact = obj.get("type").and_then(|v| v.as_str())
+                    == Some(artifact_url::URL_ARTIFACT_CONTENT_TYPE);
+                if !is_url_artifact {
+                    obj.remove("content");
+                }
                 obj.remove("modules");
             }
             artifacts.push(val);

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -24,7 +24,7 @@ use crate::settings::{AppSettings, SettingsManager, Workgroup, WorktreeEntry};
 /// これらのツールは read_only_hint = true を宣言しているため Claude Code 側が
 /// isConcurrencySafe = true とみなし、同一アーティファクトに対して並列に呼び出しうる。
 /// NotifyService は接続ごとに生成されるためプロセス共有の static で持つ。
-static ARTIFACT_WRITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+pub(crate) static ARTIFACT_WRITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// 一時ファイル名の衝突を避けるための連番。
 static ARTIFACT_TMP_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -36,7 +36,10 @@ static ARTIFACT_TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 /// Claude Code が読み書きを並列実行しうるため、一時ファイル + rename にする。
 /// rename は同一ディレクトリ内なら Windows/Unix ともに既存ファイルを置換する。
 /// 一時ファイルの拡張子は `.json` にならないため search_artifact の走査対象外。
-async fn write_artifact_atomic(path: &std::path::Path, contents: &str) -> Result<(), McpError> {
+pub(crate) async fn write_artifact_atomic(
+    path: &std::path::Path,
+    contents: &str,
+) -> Result<(), McpError> {
     let seq = ARTIFACT_TMP_SEQ.fetch_add(1, Ordering::Relaxed);
     let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
     tmp_name.push(format!(".tmp-{}-{}", std::process::id(), seq));
@@ -389,7 +392,7 @@ pub struct ArtifactParams {
     pub repository: String,
     #[schemars(description = "ブランチ名")]
     pub branch: String,
-    #[schemars(description = "コンテンツの種類 (create時必須): application/vnd.ant.code, text/markdown, text/html, image/svg+xml, application/vnd.ant.mermaid, application/vnd.ant.react (Tailwind CSSユーティリティクラス利用可), text/csv, text/tab-separated-values (1行目をヘッダとするテーブルビューアで表示)")]
+    #[schemars(description = "コンテンツの種類 (create時必須): application/vnd.ant.code, text/markdown, text/html, image/svg+xml, application/vnd.ant.mermaid, application/vnd.ant.react (Tailwind CSSユーティリティクラス利用可), text/csv, text/tab-separated-values (1行目をヘッダとするテーブルビューアで表示), text/uri-list (content に URL を1行だけ書く。ビューアには「ブラウザで開く」ボタンだけが出る)")]
     #[serde(rename = "type")]
     pub content_type: Option<String>,
     #[schemars(description = "アーティファクトのタイトル (create時必須)")]
@@ -1873,6 +1876,28 @@ async fn notify_handler(
             }
         },
     };
+
+    // URL アーティファクトの自動登録。通知フックの設定有無とは独立に動かしたいので、
+    // 通知フック未設定リポジトリの早期 return より前に処理する。
+    // ツール呼び出しごとに走るため "http" を含まない body は即スキップし、
+    // 実処理は spawn へ逃がして通知パス（サイドカーの read timeout 500ms）を塞がない。
+    if let (Some(w), Some(ev), Some(body)) = (worktree, payload.event.as_deref(), payload.body.as_deref())
+    {
+        if matches!(ev, "PreToolUse" | "PostToolUse") && body.contains("http") {
+            let hook_wt = crate::artifact_url::HookWorktree {
+                id: w.id.clone(),
+                repository_name: w.repository_name.clone(),
+                branch_name: w.branch_name.clone(),
+                path: w.path.clone(),
+            };
+            let handle = app_handle.clone();
+            let event_name = ev.to_string();
+            let body_owned = body.to_string();
+            tokio::spawn(async move {
+                crate::artifact_url::handle_tool_hook(handle, hook_wt, event_name, body_owned).await;
+            });
+        }
+    }
 
     // ライフサイクルフック由来（event 指定・kind 明示なし）の通知は、通知フックが1件も
     // 設定されていないリポジトリでは破棄する。プラグインは全ワークツリーで無条件有効化される

--- a/src-tauri/src/task_db.rs
+++ b/src-tauri/src/task_db.rs
@@ -110,6 +110,47 @@ pub async fn list(
     Ok(TaskListResult { items: rows, has_more })
 }
 
+/// 指定ワークツリー（repository + branch）宛のステップを含むタスクのプロンプトを新しい順に返す。
+///
+/// `tasks` テーブルはワークツリー ID を持たず、`steps` JSON の `code.repository` /
+/// `code.branch` でしか紐付かない（`src/types/task.ts` の `TaskStep`）。SQL では表現しづらいので
+/// 直近 `LIMIT` 件を取り出して Rust 側で突合する。
+pub async fn list_prompts_for_worktree(
+    pool: &SqlitePool,
+    repository: &str,
+    branch: &str,
+    limit: i64,
+) -> Result<Vec<String>, String> {
+    let rows: Vec<TaskRow> = sqlx::query_as::<_, TaskRow>(
+        "SELECT * FROM tasks ORDER BY created_at DESC LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(rows
+        .into_iter()
+        .filter(|row| steps_match_worktree(&row.steps, repository, branch))
+        .map(|row| row.prompt)
+        .collect())
+}
+
+/// `steps` JSON に該当ワークツリー宛のステップが含まれるか。
+fn steps_match_worktree(steps_json: &str, repository: &str, branch: &str) -> bool {
+    let Ok(steps) = serde_json::from_str::<serde_json::Value>(steps_json) else {
+        return false;
+    };
+    let Some(arr) = steps.as_array() else {
+        return false;
+    };
+    arr.iter().any(|step| {
+        let code = step.get("code").unwrap_or(step);
+        code.get("repository").and_then(|v| v.as_str()) == Some(repository)
+            && code.get("branch").and_then(|v| v.as_str()) == Some(branch)
+    })
+}
+
 pub async fn delete(pool: &SqlitePool, id: &str) -> Result<(), String> {
     sqlx::query("DELETE FROM tasks WHERE id = ?")
         .bind(id)

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,8 @@ import { useWindowFocus } from "./composables/useWindowFocus";
 import { useTasks } from "./composables/useTasks";
 import type { TrayWorktreeData, TrayTerminalData } from "./composables/useTrayPopup";
 import type { WorktreeEntry } from "./types/settings";
+import type { UrlArtifactEntry } from "./types/artifact";
+import { extractUrlArtifacts } from "./utils/artifactUrl";
 import { useAddTaskDialog } from "./composables/useAddTaskDialog";
 import { useTaskExecution } from "./composables/useTaskExecution";
 import { useWorktreeTaskMap } from "./composables/useWorktreeTaskMap";
@@ -114,6 +116,9 @@ const notificationCounts = computed(() => {
 // ワークツリーごとのアーティファクト数
 const artifactCounts = reactive(new Map<string, number>());
 
+// ワークツリーごとの URL アーティファクト（アイコン隣のドロップダウン用）
+const artifactUrls = reactive(new Map<string, UrlArtifactEntry[]>());
+
 // ホームカードの description 開閉状態（ワークツリー毎・settings.json に永続化）
 const descriptionOpenMap = reactive(new Map<string, boolean>());
 
@@ -135,8 +140,10 @@ async function refreshArtifactCount(worktreeId: string) {
   try {
     const list = await invoke<unknown[]>("list_artifacts", { worktreeId });
     artifactCounts.set(worktreeId, list.length);
+    artifactUrls.set(worktreeId, extractUrlArtifacts(list));
   } catch {
     artifactCounts.set(worktreeId, 0);
+    artifactUrls.set(worktreeId, []);
   }
 }
 
@@ -832,6 +839,7 @@ async function onRemoveRepository(repositoryId: string) {
   worktreeFrameBundles.delete(pseudoId);
   clearNotification(pseudoId);
   artifactCounts.delete(pseudoId);
+  artifactUrls.delete(pseudoId);
   descriptionOpenMap.delete(pseudoId);
   // 擬似ワークツリーの ID は決定論的で再登録時に同じ値になるため、ランタイム状態を
   // 残すと同じリポジトリを登録し直したときに自動承認が無言で復活してしまう
@@ -1584,11 +1592,13 @@ onMounted(async () => {
   });
 
   // アーティファクト変更時の処理
-  await listen<{ worktreeId: string; artifactId: string; command: string }>("artifact-changed", async (event) => {
-    const { worktreeId: wid, command } = event.payload;
+  await listen<{ worktreeId: string; artifactId: string; command: string; autoOpen?: boolean }>("artifact-changed", async (event) => {
+    const { worktreeId: wid, command, autoOpen } = event.payload;
     // アーティファクト数を更新
     refreshArtifactCount(wid);
-    // 追加時に自動でビューアを開く
+    // 追加時に自動でビューアを開く。
+    // フックによる URL 自動登録は作業の副産物なので autoOpen: false で割り込ませない。
+    if (autoOpen === false) return;
     if (command !== "create") return;
     if (settings.value.worktreeDefaults?.autoOpenArtifact === false) return;
     const wt = worktrees.value.find((w) => w.id === wid);
@@ -2000,6 +2010,7 @@ onMounted(async () => {
         :notifications="notificationCounts"
         :hotkey-chars="hotkeyChars"
         :artifact-counts="artifactCounts"
+        :artifact-urls="artifactUrls"
         :loading-worktrees="loadingWorktrees"
         :cancellable-worktrees="cancellableWorktrees"
         :auto-approvals="autoApprovalMap"
@@ -2050,6 +2061,7 @@ onMounted(async () => {
             :branch-name="wt.branchName"
             :hotkey-char="hotkeyChars.get(wt.id)"
             :artifact-count="artifactCounts.get(wt.id) ?? 0"
+            :artifact-urls="artifactUrls.get(wt.id) ?? []"
             :auto-approval="autoApprovalMap.get(wt.id) ?? false"
             :ai-judging="aiJudgingWorktrees.has(wt.id)"
             :is-window-focused="isWindowFocused"

--- a/src/ArtifactViewerApp.vue
+++ b/src/ArtifactViewerApp.vue
@@ -13,7 +13,9 @@ import ArtifactSvgView from "./components/artifact/ArtifactSvgView.vue";
 import ArtifactMermaidView from "./components/artifact/ArtifactMermaidView.vue";
 import ArtifactReactView from "./components/artifact/ArtifactReactView.vue";
 import ArtifactTableView from "./components/artifact/ArtifactTableView.vue";
+import ArtifactUrlView from "./components/artifact/ArtifactUrlView.vue";
 import { isTableContentType } from "./utils/csvArtifact";
+import { URL_ARTIFACT_CONTENT_TYPE } from "./types/artifact";
 import type {
   ArtifactMeta,
   ArtifactData,
@@ -53,6 +55,7 @@ const typeIcons: Record<string, string> = {
   "application/vnd.ant.react": "pi-play",
   "text/csv": "pi-table",
   "text/tab-separated-values": "pi-table",
+  [URL_ARTIFACT_CONTENT_TYPE]: "pi-link",
 };
 
 function typeIcon(contentType: string): string {
@@ -320,6 +323,10 @@ onUnmounted(() => {
             v-else-if="selectedArtifact.content_type === 'application/vnd.ant.react'"
             :content="selectedArtifact.content"
             :modules="selectedArtifact.modules"
+          />
+          <ArtifactUrlView
+            v-else-if="selectedArtifact.content_type === URL_ARTIFACT_CONTENT_TYPE"
+            :content="selectedArtifact.content"
           />
           <ArtifactTableView
             v-else-if="isTableContentType(selectedArtifact.content_type)"

--- a/src/SubWindowApp.vue
+++ b/src/SubWindowApp.vue
@@ -17,6 +17,8 @@ import { runApprovalLoop } from "./utils/autoApproval";
 import type { TerminalForApproval } from "./utils/autoApproval";
 import { useIdeSelect } from "./composables/useIdeSelect";
 import { useArtifactWindow } from "./composables/useArtifactWindow";
+import { extractUrlArtifacts } from "./utils/artifactUrl";
+import type { UrlArtifactEntry } from "./types/artifact";
 import { invoke } from "@tauri-apps/api/core";
 import { logDebug } from "./utils/log";
 import IdeSelectDialog from "./components/IdeSelectDialog.vue";
@@ -69,13 +71,16 @@ const { showIdeDialog, detectedIdes, openInIde, onIdeSelected } = useIdeSelect()
 // アーティファクト
 const { openArtifactViewer } = useArtifactWindow();
 const artifactCount = ref(0);
+const artifactUrls = ref<UrlArtifactEntry[]>([]);
 
 async function refreshArtifactCount() {
   try {
     const list = await invoke<unknown[]>("list_artifacts", { worktreeId });
     artifactCount.value = list.length;
+    artifactUrls.value = extractUrlArtifacts(list);
   } catch {
     artifactCount.value = 0;
+    artifactUrls.value = [];
   }
 }
 
@@ -576,6 +581,7 @@ async function onCancelAiJudging() {
         :branch-name="branchName"
         :hotkey-char="hotkeyChar"
         :artifact-count="artifactCount"
+        :artifact-urls="artifactUrls"
         :auto-approval="autoApproval"
         :ai-judging="aiJudging"
         :is-window-focused="isWindowFocused"

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -11,6 +11,11 @@ import { useSettings } from "./composables/useSettings";
 import { useHotkeyListener } from "./composables/useHotkeys";
 import { useIdeSelect } from "./composables/useIdeSelect";
 import { useArtifactWindow } from "./composables/useArtifactWindow";
+import ArtifactUrlHoverMenu from "./components/ArtifactUrlHoverMenu.vue";
+import ArtifactIcon from "./components/ArtifactIcon.vue";
+import { extractUrlArtifacts } from "./utils/artifactUrl";
+import type { UrlArtifactEntry } from "./types/artifact";
+import { invoke } from "@tauri-apps/api/core";
 import type { TrayWorktreeData } from "./composables/useTrayPopup";
 import { useWorktreeTaskMap } from "./composables/useWorktreeTaskMap";
 import type { FrameNode } from "./types/frame";
@@ -110,6 +115,10 @@ async function applyWindowSize(data: TrayWorktreeData) {
 async function showWorktree(data: TrayWorktreeData) {
   terminalEntries.clear();
   terminalRefs.clear();
+  // 前のワークツリーの URL が残ったままにならないよう先にクリアしてから、
+  // 表示切り替えを待たせないよう取得自体は投げっぱなしにする
+  artifactUrls.value = [];
+  void refreshArtifactUrls(data.worktreeId);
 
   // 情報バー(description)が現在の worktree の内容で描画されてから高さを計測する。
   // currentWorktree (= allWorktrees[currentIndex]) は呼び出し側で更新済みのため nextTick で DOM 反映を待つ。
@@ -197,6 +206,21 @@ const { openArtifactViewer } = useArtifactWindow();
 async function onOpenArtifacts() {
   if (!currentWorktree.value) return;
   await openArtifactViewer(currentWorktree.value.worktreeId, currentWorktree.value.worktreeName);
+}
+
+/** 表示中ワークツリーの URL アーティファクト（アイコン隣のドロップダウン用） */
+const artifactUrls = ref<UrlArtifactEntry[]>([]);
+
+async function refreshArtifactUrls(worktreeId: string) {
+  try {
+    const list = await invoke<unknown[]>("list_artifacts", { worktreeId });
+    // 取得中に別ワークツリーへ切り替わっていたら破棄する（表示中と一覧の不一致を防ぐ）
+    if (currentWorktree.value?.worktreeId !== worktreeId) return;
+    artifactUrls.value = extractUrlArtifacts(list);
+  } catch {
+    if (currentWorktree.value?.worktreeId !== worktreeId) return;
+    artifactUrls.value = [];
+  }
 }
 
 async function onOpenInIde() {
@@ -316,9 +340,16 @@ useHotkeyListener(() => {
 
 let unlistenInit: UnlistenFn | null = null;
 let unlistenSettings: UnlistenFn | null = null;
+let unlistenArtifact: UnlistenFn | null = null;
 
 onMounted(async () => {
   await loadSettings();
+
+  // 表示中ワークツリーにアーティファクトが登録されたら URL 一覧を追従させる
+  unlistenArtifact = await listen<{ worktreeId: string }>("artifact-changed", async (event) => {
+    if (event.payload.worktreeId !== currentWorktree.value?.worktreeId) return;
+    await refreshArtifactUrls(event.payload.worktreeId);
+  });
 
   // トレイ表示中の uiScale / ターミナル設定変更に追従
   unlistenSettings = await listen("settings-changed", async () => {
@@ -355,6 +386,7 @@ onMounted(async () => {
 onUnmounted(() => {
   unlistenInit?.();
   unlistenSettings?.();
+  unlistenArtifact?.();
 });
 </script>
 
@@ -426,14 +458,15 @@ onUnmounted(() => {
         >
           <span class="pi pi-code text-xs" />
         </button>
-        <button
-          v-if="currentWorktree"
-          class="pointer-events-auto w-6 h-6 flex items-center justify-center rounded hover:bg-[#313244] text-[#6c7086] hover:text-[#cdd6f4] transition-colors"
-          :title="t('openArtifacts')"
-          @click="onOpenArtifacts"
-        >
-          <span class="pi pi-box text-xs" />
-        </button>
+        <ArtifactUrlHoverMenu v-if="currentWorktree" :urls="artifactUrls">
+          <button
+            class="pointer-events-auto w-6 h-6 flex items-center justify-center rounded hover:bg-[#313244] text-[#6c7086] hover:text-[#cdd6f4] transition-colors"
+            :title="t('openArtifacts')"
+            @click="onOpenArtifacts"
+          >
+            <ArtifactIcon :has-url="artifactUrls.length > 0" class="text-xs" />
+          </button>
+        </ArtifactUrlHoverMenu>
         <button
           v-if="!isMac"
           class="pointer-events-auto w-6 h-6 flex items-center justify-center rounded hover:bg-[#313244] text-[#6c7086] hover:text-[#f38ba8] transition-colors"

--- a/src/components/ArtifactIcon.vue
+++ b/src/components/ArtifactIcon.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+/**
+ * アーティファクトボタン／バッジのアイコン。
+ * URL アーティファクトを持つ時は、既存のキューブの右下にリンクアイコンを重ねて示す。
+ * 大きさは呼び出し元が font-size で決め、重ねるリンクは em 追従で縮尺する。
+ */
+defineProps<{
+  hasUrl?: boolean;
+}>();
+</script>
+
+<template>
+  <span class="artifact-icon">
+    <span class="pi pi-box artifact-icon-base" />
+    <span v-if="hasUrl" class="pi pi-link artifact-icon-overlay" />
+  </span>
+</template>
+
+<style scoped>
+.artifact-icon {
+  position: relative;
+  display: inline-block;
+  line-height: 1;
+}
+
+/* .pi の font-size: 1rem を打ち消し、呼び出し元の font-size に追従させる */
+.artifact-icon .artifact-icon-base {
+  display: block;
+  font-size: 1em;
+  line-height: 1;
+}
+
+.artifact-icon .artifact-icon-overlay {
+  position: absolute;
+  right: -0.3em;
+  bottom: -0.28em;
+  font-size: 0.72em;
+  line-height: 1;
+  /* キューブの線と重なっても輪郭が潰れないよう暗いハローを敷く。
+     --bg-base は透過ウィンドウで transparent になりハローが消えるため、
+     カタッピチン系の暗色をリテラルで置く */
+  text-shadow:
+    0 0 2px #1e1e2e,
+    0 0 2px #1e1e2e;
+}
+</style>

--- a/src/components/ArtifactUrlHoverMenu.vue
+++ b/src/components/ArtifactUrlHoverMenu.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { onUnmounted, ref } from "vue";
+import Popover from "primevue/popover";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { UrlArtifactEntry } from "../types/artifact";
+
+/**
+ * アーティファクトボタン／バッジをラップし、マウスオーバーで URL 一覧を出す。
+ * ボタン自体の見た目・クリック挙動には手を出さない（クリックは従来どおり
+ * アーティファクトウィンドウを開く）。URL が 0 件なら何も起きない。
+ */
+const props = defineProps<{
+  urls: UrlArtifactEntry[];
+}>();
+
+// ルートが span + Popover の複数ノードなので、class 等は明示的にラッパへ流す
+defineOptions({ inheritAttrs: false });
+
+const wrapperRef = ref<HTMLElement | null>(null);
+const popoverRef = ref<InstanceType<typeof Popover> | null>(null);
+const visible = ref(false);
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+function cancelHide() {
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+}
+
+function showMenu() {
+  if (props.urls.length === 0 || !wrapperRef.value) return;
+  cancelHide();
+  if (visible.value) return;
+  visible.value = true;
+  // Popover.show は event.currentTarget を配置基準にするため、ラッパを渡す
+  popoverRef.value?.show({ currentTarget: wrapperRef.value } as unknown as Event, wrapperRef.value);
+}
+
+function hideNow() {
+  cancelHide();
+  if (!visible.value) return;
+  visible.value = false;
+  popoverRef.value?.hide();
+}
+
+/** ボタン → ポップアップへマウスを移す間に閉じないよう猶予を持たせる */
+function scheduleHide() {
+  cancelHide();
+  hideTimer = setTimeout(hideNow, 180);
+}
+
+onUnmounted(cancelHide);
+
+async function open(entry: UrlArtifactEntry) {
+  hideNow();
+  try {
+    await openUrl(entry.url);
+  } catch (e) {
+    console.error("openUrl failed", e);
+  }
+}
+</script>
+
+<template>
+  <span
+    ref="wrapperRef"
+    v-bind="$attrs"
+    class="url-hover-wrapper"
+    @mouseenter="showMenu"
+    @mouseleave="scheduleHide"
+    @click="hideNow"
+  >
+    <slot />
+  </span>
+  <Popover ref="popoverRef" @hide="visible = false">
+    <div class="url-popup" @mouseenter="cancelHide" @mouseleave="scheduleHide">
+      <button
+        v-for="entry in props.urls"
+        :key="entry.id"
+        class="popup-item"
+        :title="entry.url"
+        @click="open(entry)"
+      >
+        <span class="pi pi-external-link" />
+        <span class="popup-item-label">{{ entry.title }}</span>
+      </button>
+    </div>
+  </Popover>
+</template>
+
+<style scoped>
+/* ラップしたボタンのレイアウトを変えないための素通しコンテナ */
+.url-hover-wrapper {
+  display: inline-flex;
+  align-items: center;
+}
+
+.url-popup {
+  display: flex;
+  flex-direction: column;
+  min-width: 180px;
+  max-width: 420px;
+}
+
+.popup-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  color: var(--p-text-color);
+  font-size: 13px;
+  cursor: pointer;
+  border-radius: 4px;
+  text-align: left;
+  width: 100%;
+}
+
+.popup-item:hover {
+  background: var(--p-content-hover-background);
+}
+
+.popup-item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Worktree } from "../types/worktree";
+import type { UrlArtifactEntry } from "../types/artifact";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
@@ -190,6 +191,8 @@ const props = defineProps<{
   notifications: Map<string, number>;
   hotkeyChars: Map<string, string>;
   artifactCounts: Map<string, number>;
+  /** ワークツリー単位の URL アーティファクト（アイコン隣のドロップダウン用） */
+  artifactUrls: Map<string, UrlArtifactEntry[]>;
   loadingWorktrees: Map<string, string>;
   cancellableWorktrees: Set<string>;
   autoApprovals: Map<string, boolean>;
@@ -466,6 +469,7 @@ watch(
               :notification-count="notifications.get(worktree.id) ?? 0"
               :hotkey-char="hotkeyChars.get(worktree.id)"
               :artifact-count="artifactCounts.get(worktree.id) ?? 0"
+              :artifact-urls="artifactUrls.get(worktree.id) ?? []"
               :loading="loadingWorktrees.has(worktree.id)"
               :loading-text="loadingWorktrees.get(worktree.id)"
               :cancellable="cancellableWorktrees.has(worktree.id)"
@@ -505,6 +509,7 @@ watch(
         :worktrees="worktrees"
         :thumbnail-urls="thumbnailUrls"
         :artifact-counts="artifactCounts"
+        :artifact-urls="artifactUrls"
         :notifications="notifications"
         :hotkey-chars="hotkeyChars"
         :detached-worktrees="detachedWorktrees"

--- a/src/components/RepositoryCard.vue
+++ b/src/components/RepositoryCard.vue
@@ -4,8 +4,11 @@ import { useI18n } from "vue-i18n";
 import type { Repository } from "../types/settings";
 import type { Worktree } from "../types/worktree";
 import TerminalThumbnail from "./TerminalThumbnail.vue";
+import ArtifactUrlHoverMenu from "./ArtifactUrlHoverMenu.vue";
+import ArtifactIcon from "./ArtifactIcon.vue";
 import Popover from "primevue/popover";
 import Badge from "primevue/badge";
+import type { UrlArtifactEntry } from "../types/artifact";
 
 const { t } = useI18n();
 
@@ -15,6 +18,8 @@ const props = defineProps<{
   worktree?: Worktree;
   thumbnailUrls: Map<number, string>;
   artifactCount?: number;
+  /** 登録済み URL アーティファクト（バッジ隣のドロップダウン用） */
+  artifactUrls?: UrlArtifactEntry[];
   notificationCount?: number;
   hotkeyChar?: string;
   detached?: boolean;
@@ -108,15 +113,16 @@ function withMenuHidden<T>(fn: () => T): T {
     />
     <div v-if="hotkeyChar || (artifactCount && artifactCount > 0)" class="top-left-badges">
       <div v-if="hotkeyChar" class="hotkey-badge">Alt+{{ hotkeyChar }}</div>
-      <button
-        v-if="artifactCount && artifactCount > 0"
-        class="artifact-count-badge"
-        :title="t('artifactsTooltip')"
-        @click="emit('openArtifacts', repo.id)"
-      >
-        <span class="pi pi-box" style="font-size: 9px" />
-        {{ artifactCount }}
-      </button>
+      <ArtifactUrlHoverMenu v-if="artifactCount && artifactCount > 0" :urls="artifactUrls ?? []">
+        <button
+          class="artifact-count-badge"
+          :title="t('artifactsTooltip')"
+          @click="emit('openArtifacts', repo.id)"
+        >
+          <ArtifactIcon :has-url="(artifactUrls?.length ?? 0) > 0" style="font-size: 9px" />
+          {{ artifactCount }}
+        </button>
+      </ArtifactUrlHoverMenu>
     </div>
 
     <div class="card-header">

--- a/src/components/RepositoryPanel.vue
+++ b/src/components/RepositoryPanel.vue
@@ -12,7 +12,8 @@ import { useMasonryLayout } from "../composables/useMasonryLayout";
 import { computeNaturalCardWidth } from "../utils/cardWidth";
 import { isHomeWorktree } from "../utils/homeWorktree";
 import { isRepositoryWorktree, makeRepositoryWorktreeId } from "../utils/repositoryWorktree";
-import type { RepoArtifactChangedEvent } from "../types/artifact";
+import { extractUrlArtifacts } from "../utils/artifactUrl";
+import type { RepoArtifactChangedEvent, UrlArtifactEntry } from "../types/artifact";
 import type { Repository } from "../types/settings";
 import type { Worktree } from "../types/worktree";
 import PostAddSettingsDialog from "./PostAddSettingsDialog.vue";
@@ -42,6 +43,8 @@ const props = defineProps<{
   thumbnailUrls: Map<number, string>;
   /** ワークツリー単位のアーティファクト件数（ホームカード用） */
   artifactCounts: Map<string, number>;
+  /** ワークツリー単位の URL アーティファクト（ホームカード用） */
+  artifactUrls: Map<string, UrlArtifactEntry[]>;
   notifications: Map<string, number>;
   hotkeyChars: Map<string, string>;
   detachedWorktrees: Set<string>;
@@ -70,14 +73,18 @@ const emit = defineEmits<{
 
 /** リポジトリ ID → 恒久保存アーティファクト件数 */
 const repoArtifactCounts = ref(new Map<string, number>());
+/** リポジトリ ID → 恒久保存の URL アーティファクト */
+const repoArtifactUrls = ref(new Map<string, UrlArtifactEntry[]>());
 let unlisten: UnlistenFn | null = null;
 
 async function refreshArtifactCount(repoId: string) {
   try {
     const list = await invoke<unknown[]>("list_repo_artifacts", { repositoryId: repoId });
     repoArtifactCounts.value.set(repoId, list.length);
+    repoArtifactUrls.value.set(repoId, extractUrlArtifacts(list));
     // Map の変異は追跡されないため、再代入して再描画させる
     repoArtifactCounts.value = new Map(repoArtifactCounts.value);
+    repoArtifactUrls.value = new Map(repoArtifactUrls.value);
   } catch {
     /* 件数バッジは補助情報なので失敗しても無視 */
   }
@@ -212,6 +219,7 @@ defineExpose({ addRepository });
             :notification-count="notifications.get(item.worktree.id) ?? 0"
             :hotkey-char="hotkeyChars.get(item.worktree.id)"
             :artifact-count="artifactCounts.get(item.worktree.id) ?? 0"
+            :artifact-urls="artifactUrls.get(item.worktree.id) ?? []"
             :auto-approval="autoApprovals.get(item.worktree.id) ?? false"
             :ai-judging="aiJudgingWorktrees.has(item.worktree.id)"
             :tooltip="cardTooltips?.get(item.worktree.id)"
@@ -234,6 +242,7 @@ defineExpose({ addRepository });
             :worktree="item.worktree"
             :thumbnail-urls="thumbnailUrls"
             :artifact-count="repoArtifactCounts.get(item.repo.id) ?? 0"
+            :artifact-urls="repoArtifactUrls.get(item.repo.id) ?? []"
             :notification-count="item.worktree ? notifications.get(item.worktree.id) ?? 0 : 0"
             :hotkey-char="item.worktree ? hotkeyChars.get(item.worktree.id) : undefined"
             :detached="item.worktree ? detachedWorktrees.has(item.worktree.id) : false"

--- a/src/components/WorktreeCard.vue
+++ b/src/components/WorktreeCard.vue
@@ -8,8 +8,11 @@ import { useWorkgroups } from "../composables/useWorkgroups";
 const { t } = useI18n();
 const { displayName: workgroupDisplayName } = useWorkgroups();
 import TerminalThumbnail from "./TerminalThumbnail.vue";
+import ArtifactUrlHoverMenu from "./ArtifactUrlHoverMenu.vue";
+import ArtifactIcon from "./ArtifactIcon.vue";
 import Popover from "primevue/popover";
 import Badge from "primevue/badge";
+import type { UrlArtifactEntry } from "../types/artifact";
 
 const props = defineProps<{
   worktree: Worktree;
@@ -18,6 +21,8 @@ const props = defineProps<{
   notificationCount?: number;
   hotkeyChar?: string;
   artifactCount?: number;
+  /** 登録済み URL アーティファクト（バッジ隣のドロップダウン用） */
+  artifactUrls?: UrlArtifactEntry[];
   loading?: boolean;
   loadingText?: string;
   cancellable?: boolean;
@@ -147,10 +152,16 @@ const terminalList = computed(() =>
     <Badge v-if="notificationCount && notificationCount > 0" :value="notificationCount" severity="danger" class="notification-badge" />
     <div v-if="hotkeyChar || (artifactCount && artifactCount > 0)" class="top-left-badges">
       <div v-if="hotkeyChar" class="hotkey-badge">Alt+{{ hotkeyChar }}</div>
-      <div v-if="artifactCount && artifactCount > 0" class="artifact-count-badge">
-        <span class="pi pi-box" style="font-size: 9px" />
-        {{ artifactCount }}
-      </div>
+      <ArtifactUrlHoverMenu v-if="artifactCount && artifactCount > 0" :urls="artifactUrls ?? []">
+        <button
+          class="artifact-count-badge"
+          :title="t('openArtifacts')"
+          @click="emit('openArtifacts', worktree.id)"
+        >
+          <ArtifactIcon :has-url="(artifactUrls?.length ?? 0) > 0" style="font-size: 9px" />
+          {{ artifactCount }}
+        </button>
+      </ArtifactUrlHoverMenu>
     </div>
     <div class="card-header">
       <div class="card-info">
@@ -335,6 +346,11 @@ const terminalList = computed(() =>
   font-size: 10px;
   color: #89b4fa;
   white-space: nowrap;
+  cursor: pointer;
+}
+
+.artifact-count-badge:hover {
+  border-color: #89b4fa;
 }
 
 .card-detached {

--- a/src/components/WorktreeHeader.vue
+++ b/src/components/WorktreeHeader.vue
@@ -2,7 +2,10 @@
 import { useI18n } from "vue-i18n";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import MacTrafficLights from "./MacTrafficLights.vue";
+import ArtifactUrlHoverMenu from "./ArtifactUrlHoverMenu.vue";
+import ArtifactIcon from "./ArtifactIcon.vue";
 import { isMac } from "../composables/usePlatform";
+import type { UrlArtifactEntry } from "../types/artifact";
 
 const { t } = useI18n();
 
@@ -11,6 +14,8 @@ const props = defineProps<{
   branchName: string;
   hotkeyChar?: string;
   artifactCount?: number;
+  /** 登録済み URL アーティファクト（アイコン隣のドロップダウン用） */
+  artifactUrls?: UrlArtifactEntry[];
   autoApproval: boolean;
   aiJudging: boolean;
   isWindowFocused: boolean;
@@ -120,16 +125,20 @@ async function closeWindow() {
         <span class="pi pi-spin pi-spinner" style="font-size: 9px" />
         {{ t('aiJudgingBadge') }}
       </button>
-      <button
+      <ArtifactUrlHoverMenu
         v-if="props.artifactCount && props.artifactCount > 0"
-        class="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded font-medium cursor-pointer border-none"
-        style="background: rgba(137, 180, 250, 0.15); color: #89b4fa; border: 1px solid rgba(137, 180, 250, 0.3)"
-        :title="t('openArtifacts')"
-        @click="$emit('open-artifacts')"
+        :urls="props.artifactUrls ?? []"
       >
-        <span class="pi pi-box" style="font-size: 9px" />
-        {{ props.artifactCount }}
-      </button>
+        <button
+          class="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded font-medium cursor-pointer border-none"
+          style="background: rgba(137, 180, 250, 0.15); color: #89b4fa; border: 1px solid rgba(137, 180, 250, 0.3)"
+          :title="t('openArtifacts')"
+          @click="$emit('open-artifacts')"
+        >
+          <ArtifactIcon :has-url="(props.artifactUrls?.length ?? 0) > 0" style="font-size: 9px" />
+          {{ props.artifactCount }}
+        </button>
+      </ArtifactUrlHoverMenu>
     </div>
     <div class="flex items-center">
       <button
@@ -139,14 +148,18 @@ async function closeWindow() {
       >
         <span class="pi pi-code text-sm" />
       </button>
-      <button
-        class="flex items-center justify-center w-7 h-7 rounded bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors"
+      <ArtifactUrlHoverMenu
+        :urls="props.artifactUrls ?? []"
         :class="props.showWindowControls && !isMac ? 'mr-4' : ''"
-        :title="t('openArtifacts')"
-        @click="$emit('open-artifacts')"
       >
-        <span class="pi pi-box text-sm" />
-      </button>
+        <button
+          class="flex items-center justify-center w-7 h-7 rounded bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors"
+          :title="t('openArtifacts')"
+          @click="$emit('open-artifacts')"
+        >
+          <ArtifactIcon :has-url="(props.artifactUrls?.length ?? 0) > 0" class="text-sm" />
+        </button>
+      </ArtifactUrlHoverMenu>
       <template v-if="props.showWindowControls && !isMac">
         <button
           class="flex items-center justify-center h-8 hover:bg-[#313244] text-[#6c7086] hover:text-[#cdd6f4] transition-colors"

--- a/src/components/artifact/ArtifactUrlView.vue
+++ b/src/components/artifact/ArtifactUrlView.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+const props = defineProps<{
+  content: string;
+}>();
+
+const { t } = useI18n();
+
+/** content は URL 1行。前後の空白と余分な行は落とす */
+const url = computed(() => props.content.trim().split(/\r?\n/)[0]?.trim() ?? "");
+const isOpenable = computed(() => /^https?:\/\/\S+$/.test(url.value));
+
+const copied = ref(false);
+let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+async function open() {
+  if (!isOpenable.value) return;
+  try {
+    await openUrl(url.value);
+  } catch (e) {
+    console.error("openUrl failed", e);
+  }
+}
+
+async function copy() {
+  try {
+    await navigator.clipboard.writeText(url.value);
+    copied.value = true;
+    if (copyTimer) clearTimeout(copyTimer);
+    copyTimer = setTimeout(() => { copied.value = false; }, 1500);
+  } catch (e) {
+    console.error("copy failed", e);
+  }
+}
+</script>
+
+<template>
+  <div class="url-view">
+    <span class="pi pi-link url-icon" />
+    <!-- href はスキーム検証を通ったものだけ。アーティファクト本文は AI が自由に書けるため、
+         javascript: などが特権ドキュメントのリンク先に載らないようにする -->
+    <a class="url-text" :href="isOpenable ? url : undefined" @click.prevent="open">{{ url }}</a>
+    <div class="url-actions">
+      <button class="btn-url btn-open" :disabled="!isOpenable" @click="open">
+        <i class="pi pi-external-link" />
+        <span>{{ t("openInBrowser") }}</span>
+      </button>
+      <button class="btn-url" @click="copy">
+        <i :class="copied ? 'pi pi-check' : 'pi pi-copy'" />
+        <span>{{ copied ? t("copied") : t("copy") }}</span>
+      </button>
+    </div>
+    <span v-if="!isOpenable" class="url-warning">{{ t("invalidUrl") }}</span>
+  </div>
+</template>
+
+<style scoped>
+.url-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 32px;
+  overflow: auto;
+}
+
+.url-icon {
+  font-size: 32px;
+  color: #89b4fa;
+}
+
+.url-text {
+  font-family: monospace;
+  font-size: 13px;
+  color: #89b4fa;
+  text-align: center;
+  word-break: break-all;
+  max-width: 100%;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.url-text:hover {
+  text-decoration: underline;
+}
+
+.url-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-url {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #313244;
+  color: #cdd6f4;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn-url:hover:not(:disabled) {
+  background: #45475a;
+}
+
+.btn-url:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-open {
+  border-color: #89b4fa;
+  color: #89b4fa;
+}
+
+.url-warning {
+  font-size: 11px;
+  color: #f38ba8;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "openInBrowser": "Open in browser",
+    "copy": "Copy",
+    "copied": "Copied",
+    "invalidUrl": "This artifact does not contain a valid http(s) URL"
+  },
+  "ja": {
+    "openInBrowser": "ブラウザで開く",
+    "copy": "コピー",
+    "copied": "コピーしました",
+    "invalidUrl": "有効な http(s) URL が入っていません"
+  }
+}
+</i18n>

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -1,3 +1,13 @@
+/** URL アーティファクトの content_type（Rust 側は artifact_url.rs の URL_ARTIFACT_CONTENT_TYPE） */
+export const URL_ARTIFACT_CONTENT_TYPE = "text/uri-list";
+
+/** アイコンボタンのドロップダウンに並べる URL アーティファクト */
+export interface UrlArtifactEntry {
+  id: string;
+  title: string;
+  url: string;
+}
+
 export interface ArtifactMeta {
   id: string;
   title: string;

--- a/src/utils/artifactUrl.test.ts
+++ b/src/utils/artifactUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { extractUrlArtifacts } from "./artifactUrl";
+
+describe("extractUrlArtifacts", () => {
+  it("picks only text/uri-list entries", () => {
+    const list = [
+      { id: "a", type: "text/markdown", title: "doc", content: "# hi" },
+      { id: "b", type: "text/uri-list", title: "o/r#1", content: "https://github.com/o/r/issues/1" },
+    ];
+    expect(extractUrlArtifacts(list)).toEqual([
+      { id: "b", title: "o/r#1", url: "https://github.com/o/r/issues/1" },
+    ]);
+  });
+
+  it("accepts content_type as well as type", () => {
+    const list = [{ id: "b", content_type: "text/uri-list", title: "x", content: "https://e.com" }];
+    expect(extractUrlArtifacts(list)).toEqual([
+      { id: "b", title: "x", url: "https://e.com" },
+    ]);
+  });
+
+  it("uses the first line and trims whitespace", () => {
+    const list = [
+      { id: "b", type: "text/uri-list", title: "", content: "  https://e.com/a  \nignored\n" },
+    ];
+    expect(extractUrlArtifacts(list)).toEqual([
+      { id: "b", title: "https://e.com/a", url: "https://e.com/a" },
+    ]);
+  });
+
+  it("skips malformed entries", () => {
+    const list = [
+      null,
+      "nope",
+      { id: "", type: "text/uri-list", content: "https://e.com" },
+      { id: "c", type: "text/uri-list", content: "   " },
+    ];
+    expect(extractUrlArtifacts(list)).toEqual([]);
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    const list = [
+      { id: "a", type: "text/uri-list", title: "js", content: "javascript:alert(1)" },
+      { id: "b", type: "text/uri-list", title: "file", content: "file:///C:/Windows" },
+      { id: "c", type: "text/uri-list", title: "mail", content: "mailto:x@example.com" },
+      { id: "d", type: "text/uri-list", title: "ok", content: "https://e.com" },
+    ];
+    expect(extractUrlArtifacts(list)).toEqual([
+      { id: "d", title: "ok", url: "https://e.com" },
+    ]);
+  });
+});

--- a/src/utils/artifactUrl.ts
+++ b/src/utils/artifactUrl.ts
@@ -1,0 +1,28 @@
+import { URL_ARTIFACT_CONTENT_TYPE, type UrlArtifactEntry } from "../types/artifact";
+
+/**
+ * `list_artifacts` / `list_repo_artifacts` の生 JSON 配列から URL アーティファクトだけを取り出す。
+ * `list_artifacts` は content 込みで返す。`list_repo_artifacts` は通常 content を落とすが、
+ * `text/uri-list` だけは例外的に残す（src-tauri/src/lib.rs の list_repo_artifacts）ので、
+ * どちらも追加の read なしで URL を取れる。
+ * JSON 側のキーは `type`（Rust の serde rename）である点に注意。
+ */
+export function extractUrlArtifacts(list: unknown[]): UrlArtifactEntry[] {
+  const entries: UrlArtifactEntry[] = [];
+  for (const raw of list) {
+    if (!raw || typeof raw !== "object") continue;
+    const obj = raw as Record<string, unknown>;
+    const contentType = obj.type ?? obj.content_type;
+    if (contentType !== URL_ARTIFACT_CONTENT_TYPE) continue;
+
+    const id = typeof obj.id === "string" ? obj.id : "";
+    const content = typeof obj.content === "string" ? obj.content : "";
+    const url = content.trim().split(/\r?\n/)[0]?.trim() ?? "";
+    // アーティファクト本文は AI が自由に書けるため、ブラウザで開く前にスキームを絞る
+    if (!id || !/^https?:\/\/\S+$/.test(url)) continue;
+
+    const title = typeof obj.title === "string" && obj.title.trim() ? obj.title : url;
+    entries.push({ id, title, url });
+  }
+  return entries;
+}


### PR DESCRIPTION
closes #113

## 概要

アーティファクトに URL 型 (`content_type: text/uri-list`) を追加し、issue / PR の URL をワークツリーごとの「関連リンク集」として自動で育てられるようにする。

## 変更点

### データモデル

`text/uri-list` を既存の content_type 体系に足すだけで、保存形式 (`artifacts/<worktreeId>/<id>.json`)・Tauri コマンド・MCP `artifact` ツールはそのまま使う。`content` は URL 1 行。

`list_repo_artifacts` は一覧用に `content` を落とすが、URL アーティファクトだけは例外的に残す（content が URL 1 行しかなく、ドロップダウンがこの値を必要とするため）。

### ビューア

`ArtifactUrlView.vue` を追加。URL 表示＋「ブラウザで開く」＋コピーのみで、内蔵ブラウザは持たない。`openUrl` は `@tauri-apps/plugin-opener`（前例: `FramePane.vue`）。`artifact-*` ウィンドウは `opener:default` を既に持つので capability の変更なし。

### アイコンとホバーメニュー

- `ArtifactIcon.vue`: URL を持つ時だけキューブ (`pi-box`) の右下にリンク (`pi-link`) を重ねる。primeicons の `.pi { font-size: 1rem }` を `1em` で打ち消し、呼び出し元のサイズ指定に追従する
- `ArtifactUrlHoverMenu.vue`: 既存のボタン／バッジを slot でラップし、マウスオーバーで URL 一覧を出す。ボタンのデザインとクリック挙動（アーティファクトウィンドウを開く）は変えない
- 対象は WorktreeCard / WorktreeHeader（バッジとアイコンボタン）/ RepositoryCard / SubWindowApp / TrayPopupApp の全アーティファクトボタン
- ついでに WorktreeCard のバッジを `<div>` から `<button>` にした。従来はクリックしても何も起きず、ホームタブからアーティファクトを開けるのは ⋮ メニューだけだった

### フックによる自動登録

新しいフックは追加しない。`build_hooks_json` は既に PreToolUse / PostToolUse を matcher `""` で全ツールに登録しており、`oretachi-notify --notify` が hook JSON を `/notify` に運んでいる。ツール呼び出しごとのサイドカー起動を倍にしないため、サーバ側 `notify_handler` で分岐する。通知フックの設定有無とは独立に動かすため、未設定リポジトリの早期 return より前に処理し、実処理は `tokio::spawn` へ逃がす。

- **issue を開く (PreToolUse)**: ツール入力の URL が、`tasks.db` のこのワークツリー宛タスクプロンプトの URL と一致した時
- **issue / PR 作成 (PostToolUse)**: `gh issue create` / `gh pr create` の出力 URL の `owner/repo` が `git remote` と一致した時（PreToolUse 時点では発行 URL が存在しないため）
- **重複スキップ**: ID ではなく正規化 URL の内容で突き合わせる。MCP の `artifact` ツールは任意 ID で作れるため、ハッシュ ID の存在確認だけでは同一 URL の二重登録を防げない
- 自動登録は作業の副産物なので `autoOpen: false` を載せ、ビューアウィンドウで作業に割り込まない

## 実装上の注意

- hook JSON は `Value::to_string()` ではなく文字列リーフを再帰的に集めてから走査する。`gh` の stdout は末尾に改行が付くため、シリアライズしたまま走査するとエスケープ列 `\n` が URL に食い込む
- タスクプロンプトの URL は worktree 単位・TTL 60 秒でメモ化する。PreToolUse は「http を含む全ツール呼び出し」で走るため、毎回 tasks.db を 200 件走査するのは無駄が大きい
- アーティファクト本文は AI が自由に書けるため、`extractUrlArtifacts` と `ArtifactUrlView` の `href` の両方で http(s) 以外のスキームを弾く（`opener:default` のスコープも mailto/tel/http/https に限定されており多層防御）
- `hooks.json` の内容は変えないので、既存ワークツリーの `.claude/settings.local.json` の再生成は不要

## テスト

- `cargo test --lib`: 82 passed（`artifact_url` 17 件。URL 抽出、GitHub URL パース、クエリ/フラグメント付き URL、`@` を含むパスの誤判定、内容による重複判定の回帰テストを含む）
- `vitest`: 83 passed（`extractUrlArtifacts` 5 件。非 http(s) スキームの拒否を含む）
- `pnpm run type-check` / `vite build` ともに通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
