### PR TITLE
feat(home): HOMEタブ周辺の挙動を修正 (#112)

### DIFF
--- a/src-tauri/skills-home/worktree-report/SKILL.md
+++ b/src-tauri/skills-home/worktree-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: worktree-report
 description: 全ワークツリーの状況を1つのレポートにまとめて報告する。作業内容(description)・ブランチ・git 状態・ターミナルの稼働状況・PR 状態を横断的に集約する。「今どうなってる」「状況を教えて」「ワークツリー一覧」などの依頼で使う。
-allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status, mcp__plugin_oretachi_oretachi__oretachi_inspect_worktree, mcp__plugin_oretachi_oretachi__oretachi_list_terminals, mcp__plugin_oretachi_oretachi__oretachi_read_terminal, mcp__plugin_oretachi_oretachi__oretachi_list_repository, Bash
+allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status, mcp__plugin_oretachi_oretachi__oretachi_inspect_worktree, mcp__plugin_oretachi_oretachi__oretachi_list_terminals, mcp__plugin_oretachi_oretachi__oretachi_read_terminal, mcp__plugin_oretachi_oretachi__oretachi_list_repository, mcp__plugin_oretachi_oretachi__oretachi_show_worktree, Bash
 ---
 
 # worktree-report スキル
@@ -12,23 +12,40 @@ allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status, mcp_
 
 1. `oretachi_get_worktree_status` で全ワークツリーを取得する（`isHome` / `isRepository` は除外）。
    `query` を渡せば name / branchName / description の部分一致で絞り込める。
+   各エントリの `workgroupName` が所属ワークグループ（表示名）。レポートはこれで章立てする。
 2. `oretachi_inspect_worktree` で各ワークツリーの git 状態を取得する。
 3. `oretachi_list_terminals` でターミナルの稼働状況（running / exited、AI エージェントの有無）を取得する。
 4. 必要なら `gh pr list --json number,title,headRefName,state` で PR 状態を突き合わせる。
    ブランチ名で紐付ける。`gh` が無い環境ではこの列を省略する。
-5. 下記フォーマットで表を出力し、最後に注意が必要なものを 2〜3 行でまとめる。
+5. `workgroupName` ごとにグループ分けし、下記フォーマットで表を出力する。
+   最後に注意が必要なものを 2〜3 行でまとめる。
 
 ## 出力フォーマット
 
+ワークグループごとに見出しを立て、その配下に表を出す。
+グループが 1 つしかない場合は見出しを省略してよい。
+
 ```
+## グループ(1)
+
 ワークツリー      ブランチ              状態     端末   PR      作業内容
 oretachi-jaqo     worktree/home-...     dirty 3  claude #112    ホームターミナルの実装
 oretachi-k3p1     fix/tray-focus        clean    —      #111 M  トレイのフォーカス修正
+
+## リリース準備
+
+ワークツリー      ブランチ              状態     端末   PR      作業内容
+oretachi-9x2b     release/0.29.0        clean    —      #120 O  0.29.0 のリリース作業
 ```
 
 - 状態: `clean` / `dirty N` / `merged→<branch>`
 - 端末: 動作中のプロセス名。停止済みなら `—`
 - PR: 番号と状態（O=OPEN, M=MERGED, C=CLOSED）
+
+## ワークツリーを見せる
+
+「〜の様子を見せて」「〜を開いて」と言われたら `oretachi_show_worktree` でフォーカスを移す。
+レポート中に特定のワークツリーへ誘導したいときにも使える。
 
 ## まとめの観点
 

--- a/src-tauri/src/git_worktree.rs
+++ b/src-tauri/src/git_worktree.rs
@@ -86,6 +86,20 @@ pub fn validate_repo(path: &str) -> Result<bool, String> {
     Ok(output.status.success())
 }
 
+/// 与えられたパスを含む git リポジトリのルート（メインワークツリー）を返す。
+/// validate_repo は `--is-inside-work-tree` なのでサブディレクトリでも成功する。
+/// リポジトリ登録時にここを通してルートへ正規化しないと、`git worktree list` が返す
+/// メインワークツリーと登録パスが食い違い、メインワークツリーが「未登録のワークツリー」
+/// として取り込み候補に現れてしまう。
+pub fn repo_root(path: &str) -> Result<String, String> {
+    let stdout = run_git_in(path, &["rev-parse", "--show-toplevel"])?;
+    let root = stdout.trim();
+    if root.is_empty() {
+        return Err("git rev-parse --show-toplevel returned empty".to_string());
+    }
+    Ok(root.to_string())
+}
+
 /// リモート名を抽出する: "<remote>/<branch>" 形式の場合にリモート名を返す
 fn extract_remote_name(repo_path: &str, branch: &str) -> Option<String> {
     if !branch.contains('/') {
@@ -200,6 +214,76 @@ pub fn list_branches(repo_path: &str) -> Result<Vec<String>, String> {
         .filter(|l| !l.is_empty())
         .collect();
     Ok(branches)
+}
+
+/// `git worktree list --porcelain` の 1 エントリ。
+#[derive(Debug, Clone, Serialize)]
+pub struct GitWorktreeInfo {
+    pub path: String,
+    /// `refs/heads/` を剥がしたブランチ名。detached HEAD や bare では None
+    pub branch: Option<String>,
+    pub head: Option<String>,
+    /// メインの bare リポジトリ本体（ワークツリーとして取り込む対象ではない）
+    pub bare: bool,
+    pub detached: bool,
+    /// メインワークツリー（git は必ず先頭に出力する）。
+    /// `git worktree remove` できない特別な存在なので、取り込み対象から必ず外すこと。
+    pub is_main: bool,
+    /// 実体ディレクトリが消えている等で `git worktree prune` の対象になっている。
+    /// 取り込んでも存在しないパスが登録されるだけなので候補から外すこと。
+    pub prunable: bool,
+    pub locked: bool,
+}
+
+/// リポジトリに紐づく git ワークツリーを全件返す（メインワークツリー自身を含む）。
+/// パスは git が返す絶対パスそのままなので、oretachi の追加先ディレクトリ外にあるものも拾える。
+pub fn list_worktrees(repo_path: &str) -> Result<Vec<GitWorktreeInfo>, String> {
+    let stdout = run_git_in(repo_path, &["worktree", "list", "--porcelain"])?;
+    Ok(parse_worktree_list(&stdout))
+}
+
+/// `git worktree list --porcelain` の出力をパースする。
+fn parse_worktree_list(stdout: &str) -> Vec<GitWorktreeInfo> {
+    let mut result: Vec<GitWorktreeInfo> = Vec::new();
+
+    // porcelain は 1 エントリが空行区切り。`worktree <path>` が必ずエントリの先頭に来る。
+    for line in stdout.lines() {
+        let line = line.trim_end();
+        if let Some(path) = line.strip_prefix("worktree ") {
+            result.push(GitWorktreeInfo {
+                path: path.to_string(),
+                branch: None,
+                head: None,
+                bare: false,
+                detached: false,
+                // git は必ずメインワークツリーを先頭に出力する
+                is_main: result.is_empty(),
+                prunable: false,
+                locked: false,
+            });
+            continue;
+        }
+        let Some(current) = result.last_mut() else {
+            continue;
+        };
+        if let Some(head) = line.strip_prefix("HEAD ") {
+            current.head = Some(head.to_string());
+        } else if let Some(branch) = line.strip_prefix("branch ") {
+            current.branch = Some(branch.strip_prefix("refs/heads/").unwrap_or(branch).to_string());
+        } else if line == "bare" {
+            current.bare = true;
+        } else if line == "detached" {
+            current.detached = true;
+        } else if line == "prunable" || line.starts_with("prunable ") {
+            // 理由付き (`prunable gitdir file points to non-existent location`) と
+            // 理由なしの両方がありうる
+            current.prunable = true;
+        } else if line == "locked" || line.starts_with("locked ") {
+            current.locked = true;
+        }
+    }
+
+    result
 }
 
 fn find_branch_worktree(repo_path: &str, branch_name: &str) -> Result<Option<String>, String> {
@@ -1333,6 +1417,15 @@ pub fn worktree_restore(repo_path: &str, worktree_path: &str, branch_name: &str)
     Ok(())
 }
 
+/// `git worktree remove` がメインワークツリーを理由に失敗したか。
+/// この場合にディレクトリ直接削除へフォールバックすると .git ごとリポジトリ本体を消してしまう。
+///
+/// 「実体ディレクトリが既に無い」系のエラー (`is not a working tree`) はここに含めない。
+/// あちらはフォールバック側の prune 処理で掃除するのが正しい挙動のため。
+fn is_main_worktree_error(stderr: &str) -> bool {
+    stderr.to_lowercase().contains("is a main working tree")
+}
+
 fn is_lock_error(stderr: &str) -> bool {
     // Windows でプロセス終了直後にファイルハンドルが残留している場合に git や OS が返すエラー文言
     let lower = stderr.to_lowercase();
@@ -1367,6 +1460,15 @@ pub fn worktree_remove(repo_path: &str, worktree_path: &str) -> Result<(), Strin
         }
 
         let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // メインワークツリーはディレクトリ直接削除へフォールバックしてはいけない。
+        // ここで remove_dir_all に落ちると .git ごとリポジトリ本体が消える。
+        if is_main_worktree_error(&stderr) {
+            return Err(format!(
+                "git worktree remove failed (メインワークツリーのため中止しました): {}",
+                stderr.trim()
+            ));
+        }
 
         // ロック起因のエラーで試行回数が残っている場合はリトライ
         if attempt < MAX_ATTEMPTS - 1 && is_lock_error(&stderr) {
@@ -1575,4 +1677,103 @@ pub fn copy_claude_session_data(
         .map_err(|e| format!("failed to rename tmp dir to target: {}", e))?;
 
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_worktree_list_handles_main_branch_detached_and_bare() {
+        // git worktree list --porcelain の実出力形式（エントリは空行区切り）
+        let stdout = "\
+worktree C:/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree X:/devel/worktree/feature-a
+HEAD def456
+branch refs/heads/feature/a
+
+worktree D:/elsewhere/detached-wt
+HEAD 789abc
+detached
+
+worktree C:/bare-repo
+bare
+";
+        let list = parse_worktree_list(stdout);
+        assert_eq!(list.len(), 4);
+
+        assert_eq!(list[0].path, "C:/repo");
+        assert_eq!(list[0].branch.as_deref(), Some("main"));
+        assert_eq!(list[0].head.as_deref(), Some("abc123"));
+        assert!(!list[0].bare && !list[0].detached);
+        // 先頭がメインワークツリー。取り込み候補から外す判定に使う
+        assert!(list[0].is_main);
+        assert!(!list[1].is_main && !list[2].is_main && !list[3].is_main);
+
+        // refs/heads/ を剥がしつつ、スラッシュを含むブランチ名を壊さない
+        assert_eq!(list[1].branch.as_deref(), Some("feature/a"));
+        // 追加先ディレクトリ外（別ドライブ）のパスもそのまま拾える
+        assert_eq!(list[2].path, "D:/elsewhere/detached-wt");
+        assert!(list[2].detached);
+        assert_eq!(list[2].branch, None);
+
+        assert!(list[3].bare);
+    }
+
+    #[test]
+    fn parse_worktree_list_flags_prunable_and_locked() {
+        // 実体ディレクトリを消したワークツリーには理由付きの prunable 行が出る。
+        // locked も porcelain に出力される（理由の有無は状況次第）。
+        let stdout = "\
+worktree C:/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree C:/gone-wt
+HEAD def456
+branch refs/heads/gone
+prunable gitdir file points to non-existent location
+
+worktree C:/locked-wt
+HEAD 789abc
+branch refs/heads/locked
+locked because it is on a removable device
+
+worktree C:/plain-locked
+HEAD 111222
+detached
+locked
+";
+        let list = parse_worktree_list(stdout);
+        assert_eq!(list.len(), 4);
+        assert!(!list[0].prunable && !list[0].locked);
+        assert!(list[1].prunable, "理由付き prunable を拾えていない");
+        assert!(list[2].locked, "理由付き locked を拾えていない");
+        assert!(list[3].locked, "理由なし locked を拾えていない");
+        // locked は実体が存在するので取り込み対象から外さない
+        assert!(!list[2].prunable && !list[3].prunable);
+    }
+
+    #[test]
+    fn is_main_worktree_error_only_matches_main_worktree() {
+        // メインワークツリーはディレクトリ直接削除へフォールバックさせてはいけない
+        assert!(is_main_worktree_error(
+            "fatal: 'C:/repo' is a main working tree\n"
+        ));
+        // 実体が既に無いケースはフォールバック側の prune 処理に任せる（誤って止めない）
+        assert!(!is_main_worktree_error(
+            "fatal: 'C:/gone' is not a working tree\n"
+        ));
+        assert!(!is_main_worktree_error("error: Permission denied\n"));
+    }
+
+    #[test]
+    fn parse_worktree_list_returns_empty_for_blank_output() {
+        assert!(parse_worktree_list("").is_empty());
+        // worktree 行より前の孤立した属性行はどのエントリにも属さず無視される
+        assert!(parse_worktree_list("HEAD abc\nbare\n").is_empty());
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,6 +201,12 @@ async fn git_validate_repo(path: String) -> Result<bool, String> {
     run_git(move || git_worktree::validate_repo(&path)).await
 }
 
+/// リポジトリ登録用に、選択されたパスをリポジトリのルートへ正規化する。
+#[tauri::command]
+async fn git_repo_root(path: String) -> Result<String, String> {
+    run_git(move || git_worktree::repo_root(&path)).await
+}
+
 #[tauri::command]
 async fn git_pull(repo_path: String) -> Result<(), String> {
     run_git(move || git_worktree::git_pull(&repo_path)).await
@@ -1317,6 +1323,7 @@ pub fn run() {
         .manage(mcp_server::McpPeerRegistry(std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()))))
         .manage(mcp_server::DetachedWorktreeRegistry::default())
         .manage(mcp_server::CloseWorktreeAckRegistry::default())
+        .manage(mcp_server::ImportWorktreeAckRegistry::default())
         .manage(ai_judge::ApprovalManager::new())
         .manage(ai_commit_message::CommitMessageManager::new())
         .manage(ai_description::DescriptionManager::new())
@@ -1334,6 +1341,7 @@ pub fn run() {
             get_settings,
             save_settings,
             git_validate_repo,
+            git_repo_root,
             git_pull,
             git_worktree_add,
             git_worktree_remove,
@@ -1373,6 +1381,7 @@ pub fn run() {
             mcp_server::register_detached_worktree,
             mcp_server::unregister_detached_worktree,
             mcp_server::mcp_close_worktree_result,
+            mcp_server::mcp_import_worktree_result,
             download_and_install_update,
             ai_judge::judge_approval,
             ai_judge::cancel_approval,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -155,8 +155,64 @@ pub fn mcp_close_worktree_result(
     }
 }
 
+/// ワークツリー取り込みの最終結果。
+pub enum ImportWorktreeOutcome {
+    /// 登録できた（ワークツリーID）
+    Imported(String),
+    /// 既に登録済みだった（エラーではない）
+    AlreadyRegistered,
+    Failed(String),
+}
+
+/// oretachi_import_worktree の処理結果をフロントエンドから受け取る。
+/// settings の所有権はフロント側にあるため、登録そのものはフロントに行わせて結果だけ受け取る。
+#[derive(Default)]
+pub struct ImportWorktreeAckRegistry(pub Mutex<HashMap<String, oneshot::Sender<ImportWorktreeOutcome>>>);
+
+impl ImportWorktreeAckRegistry {
+    fn register(&self, request_id: String) -> oneshot::Receiver<ImportWorktreeOutcome> {
+        let (tx, rx) = oneshot::channel();
+        match self.0.lock() {
+            Ok(mut g) => { g.insert(request_id, tx); }
+            Err(e) => { e.into_inner().insert(request_id, tx); }
+        }
+        rx
+    }
+
+    fn take(&self, request_id: &str) -> Option<oneshot::Sender<ImportWorktreeOutcome>> {
+        match self.0.lock() {
+            Ok(mut g) => g.remove(request_id),
+            Err(e) => e.into_inner().remove(request_id),
+        }
+    }
+}
+
+/// フロントエンドがワークツリー取り込みの成否を MCP ツールへ返す。
+/// status: "ok" | "already" | それ以外は失敗扱い。
+#[tauri::command]
+pub fn mcp_import_worktree_result(
+    request_id: String,
+    status: String,
+    worktree_id: Option<String>,
+    error: Option<String>,
+    registry: tauri::State<'_, ImportWorktreeAckRegistry>,
+) {
+    if let Some(tx) = registry.take(&request_id) {
+        let outcome = match status.as_str() {
+            "ok" => ImportWorktreeOutcome::Imported(worktree_id.unwrap_or_default()),
+            "already" => ImportWorktreeOutcome::AlreadyRegistered,
+            _ => ImportWorktreeOutcome::Failed(error.unwrap_or_else(|| "unknown error".to_string())),
+        };
+        let _ = tx.send(outcome);
+    }
+}
+
 static PEER_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CLOSE_WORKTREE_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+static IMPORT_WORKTREE_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// 取り込み結果を待つ上限。登録はファイル I/O を伴わない settings 操作なので短くてよいが、
+/// フロントが重い処理中でも取りこぼさないよう余裕を持たせる。
+const IMPORT_WORKTREE_ACK_TIMEOUT_SECS: u64 = 30;
 /// クローズ結果を待つ上限。worktree remove はロックエラー時にキャンセルまで無限リトライする
 /// (git_worktree::worktree_remove_persistent) ため、タイムアウトしても失敗とは断定せず
 /// 「継続中」として返す。MCP クライアント側のツールタイムアウト(既定 60 秒前後)に
@@ -536,6 +592,39 @@ struct SpawnTerminalEvent {
     worktree_id: String,
     command: String,
     title: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ImportWorktreeParams {
+    #[schemars(description = "取り込むワークツリーの絶対パス。省略すると候補の列挙のみ行う")]
+    pub path: Option<String>,
+    #[schemars(description = "対象リポジトリ名で絞り込む（省略時は登録済み全リポジトリを走査）")]
+    pub repository_name: Option<String>,
+    #[schemars(description = "true なら path を指定していても登録せず候補列挙だけ行う（デフォルト false）")]
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ImportWorktreeEvent {
+    request_id: String,
+    repository_id: String,
+    repository_name: String,
+    path: String,
+    name: String,
+    branch_name: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ShowWorktreeParams {
+    #[schemars(description = "フォーカスするワークツリーの名前")]
+    pub worktree_name: Option<String>,
+    #[schemars(description = "ワークツリーID（同名ワークツリーが複数ある場合に指定）")]
+    pub worktree_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ShowWorktreeEvent {
+    worktree_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1050,43 +1139,13 @@ impl NotifyService {
         let settings = settings_manager.get();
 
         // 解決優先順位: worktree_id > worktree_name > project_dir 逆引き
-        let wt = if let Some(id) = worktree_id.as_deref() {
-            settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
-                McpError::invalid_params(format!("worktree id '{}' not found", id), None)
-            })?
-        } else if let Some(name) = worktree_name.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == name).collect();
-            match matches.len() {
-                0 => {
-                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("worktree '{}' not found. available: [{}]", name, names.join(", ")),
-                        None,
-                    ));
-                }
-                1 => matches[0],
-                _ => {
-                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", name, ids.join(", ")),
-                        None,
-                    ));
-                }
-            }
-        } else if let Some(dir) = project_dir.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-            resolve_worktree_by_dir(&settings, dir).ok_or_else(|| {
-                let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
-                McpError::invalid_params(
-                    format!("no worktree matches project_dir '{}'. available: [{}]", dir, names.join(", ")),
-                    None,
-                )
-            })?
-        } else {
-            return Err(McpError::invalid_params(
-                "specify one of project_dir / worktree_name / worktree_id",
-                None,
-            ));
-        };
+        let wt = resolve_worktree(
+            &settings,
+            worktree_id.as_deref(),
+            worktree_name.as_deref(),
+            project_dir.as_deref(),
+            "specify one of project_dir / worktree_name / worktree_id",
+        )?;
 
         let previous = wt.description.clone();
         let event = SetWorktreeDescriptionEvent {
@@ -1110,7 +1169,7 @@ impl NotifyService {
         )]))
     }
 
-    #[tool(description = "登録済みワークツリーのステータス一覧を取得する。各エントリはルートパス(path)・1行説明(description)・ブランチ名・isHome・isRepository を含む。isHome / isRepository が true のものは git ワークツリーではない擬似エントリなので、作業割り当てや削除の候補からは外すこと。query で name / branchName / description の部分一致検索ができる", annotations(read_only_hint = true))]
+    #[tool(description = "登録済みワークツリーのステータス一覧を取得する。各エントリはルートパス(path)・1行説明(description)・ブランチ名・所属ワークグループ(workgroupId / workgroupName)・isHome・isRepository を含む。isHome / isRepository が true のものは git ワークツリーではない擬似エントリなので、作業割り当てや削除の候補からは外すこと。query で name / branchName / description の部分一致検索ができる", annotations(read_only_hint = true))]
     fn oretachi_get_worktree_status(
         &self,
         Parameters(GetWorktreeStatusParams { query }): Parameters<GetWorktreeStatusParams>,
@@ -1142,6 +1201,9 @@ impl NotifyService {
                 }
             })
             .map(|wt| {
+                // 所属ワークグループ。未設定なら先頭グループへフォールバックする（UI の表示と同じ解決）。
+                // グループ自体が未定義なら workgroupId / workgroupName ともに null。
+                let group = resolve_workgroup(&settings, wt);
                 serde_json::json!({
                     "id": wt.id,
                     "name": wt.name,
@@ -1149,6 +1211,8 @@ impl NotifyService {
                     "description": wt.description,
                     "repositoryName": wt.repository_name,
                     "branchName": wt.branch_name,
+                    "workgroupId": group.map(|g| g.id.as_str()),
+                    "workgroupName": group.map(|g| workgroup_display_name(&settings, g)),
                     "isHome": wt.is_home,
                     "isRepository": wt.is_repository,
                     "isDetached": detached.contains(wt.id.as_str()),
@@ -1171,35 +1235,13 @@ impl NotifyService {
         let settings_manager = self.app_handle.state::<SettingsManager>();
         let settings = settings_manager.get();
 
-        let wt = if let Some(id) = worktree_id.as_deref() {
-            settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
-                McpError::invalid_params(format!("worktree id '{}' not found", id), None)
-            })?
-        } else if let Some(name) = worktree_name.as_deref().map(str::trim).filter(|n| !n.is_empty()) {
-            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == name).collect();
-            match matches.len() {
-                0 => {
-                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("worktree '{}' not found. available: [{}]", name, names.join(", ")),
-                        None,
-                    ));
-                }
-                1 => matches[0],
-                _ => {
-                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", name, ids.join(", ")),
-                        None,
-                    ));
-                }
-            }
-        } else {
-            return Err(McpError::invalid_params(
-                "specify one of worktree_name / worktree_id",
-                None,
-            ));
-        };
+        let wt = resolve_worktree(
+            &settings,
+            worktree_id.as_deref(),
+            worktree_name.as_deref(),
+            None,
+            "specify one of worktree_name / worktree_id",
+        )?;
 
         // ホーム / リポジトリは git ワークツリーではないので、ワークツリーとしての git 状態を持たない
         // （リポジトリ root で git は動くが branchName が空の擬似エントリなので結果が噛み合わない）
@@ -1419,32 +1461,14 @@ impl NotifyService {
             let settings_manager = self.app_handle.state::<SettingsManager>();
             let settings = settings_manager.get();
 
-            let wt = if let Some(id) = worktree_id.as_deref() {
-                // IDが指定されている場合はIDで特定
-                settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
-                    McpError::invalid_params(format!("worktree id '{}' not found", id), None)
-                })?
-            } else {
-                // 名前で特定（同名が複数ある場合はエラー）
-                let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == worktree_name).collect();
-                match matches.len() {
-                    0 => {
-                        let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
-                        return Err(McpError::invalid_params(
-                            format!("worktree '{}' not found. available: [{}]", worktree_name, names.join(", ")),
-                            None,
-                        ));
-                    }
-                    1 => matches[0],
-                    _ => {
-                        let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
-                        return Err(McpError::invalid_params(
-                            format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", worktree_name, ids.join(", ")),
-                            None,
-                        ));
-                    }
-                }
-            };
+            // worktree_name は上で空チェック済みなので missing_hint には到達しない
+            let wt = resolve_worktree(
+                &settings,
+                worktree_id.as_deref(),
+                Some(worktree_name.as_str()),
+                None,
+                "specify one of worktree_name / worktree_id",
+            )?;
 
             // ホーム / リポジトリは git ワークツリーではなく、path がワークツリー追加先ディレクトリ
             // またはリポジトリのルートそのもの。削除すると親ごと壊すため、要求は必ず拒否する。
@@ -1545,30 +1569,14 @@ impl NotifyService {
         let settings_manager = self.app_handle.state::<SettingsManager>();
         let settings = settings_manager.get();
 
-        let wt = if let Some(id) = worktree_id.as_deref() {
-            settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
-                McpError::invalid_params(format!("worktree id '{}' not found", id), None)
-            })?
-        } else {
-            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == worktree_name).collect();
-            match matches.len() {
-                0 => {
-                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("worktree '{}' not found. available: [{}]", worktree_name, names.join(", ")),
-                        None,
-                    ));
-                }
-                1 => matches[0],
-                _ => {
-                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", worktree_name, ids.join(", ")),
-                        None,
-                    ));
-                }
-            }
-        };
+        // worktree_name は上で空チェック済みなので missing_hint には到達しない
+        let wt = resolve_worktree(
+            &settings,
+            worktree_id.as_deref(),
+            Some(worktree_name.as_str()),
+            None,
+            "specify one of worktree_name / worktree_id",
+        )?;
 
         // detached（サブウィンドウ化済み）ワークツリーへの spawn はフロント側で
         // handleDetachedMcpSpawn 経由でサブウィンドウへ pendingCommand 付きでルーティングされる。
@@ -1589,6 +1597,202 @@ impl NotifyService {
         )]))
     }
 
+    #[tool(description = "指定ワークツリーを oretachi UI 上でフォーカスする。メインウィンドウにあればタブを切り替え（所属ワークグループが非アクティブなら併せて切り替え）、サブウィンドウへ分離済みならそのウィンドウを前面に出す。ユーザーに特定ワークツリーの様子を見せたいときに使う", annotations(read_only_hint = true))]
+    fn oretachi_show_worktree(
+        &self,
+        Parameters(ShowWorktreeParams { worktree_name, worktree_id }): Parameters<ShowWorktreeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let settings_manager = self.app_handle.state::<SettingsManager>();
+        let settings = settings_manager.get();
+
+        let wt = resolve_worktree(
+            &settings,
+            worktree_id.as_deref(),
+            worktree_name.as_deref(),
+            None,
+            "specify one of worktree_name / worktree_id",
+        )?;
+
+        // detached かどうかの判定はフロント側に任せる。ここで分岐すると
+        // サブウィンドウの生成/破棄との競合で古い情報を見ることになる。
+        let event = ShowWorktreeEvent { worktree_id: wt.id.clone() };
+        self.app_handle
+            .emit("mcp-show-worktree", &event)
+            .map_err(|e: tauri::Error| McpError::internal_error(e.to_string(), None))?;
+        log::info!("[mcp] oretachi_show_worktree: name={} id={}", wt.name, wt.id);
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "ワークツリー '{}' を表示しました。",
+            wt.name
+        ))]))
+    }
+
+    #[tool(description = "git リポジトリには存在するが oretachi に未登録のワークツリーを取り込む。path 省略または dry_run=true で候補を列挙し、path を指定するとその1件を登録する。ワークツリーの追加先ディレクトリの外にあるものも検出できる")]
+    async fn oretachi_import_worktree(
+        &self,
+        Parameters(ImportWorktreeParams { path, repository_name, dry_run }): Parameters<ImportWorktreeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        // await をまたいで State / settings の参照を保持しないよう、必要な値をここで所有権付きに確定させる
+        let (repos, registered): (Vec<(String, String, String)>, std::collections::HashSet<String>) = {
+            let settings_manager = self.app_handle.state::<SettingsManager>();
+            let settings = settings_manager.get();
+
+            let wanted = repository_name.as_deref().map(str::trim).filter(|s| !s.is_empty());
+            let repos: Vec<(String, String, String)> = settings
+                .repositories
+                .iter()
+                .filter(|r| wanted.map_or(true, |n| r.name == n))
+                .map(|r| (r.id.clone(), r.name.clone(), r.path.clone()))
+                .collect();
+            if repos.is_empty() {
+                let names: Vec<&str> = settings.repositories.iter().map(|r| r.name.as_str()).collect();
+                return Err(McpError::invalid_params(
+                    match wanted {
+                        Some(n) => format!("repository '{}' not found. available: [{}]", n, names.join(", ")),
+                        None => "no repository is registered in oretachi".to_string(),
+                    },
+                    None,
+                ));
+            }
+
+            // 登録済み判定にはリポジトリ擬似エントリ・ホームも含める（同一パスの二重登録を防ぐ）
+            let mut registered: std::collections::HashSet<String> = settings
+                .worktrees
+                .iter()
+                .map(|w| normalize_path_for_match(&w.path))
+                .collect();
+            // リポジトリ root 自体は「ワークツリー」として取り込む対象ではない
+            registered.extend(repos.iter().map(|(_, _, p)| normalize_path_for_match(p)));
+            (repos, registered)
+        };
+
+        // git worktree list はブロッキング I/O なのでワーカースレッドへ逃がす
+        let scan_repos = repos.clone();
+        let candidates: Vec<(String, String, crate::git_worktree::GitWorktreeInfo)> =
+            tokio::task::spawn_blocking(move || {
+                let mut out = Vec::new();
+                for (repo_id, repo_name, repo_path) in &scan_repos {
+                    match crate::git_worktree::list_worktrees(repo_path) {
+                        Ok(list) => {
+                            for info in list {
+                                // bare リポジトリ本体は作業ディレクトリを持たない。
+                                // メインワークツリーは git worktree remove できず、誤登録して削除すると
+                                // リポジトリ本体を巻き込む（リポジトリをサブディレクトリで登録していると
+                                // registered による除外をすり抜けるため、フラグで確実に外す）。
+                                // prunable は実体ディレクトリが既に無く、登録しても壊れたカードになるだけ。
+                                if info.bare || info.is_main || info.prunable {
+                                    continue;
+                                }
+                                if registered.contains(&normalize_path_for_match(&info.path)) {
+                                    continue;
+                                }
+                                out.push((repo_id.clone(), repo_name.clone(), info));
+                            }
+                        }
+                        // 1 リポジトリの失敗で全体を落とさない（移動済み・削除済みのリポジトリがありうる）
+                        Err(e) => log::warn!(
+                            "[mcp] oretachi_import_worktree: git worktree list failed for {}: {}",
+                            repo_path, e
+                        ),
+                    }
+                }
+                out
+            })
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let target_path = path.as_deref().map(str::trim).filter(|s| !s.is_empty());
+
+        // path 未指定 or dry_run なら候補の列挙だけ
+        if target_path.is_none() || dry_run.unwrap_or(false) {
+            let json: Vec<serde_json::Value> = candidates
+                .iter()
+                .map(|(_, repo_name, info)| {
+                    serde_json::json!({
+                        "path": info.path,
+                        "name": worktree_name_from_path(&info.path),
+                        "branch": info.branch,
+                        "detached": info.detached,
+                        "repositoryName": repo_name,
+                    })
+                })
+                .collect();
+            log::info!("[mcp] oretachi_import_worktree: {} candidate(s)", json.len());
+            return Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&json)
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?,
+            )]));
+        }
+
+        let wanted_path = normalize_path_for_match(target_path.expect("checked above"));
+        let Some((repo_id, repo_name, info)) = candidates
+            .into_iter()
+            .find(|(_, _, i)| normalize_path_for_match(&i.path) == wanted_path)
+        else {
+            return Err(McpError::invalid_params(
+                format!(
+                    "'{}' is not an unregistered worktree of any registered repository. call this tool without path to list candidates",
+                    target_path.unwrap_or_default()
+                ),
+                None,
+            ));
+        };
+
+        // フロント側の登録結果を受け取るための oneshot を先に登録してから emit する
+        let request_id = format!(
+            "import-{}",
+            IMPORT_WORKTREE_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        let rx = {
+            let registry = self.app_handle.state::<ImportWorktreeAckRegistry>();
+            registry.register(request_id.clone())
+        };
+
+        let name = worktree_name_from_path(&info.path);
+        let event = ImportWorktreeEvent {
+            request_id: request_id.clone(),
+            repository_id: repo_id,
+            repository_name: repo_name,
+            path: info.path.clone(),
+            name: name.clone(),
+            // detached HEAD のワークツリーはブランチ名を持たない。空文字で登録する
+            branch_name: info.branch.clone().unwrap_or_default(),
+        };
+        if let Err(e) = self.app_handle.emit("mcp-import-worktree", &event) {
+            self.app_handle.state::<ImportWorktreeAckRegistry>().take(&request_id);
+            return Err(McpError::internal_error(e.to_string(), None));
+        }
+        log::info!("[mcp] oretachi_import_worktree: path={} request_id={}", info.path, request_id);
+
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(IMPORT_WORKTREE_ACK_TIMEOUT_SECS),
+            rx,
+        )
+        .await
+        {
+            Ok(Ok(ImportWorktreeOutcome::Imported(id))) => Ok(CallToolResult::success(vec![Content::text(
+                format!("ワークツリー '{}' ({}) を登録しました。id={}", name, info.path, id),
+            )])),
+            Ok(Ok(ImportWorktreeOutcome::AlreadyRegistered)) => Ok(CallToolResult::success(vec![Content::text(
+                format!("'{}' は既に登録済みでした。", info.path),
+            )])),
+            Ok(Ok(ImportWorktreeOutcome::Failed(e))) => {
+                Err(McpError::internal_error(format!("取り込みに失敗しました: {}", e), None))
+            }
+            // 送信側が drop された（ウィンドウが閉じた等）/ タイムアウト
+            Ok(Err(_)) | Err(_) => {
+                self.app_handle.state::<ImportWorktreeAckRegistry>().take(&request_id);
+                Err(McpError::internal_error(
+                    format!(
+                        "'{}' の取り込み結果を {} 秒以内に受け取れませんでした。oretachi_get_worktree_status で登録状況を確認してください。",
+                        info.path, IMPORT_WORKTREE_ACK_TIMEOUT_SECS
+                    ),
+                    None,
+                ))
+            }
+        }
+    }
+
     #[tool(description = "現在の PTY セッション一覧を返す。session_id, cwd, isAiAgent, ワークツリー名/ID を含む。oretachi_kill_terminal を呼ぶ前の確認に使う", annotations(read_only_hint = true))]
     fn oretachi_list_terminals(
         &self,
@@ -1600,30 +1804,21 @@ impl NotifyService {
         let settings_manager = self.app_handle.state::<SettingsManager>();
         let settings = settings_manager.get();
 
-        let filter_id: Option<String> = if let Some(id) = worktree_id.as_deref() {
-            if !settings.worktrees.iter().any(|w| w.id == id) {
-                return Err(McpError::invalid_params(format!("worktree id '{}' not found", id), None));
-            }
-            Some(id.to_string())
-        } else if let Some(name) = worktree_name.as_deref() {
-            let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == name).collect();
-            match matches.len() {
-                0 => {
-                    let names: Vec<&str> = settings.worktrees.iter().map(|w| w.name.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("worktree '{}' not found. available: [{}]", name, names.join(", ")),
-                        None,
-                    ));
-                }
-                1 => Some(matches[0].id.clone()),
-                _ => {
-                    let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
-                    return Err(McpError::invalid_params(
-                        format!("multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]", name, ids.join(", ")),
-                        None,
-                    ));
-                }
-            }
+        // どちらも未指定なら絞り込みなし（全 PTY を返す）
+        let has_filter = worktree_id.as_deref().map_or(false, |s| !s.trim().is_empty())
+            || worktree_name.as_deref().map_or(false, |s| !s.trim().is_empty());
+        let filter_id: Option<String> = if has_filter {
+            Some(
+                resolve_worktree(
+                    &settings,
+                    worktree_id.as_deref(),
+                    worktree_name.as_deref(),
+                    None,
+                    "specify one of worktree_name / worktree_id",
+                )?
+                .id
+                .clone(),
+            )
         } else {
             None
         };
@@ -1805,6 +2000,81 @@ fn resolve_worktree_by_dir<'a>(settings: &'a AppSettings, dir: &str) -> Option<&
         .find(|w| normalize_path_for_match(&w.path) == target)
 }
 
+/// ワークツリーのパスから表示名（末尾ディレクトリ名）を取り出す。
+/// フロントのリポジトリ名導出（`path.split(/[/\\]/).pop()`）と同じ規則。
+fn worktree_name_from_path(path: &str) -> String {
+    path.trim_end_matches(['/', '\\'])
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(path)
+        .to_string()
+}
+
+/// worktree_id / worktree_name / project_dir のいずれかからワークツリーを1件に確定する。
+/// 優先順位は id > name > project_dir。同名が複数ある場合は ID を列挙したエラーを返し、
+/// 呼び出し元（AI agent）に worktree_id での指定をやり直させる。
+/// `missing_hint` はどれも指定されなかったときのエラー文（ツールごとに受け付ける引数が違うため呼び出し側が渡す）。
+fn resolve_worktree<'a>(
+    settings: &'a AppSettings,
+    worktree_id: Option<&str>,
+    worktree_name: Option<&str>,
+    project_dir: Option<&str>,
+    missing_hint: &str,
+) -> Result<&'a WorktreeEntry, McpError> {
+    let available = || {
+        settings
+            .worktrees
+            .iter()
+            .map(|w| w.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    if let Some(id) = worktree_id.map(str::trim).filter(|s| !s.is_empty()) {
+        return settings.worktrees.iter().find(|w| w.id == id).ok_or_else(|| {
+            McpError::invalid_params(format!("worktree id '{}' not found", id), None)
+        });
+    }
+
+    if let Some(name) = worktree_name.map(str::trim).filter(|s| !s.is_empty()) {
+        let matches: Vec<_> = settings.worktrees.iter().filter(|w| w.name == name).collect();
+        return match matches.len() {
+            0 => Err(McpError::invalid_params(
+                format!("worktree '{}' not found. available: [{}]", name, available()),
+                None,
+            )),
+            1 => Ok(matches[0]),
+            _ => {
+                let ids: Vec<&str> = matches.iter().map(|w| w.id.as_str()).collect();
+                Err(McpError::invalid_params(
+                    format!(
+                        "multiple worktrees named '{}'. specify worktree_id to disambiguate: [{}]",
+                        name,
+                        ids.join(", ")
+                    ),
+                    None,
+                ))
+            }
+        };
+    }
+
+    if let Some(dir) = project_dir.map(str::trim).filter(|s| !s.is_empty()) {
+        return resolve_worktree_by_dir(settings, dir).ok_or_else(|| {
+            McpError::invalid_params(
+                format!(
+                    "no worktree matches project_dir '{}'. available: [{}]",
+                    dir,
+                    available()
+                ),
+                None,
+            )
+        });
+    }
+
+    Err(McpError::invalid_params(missing_hint.to_string(), None))
+}
+
 /// ワークツリーの所属ワークグループを解決する。workgroup_id が未設定/不明な場合は
 /// 先頭グループにフォールバック（フロントの resolvedGroupId と同仕様）。
 fn resolve_workgroup<'a>(settings: &'a AppSettings, worktree: &WorktreeEntry) -> Option<&'a Workgroup> {
@@ -1813,6 +2083,25 @@ fn resolve_workgroup<'a>(settings: &'a AppSettings, worktree: &WorktreeEntry) ->
         .as_ref()
         .and_then(|id| settings.workgroups.iter().find(|g| &g.id == id))
         .or_else(|| settings.workgroups.first())
+}
+
+/// ワークグループの表示名。UI と同じ規則で、name 未設定なら並び順から自動生成する
+/// （フロントの useWorkgroups.displayName / i18n `workgroup.autoName` と一致させる）。
+/// 生の name をそのまま返すと、リネームしていない既定グループが全部 null になり
+/// レポート側で「グループが出てこない」状態になるため、ここで解決しておく。
+fn workgroup_display_name(settings: &AppSettings, group: &Workgroup) -> String {
+    if let Some(name) = group.name.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        return name.to_string();
+    }
+    let n = settings
+        .workgroups
+        .iter()
+        .position(|g| g.id == group.id)
+        .map_or(1, |i| i + 1);
+    match settings.locale.as_deref() {
+        Some("en") => format!("Group ({})", n),
+        _ => format!("グループ({})", n),
+    }
 }
 
 /// リポジトリに通知フックが1件以上設定されているか。
@@ -2645,6 +2934,29 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
 mod tests {
     use super::*;
 
+    /// name 未設定のグループは UI 側 (useWorkgroups.displayName / i18n workgroup.autoName) が
+    /// 並び順から「グループ(N)」を自動生成して表示する。MCP が生の name をそのまま返すと
+    /// リネームしていない既定グループが null になり、レポートにグループが出せなくなる。
+    #[test]
+    fn workgroup_display_name_matches_ui_fallback() {
+        let mut settings = AppSettings::default();
+        settings.workgroups = vec![
+            Workgroup { id: "wg-1".into(), name: None, ..Default::default() },
+            Workgroup { id: "wg-2".into(), name: Some("  ".into()), ..Default::default() },
+            Workgroup { id: "wg-3".into(), name: Some("リリース準備".into()), ..Default::default() },
+        ];
+
+        // 既定ロケール (ja) は 1 始まりの並び順で自動生成
+        assert_eq!(workgroup_display_name(&settings, &settings.workgroups[0]), "グループ(1)");
+        // 空白のみの name も未設定扱い（UI の trim と揃える）
+        assert_eq!(workgroup_display_name(&settings, &settings.workgroups[1]), "グループ(2)");
+        // 明示的な name はそのまま
+        assert_eq!(workgroup_display_name(&settings, &settings.workgroups[2]), "リリース準備");
+
+        settings.locale = Some("en".into());
+        assert_eq!(workgroup_display_name(&settings, &settings.workgroups[0]), "Group (1)");
+    }
+
     /// Claude Code は plan モードで `readOnlyHint` が立っていない MCP ツールを
     /// permissions.allow に関わらず一律 ask にする。ここで advertise 内容を固定しておく。
     #[test]
@@ -2659,6 +2971,7 @@ mod tests {
             "oretachi_list_repository",
             "oretachi_list_terminals",
             "oretachi_read_terminal",
+            "oretachi_show_worktree",
         ];
         const NOT_READ_ONLY: &[&str] = &[
             "notify_worktree",
@@ -2668,6 +2981,7 @@ mod tests {
             "oretachi_spawn_terminal",
             "oretachi_kill_terminal",
             "oretachi_write_terminal",
+            "oretachi_import_worktree",
         ];
 
         let tools = NotifyService::tool_router().list_all();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -64,7 +64,7 @@ pub struct WorktreeEntry {
     pub is_repository: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Workgroup {
     pub id: String,

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,7 @@ import FirstRunWizard from "./components/wizard/FirstRunWizard.vue";
 import { message } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { useIdeSelect } from "./composables/useIdeSelect";
-import { useSettings, syncRepositoryWorktrees } from "./composables/useSettings";
+import { useSettings, syncRepositoryWorktrees, applyPluginConfig } from "./composables/useSettings";
 import { useWorktrees } from "./composables/useWorktrees";
 import { useI18n } from "vue-i18n";
 import { useSubWindows, requestSubWindowLayout } from "./composables/useSubWindows";
@@ -64,7 +64,7 @@ import { useUpdater } from "./composables/useUpdater";
 import Toast from "primevue/toast";
 import Popover from "primevue/popover";
 import MacTrafficLights from "./components/MacTrafficLights.vue";
-import { isMac } from "./composables/usePlatform";
+import { isMac, isWindows } from "./composables/usePlatform";
 
 const { t } = useI18n();
 
@@ -422,7 +422,7 @@ const activeTaskExecAgent = computed(() => {
 
 // タスク追加ダイアログ「追加先」のデフォルト:
 // ホームのパネルが worktree 一覧なら現在選択中グループ、それ以外（task/archive）なら先頭グループ
-const { panelMode } = useHomePanel();
+const { panelMode, listMode } = useHomePanel();
 const taskDialogDefaultWorkgroupId = computed(() =>
   panelMode.value === "worktree"
     ? activeWorkgroupId.value
@@ -1481,6 +1481,115 @@ onMounted(async () => {
       }
     },
   );
+
+  // MCP: 指定ワークツリーをフォーカスする
+  await listen<{ worktree_id: string }>("mcp-show-worktree", async (event) => {
+    const { worktree_id } = event.payload;
+    const targetWt = worktrees.value.find((w) => w.id === worktree_id);
+    if (!targetWt) {
+      logDebug(`[Terminal] mcp-show-worktree: worktree ${worktree_id} not found, skipping`);
+      return;
+    }
+    // サブウィンドウへ分離済みならそのウィンドウを前面に出す（メイン側のタブは動かさない）
+    if (isDetached(worktree_id)) {
+      try {
+        await focusSubWindow(worktree_id);
+      } catch (e) {
+        logDebug(`[Terminal] mcp-show-worktree: focusSubWindow failed: ${e}`);
+      }
+      return;
+    }
+    // ホームへ戻ったときにカードが見えるよう、所属グループが非アクティブなら併せて切り替える。
+    // ホーム/リポジトリ擬似ワークツリーは専用パネル側の表示なのでグループ切替の対象外。
+    if (!isPseudoWorktree(targetWt)) {
+      const groupId = resolvedGroupId(targetWt.workgroupId);
+      if (groupId && groupId !== activeWorkgroupId.value) {
+        activeWorkgroupId.value = groupId;
+      }
+      // グループを選んだらリポジトリ一覧ではなくワークツリー一覧を出す
+      // （WorkgroupBar / cycleWorkgroup のグループ切替と同じ扱い）
+      listMode.value = "worktree";
+    }
+    try {
+      await switchToWorktree(worktree_id);
+    } catch (e) {
+      logDebug(`[Terminal] mcp-show-worktree: switchToWorktree failed: ${e}`);
+      return;
+    }
+    // トレイ常駐のためメインウィンドウは hide / minimize されているのが常態。
+    // setFocus だけでは画面に出てこないので show → unminimize から行う。
+    const win = getCurrentWindow();
+    await win.show();
+    await win.unminimize();
+    await win.setFocus();
+  });
+
+  // MCP: git 上に存在するが oretachi 未登録のワークツリーを settings へ取り込む。
+  // git worktree 自体は既にあるので git_worktree_add は呼ばず、エントリ登録だけを行う。
+  await listen<{
+    request_id: string;
+    repository_id: string;
+    repository_name: string;
+    path: string;
+    name: string;
+    branch_name: string;
+  }>("mcp-import-worktree", async (event) => {
+    const { request_id, repository_id, repository_name, path, name, branch_name } = event.payload;
+    const ack = (status: string, worktreeId?: string, error?: string) =>
+      invoke("mcp_import_worktree_result", { requestId: request_id, status, worktreeId, error }).catch(
+        (e) => logDebug(`[Terminal] mcp-import-worktree: ack failed: ${e}`),
+      );
+
+    // Rust 側でも重複チェックしているが、emit と登録のあいだに他経路で追加される余地がある。
+    // 比較規則は Rust の normalize_path_for_match と揃える（Windows のみ小文字化）。
+    const normalize = (p: string) => {
+      const s = p.replace(/\\/g, "/").replace(/\/+$/, "");
+      return isWindows ? s.toLowerCase() : s;
+    };
+    const existing = settings.value.worktrees.find((w) => normalize(w.path) === normalize(path));
+    if (existing) {
+      await ack("already", existing.id);
+      return;
+    }
+
+    let entry: WorktreeEntry;
+    try {
+      entry = {
+        id: `${Date.now()}-${crypto.randomUUID().replace(/-/g, "").slice(0, 6)}`,
+        name,
+        repositoryId: repository_id,
+        repositoryName: repository_name,
+        path,
+        branchName: branch_name,
+        // 取り込み先は現在表示中のワークグループ（手動追加と同じ扱い）
+        ...(activeWorkgroupId.value ? { workgroupId: activeWorkgroupId.value } : {}),
+        // 手動追加 (onAddWorktreeConfirm) と初期状態を揃える
+        ...(settings.value.worktreeDefaults?.autoApproval ? { autoApproval: true } : {}),
+      };
+      commitWorktree(entry);
+    } catch (e) {
+      await ack("failed", undefined, String(e));
+      return;
+    }
+
+    // ここから先の失敗は「登録済みだが後続処理が一部失敗した」状態。
+    // ack を failed にするとエージェントが再取り込みを試みて実態と食い違うため、必ず ok を返す。
+    try {
+      // settings 配列とランタイム配列は二重管理。片方だけ変異させるとカウントと表示が
+      // 再起動まで分裂するため、必ずここで同期する。
+      syncWorktreesFromSettings();
+      if (settings.value.worktreeDefaults?.autoApproval) autoApprovalMap.set(entry.id, true);
+      tryAutoAssignHotkey(entry.id);
+
+      // 通常のワークツリー追加と同じく、プラグイン設定を書いて MCP / 通知を有効化する
+      const repo = settings.value.repositories.find((r) => r.id === repository_id);
+      await applyPluginConfig(entry.path, entry.name, repo?.notificationHooks ?? []);
+    } catch (e) {
+      logDebug(`[Terminal] mcp-import-worktree: post-commit step failed: ${e}`);
+    }
+
+    await ack("ok", entry.id);
+  });
 
   // サブウィンドウ準備完了 → init データをイベントで送信（サブウィンドウ復元より前に登録必須）
   await listen<{ worktreeId: string }>("sub-ready", async (event) => {

--- a/src/components/HomeSettingsDialog.vue
+++ b/src/components/HomeSettingsDialog.vue
@@ -36,6 +36,7 @@ async function selectWorktreeBaseDir() {
 }
 
 const reseedResult = ref("");
+const reapplyResult = ref("");
 
 // プロンプト未設定時に実際に注入される既定値（Rust 側の定義を唯一の出所にする）
 const defaultHomeAgentPrompt = ref("");
@@ -55,6 +56,30 @@ async function reseedHomeSkills() {
   } catch (e) {
     await message(t("homeAgent.reseedFailed", { error: e }), { kind: "error" });
   }
+}
+
+/** oretachi プラグイン設定 (settings.local.json) をホームへ再適用する */
+async function reapplyPluginConfig() {
+  const baseDir = settings.value.worktreeBaseDir;
+  if (!baseDir) return;
+  reapplyResult.value = "";
+  try {
+    // overwrite=false: プラグイン設定は毎回マージ書き込みされ、スキルの編集は温存される
+    await invoke("setup_home_claude_dir", { homePath: baseDir, overwrite: false });
+    reapplyResult.value = t("homeAgent.reapplyDone");
+  } catch (e) {
+    await message(t("homeAgent.reapplyFailed", { error: e }), { kind: "error" });
+  }
+}
+
+// 空欄にフォーカスしたら既定値を実値として投入する。
+// placeholder のままだと「既定値に一行足したい」ときに全文を打ち直す必要があるため。
+// 全消しして blur すれば undefined に戻り、「空 = 既定値」のセマンティクスは維持される。
+function onPromptFocus() {
+  if (settings.value.homeAgentPrompt) return;
+  if (!defaultHomeAgentPrompt.value) return;
+  settings.value.homeAgentPrompt = defaultHomeAgentPrompt.value;
+  scheduleSave();
 }
 
 function onPromptChange(e: Event) {
@@ -96,6 +121,7 @@ function onPromptChange(e: Event) {
             rows="6"
             :value="settings.homeAgentPrompt ?? ''"
             :placeholder="defaultHomeAgentPrompt"
+            @focus="onPromptFocus"
             @change="onPromptChange"
           />
         </div>
@@ -108,6 +134,16 @@ function onPromptChange(e: Event) {
             <span v-if="reseedResult" class="hint">{{ reseedResult }}</span>
           </div>
           <p class="hint">{{ t('homeAgent.reseedSkillsDesc') }}</p>
+        </div>
+
+        <div class="field">
+          <div class="row">
+            <button class="btn-secondary" @click="reapplyPluginConfig">
+              {{ t('homeAgent.reapplyPlugin') }}
+            </button>
+            <span v-if="reapplyResult" class="hint">{{ reapplyResult }}</span>
+          </div>
+          <p class="hint">{{ t('homeAgent.reapplyPluginDesc') }}</p>
         </div>
       </template>
 
@@ -255,7 +291,11 @@ function onPromptChange(e: Event) {
     },
     "homeAgent": {
       "label": "Home management agent",
-      "desc": "Injected into every Claude Code session started in the home worktree (via the SessionStart hook, so it survives /clear and restarts). Just run `claude` there and it becomes the worktree management agent. Leave empty to use the default shown below; the actual procedures live as skills under .claude/skills/ in the base directory.",
+      "desc": "Injected into every Claude Code session started in the home worktree (via the SessionStart hook, so it survives /clear and restarts). Just run `claude` there and it becomes the worktree management agent. Click the empty box to drop in the default text and edit from there; leave it empty and the default is used as-is. The actual procedures live as skills under .claude/skills/ in the base directory.",
+      "reapplyPlugin": "Re-apply plugin settings",
+      "reapplyPluginDesc": "Writes the oretachi plugin settings into .claude/settings.local.json in the base directory again. Use this if the file was edited or deleted by hand and MCP tools / notifications stopped working. Other keys in the file are preserved.",
+      "reapplyDone": "Re-applied the plugin settings.",
+      "reapplyFailed": "Failed to re-apply the plugin settings: {error}",
       "reseedSkills": "Restore bundled skills",
       "reseedSkillsDesc": "Bundled skills (worktree-cleanup / report / assign) are written once and never overwrite your edits. This button restores them to the defaults; skills you added yourself are left untouched.",
       "reseedConfirm": "Overwrite the bundled skill files with their default contents? Your edits to those files will be lost.",
@@ -276,7 +316,11 @@ function onPromptChange(e: Event) {
     },
     "homeAgent": {
       "label": "ホームの管理エージェント",
-      "desc": "home で起動した Claude Code セッションに常時注入されます（SessionStart フック経由。/clear や再起動後も維持）。home で claude を起動するだけでワークツリー管理エージェントになります。空なら薄く表示されている既定値が使われます。実際の手順は追加先ディレクトリの .claude/skills/ にスキルとして置かれます。",
+      "desc": "home で起動した Claude Code セッションに常時注入されます（SessionStart フック経由。/clear や再起動後も維持）。home で claude を起動するだけでワークツリー管理エージェントになります。空欄をクリックすると既定値が入るので、そこから追記・編集できます。空のままなら既定値がそのまま使われます。実際の手順は追加先ディレクトリの .claude/skills/ にスキルとして置かれます。",
+      "reapplyPlugin": "プラグイン設定を再適用",
+      "reapplyPluginDesc": "追加先ディレクトリの .claude/settings.local.json に oretachi プラグイン設定を書き直します。手で編集・削除して MCP ツールや通知が効かなくなったときに使います。ファイル内の他のキーは保持されます。",
+      "reapplyDone": "プラグイン設定を再適用しました。",
+      "reapplyFailed": "プラグイン設定の再適用に失敗しました: {error}",
       "reseedSkills": "同梱スキルを再展開",
       "reseedSkillsDesc": "同梱スキル (worktree-cleanup / report / assign) は初回のみ書き出され、以降ユーザーの編集を上書きしません。このボタンは既定内容に戻します。自分で追加したスキルには触れません。",
       "reseedConfirm": "同梱スキルのファイルを既定内容で上書きしますか？ これらのファイルへの編集は失われます。",

--- a/src/components/RepositoryCard.vue
+++ b/src/components/RepositoryCard.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { message } from "@tauri-apps/plugin-dialog";
+import { applyPluginConfig } from "../composables/useSettings";
 import type { Repository } from "../types/settings";
 import type { Worktree } from "../types/worktree";
 import TerminalThumbnail from "./TerminalThumbnail.vue";
@@ -92,6 +94,20 @@ function onMoveWindow(id: string) {
 function withMenuHidden<T>(fn: () => T): T {
   menuRef.value?.hide();
   return fn();
+}
+
+/**
+ * リポジトリ root の .claude/settings.local.json に oretachi プラグイン設定を書き直す。
+ * 手編集や削除で MCP / 通知が効かなくなったときの復旧口。
+ * 親へ emit せずここで完結させる（他の状態に影響しない自己完結の操作のため）。
+ */
+async function reapplyPluginConfig() {
+  try {
+    await applyPluginConfig(props.repo.path, props.repo.name, props.repo.notificationHooks ?? []);
+    await message(t("menu.reapplyPluginDone"), { kind: "info" });
+  } catch (e) {
+    await message(t("menu.reapplyPluginFailed", { error: e }), { kind: "error" });
+  }
 }
 </script>
 
@@ -185,6 +201,10 @@ function withMenuHidden<T>(fn: () => T): T {
         <button class="popup-item" @click="withMenuHidden(() => emit('openArtifacts', repo.id))">
           <span class="pi pi-box" />
           {{ t('menu.openArtifacts') }}
+        </button>
+        <button class="popup-item" @click="withMenuHidden(reapplyPluginConfig)">
+          <span class="pi pi-refresh" />
+          {{ t('menu.reapplyPlugin') }}
         </button>
         <template v-if="worktreeId">
           <button
@@ -454,6 +474,9 @@ function withMenuHidden<T>(fn: () => T): T {
       "selectExecScript": "Select exec script",
       "clearExecScript": "Clear exec script",
       "openArtifacts": "Artifacts",
+      "reapplyPlugin": "Re-apply plugin settings",
+      "reapplyPluginDone": "Wrote the oretachi plugin settings into .claude/settings.local.json.",
+      "reapplyPluginFailed": "Failed to re-apply the plugin settings: {error}",
       "autoApproval": "Auto approval",
       "setHotkey": "Assign hotkey",
       "moveToSubWindow": "Move to sub window",
@@ -481,6 +504,9 @@ function withMenuHidden<T>(fn: () => T): T {
       "selectExecScript": "実行スクリプトを選択",
       "clearExecScript": "実行スクリプトを解除",
       "openArtifacts": "アーティファクト",
+      "reapplyPlugin": "プラグイン設定を再適用",
+      "reapplyPluginDone": ".claude/settings.local.json に oretachi プラグイン設定を書き込みました。",
+      "reapplyPluginFailed": "プラグイン設定の再適用に失敗しました: {error}",
       "autoApproval": "自動承認",
       "setHotkey": "ホットキーを割り当て",
       "moveToSubWindow": "サブウィンドウへ移動",

--- a/src/components/WorktreeCard.vue
+++ b/src/components/WorktreeCard.vue
@@ -3,7 +3,10 @@ import { ref, computed } from "vue";
 import type { Worktree } from "../types/worktree";
 import type { Workgroup } from "../types/settings";
 import { useI18n } from "vue-i18n";
+import { invoke } from "@tauri-apps/api/core";
+import { message } from "@tauri-apps/plugin-dialog";
 import { useWorkgroups } from "../composables/useWorkgroups";
+import { useSettings, applyPluginConfig } from "../composables/useSettings";
 
 const { t } = useI18n();
 const { displayName: workgroupDisplayName } = useWorkgroups();
@@ -108,6 +111,36 @@ function onMoveWindow() {
 function onOpenArtifacts() {
   menuRef.value?.hide();
   emit("openArtifacts", props.worktree.id);
+}
+
+/**
+ * このワークツリーの .claude/settings.local.json に oretachi プラグイン設定を書き直す。
+ * 手編集や削除で MCP / 通知が効かなくなったときの復旧口。
+ * ホームは同梱スキルのシードも伴うため専用コマンド経由にする。
+ * 親へ emit せずここで完結させる（他の状態に影響しない自己完結の操作のため）。
+ */
+async function onReapplyPluginConfig() {
+  menuRef.value?.hide();
+  const { settings } = useSettings();
+  try {
+    if (isHome.value) {
+      // overwrite=false: プラグイン設定は毎回マージ書き込みされ、スキルの編集は温存される
+      await invoke("setup_home_claude_dir", {
+        homePath: props.worktree.path,
+        overwrite: false,
+      });
+    } else {
+      const repo = settings.value.repositories.find((r) => r.id === props.worktree.repositoryId);
+      await applyPluginConfig(
+        props.worktree.path,
+        props.worktree.name,
+        repo?.notificationHooks ?? [],
+      );
+    }
+    await message(t("menu.reapplyPluginDone"), { kind: "info" });
+  } catch (e) {
+    await message(t("menu.reapplyPluginFailed", { error: e }), { kind: "error" });
+  }
 }
 
 function onDuplicate() {
@@ -239,6 +272,10 @@ const terminalList = computed(() =>
         <button class="popup-item" :disabled="loading" @click="onMoveWindow">
           <span :class="detached ? 'pi pi-window-maximize' : 'pi pi-external-link'" />
           {{ detached ? t('menu.moveToMainWindow') : t('menu.moveToSubWindow') }}
+        </button>
+        <button class="popup-item" :disabled="loading" @click="onReapplyPluginConfig">
+          <span class="pi pi-refresh" />
+          {{ t('menu.reapplyPlugin') }}
         </button>
         <button v-if="!isHome" class="popup-item" :disabled="loading" @click="onDuplicate">
           <span class="pi pi-copy" />
@@ -597,6 +634,9 @@ const terminalList = computed(() =>
       "openArtifacts": "Artifacts",
       "moveToSubWindow": "Move to sub window",
       "moveToMainWindow": "Move to main window",
+      "reapplyPlugin": "Re-apply plugin settings",
+      "reapplyPluginDone": "Wrote the oretachi plugin settings into .claude/settings.local.json.",
+      "reapplyPluginFailed": "Failed to re-apply the plugin settings: {error}",
       "duplicate": "Duplicate",
       "moveToWorkgroup": "Move to group",
       "delete": "Delete"
@@ -618,6 +658,9 @@ const terminalList = computed(() =>
       "openArtifacts": "アーティファクト",
       "moveToSubWindow": "サブウィンドウに移動",
       "moveToMainWindow": "メインウィンドウに戻す",
+      "reapplyPlugin": "プラグイン設定を再適用",
+      "reapplyPluginDone": ".claude/settings.local.json に oretachi プラグイン設定を書き込みました。",
+      "reapplyPluginFailed": "プラグイン設定の再適用に失敗しました: {error}",
       "duplicate": "複製",
       "moveToWorkgroup": "グループ移動",
       "delete": "削除"

--- a/src/components/WorktreeHeader.vue
+++ b/src/components/WorktreeHeader.vue
@@ -51,7 +51,7 @@ async function closeWindow() {
 
 <template>
   <div
-    class="flex items-center justify-between border-b shrink-0 pr-[2px] py-1 transition-colors duration-200"
+    class="flex items-center justify-between border-b shrink-0 pr-2 py-1 transition-colors duration-200"
     :class="[
       props.isWindowFocused ? 'border-[#cba6f7]/50' : 'opacity-80 border-[#313244]',
       isMac && props.showWindowControls ? '' : 'pl-4'
@@ -131,51 +131,75 @@ async function closeWindow() {
         {{ props.artifactCount }}
       </button>
     </div>
-    <div class="flex items-center">
+    <!-- 右端のボタン列。5つとも hdr-btn で同一寸法・同一アイコンサイズに揃える
+         （個別に w-*/h-*/font-size を書くと必ずどれかがずれるため、寸法はここに集約する） -->
+    <div class="flex items-center gap-1">
       <button
-        class="flex items-center justify-center w-7 h-7 rounded bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors mr-1"
+        class="hdr-btn bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4]"
         :title="t('openInIde')"
         @click="$emit('open-in-ide')"
       >
-        <span class="pi pi-code text-sm" />
+        <span class="pi pi-code" />
       </button>
       <button
-        class="flex items-center justify-center w-7 h-7 rounded bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors"
-        :class="props.showWindowControls && !isMac ? 'mr-4' : ''"
+        class="hdr-btn bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4]"
         :title="t('openArtifacts')"
         @click="$emit('open-artifacts')"
       >
-        <span class="pi pi-box text-sm" />
+        <span class="pi pi-box" />
       </button>
       <template v-if="props.showWindowControls && !isMac">
+        <!-- アプリ機能ボタンとウィンドウ操作の区切り（誤クリック防止の間隔） -->
+        <span class="w-2 shrink-0" aria-hidden="true" />
         <button
-          class="flex items-center justify-center h-8 hover:bg-[#313244] text-[#6c7086] hover:text-[#cdd6f4] transition-colors"
-          style="width: 42px; margin: 0 1px;"
+          class="hdr-btn hover:bg-[#313244] text-[#6c7086] hover:text-[#cdd6f4]"
           :title="t('minimize')"
           @click="minimize"
         >
-          <span class="pi pi-minus text-xs" />
+          <span class="pi pi-minus" />
         </button>
         <button
-          class="flex items-center justify-center h-8 hover:bg-[#313244] text-[#6c7086] hover:text-[#cdd6f4] transition-colors"
-          style="width: 42px; margin: 0 1px;"
+          class="hdr-btn hover:bg-[#313244] text-[#6c7086] hover:text-[#cdd6f4]"
           :title="t('maximize')"
           @click="toggleMaximize"
         >
-          <span class="pi pi-stop text-xs" />
+          <span class="pi pi-stop" />
         </button>
         <button
-          class="flex items-center justify-center h-8 hover:bg-[#c0392b] hover:text-white text-[#6c7086] transition-colors"
-          style="width: 42px; margin: 0 1px;"
+          class="hdr-btn hover:bg-[#c0392b] hover:text-white text-[#6c7086]"
           :title="t('close')"
           @click="closeWindow"
         >
-          <span class="pi pi-times text-xs" />
+          <span class="pi pi-times" />
         </button>
       </template>
     </div>
   </div>
 </template>
+
+<style scoped>
+/**
+ * ヘッダ右端のボタン共通スタイル。
+ * 寸法は rem 基準に統一する。webview の setZoom は px/rem を同率で拡大するのでズームでは崩れないが、
+ * 単位を混ぜると（w-7 = rem と inline の px）差分を見落としやすいため rem に寄せている。
+ */
+.hdr-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+/* アイコンの実寸も揃える。pi の既定 font-size (1rem) と line-height を上書きして中央に置く */
+.hdr-btn .pi {
+  font-size: 0.875rem;
+  line-height: 1;
+}
+</style>
 
 <i18n lang="json">
 {

--- a/src/composables/usePlatform.ts
+++ b/src/composables/usePlatform.ts
@@ -1,3 +1,5 @@
 import { platform } from "@tauri-apps/plugin-os";
 
 export const isMac = platform() === "macos";
+/** パス比較の大文字小文字を無視すべきか等、Windows 固有の分岐に使う */
+export const isWindows = platform() === "windows";

--- a/src/composables/useRepositoryActions.ts
+++ b/src/composables/useRepositoryActions.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
-import { useSettings, syncRepositoryWorktrees } from "./useSettings";
+import { useSettings, syncRepositoryWorktrees, applyPluginConfig } from "./useSettings";
 import { useWorktrees } from "./useWorktrees";
 
 export type AddRepositoryResult = "added" | "cancelled" | "notARepo" | "alreadyRegistered";
@@ -18,22 +18,27 @@ export function useRepositoryActions() {
     const selected = await open({ directory: true, multiple: false });
     if (typeof selected !== "string") return "cancelled";
 
+    // サブディレクトリを選ばれてもリポジトリのルートへ正規化する。
+    // ルート以外を登録すると git worktree list が返すメインワークツリーと食い違い、
+    // oretachi_import_worktree がメインワークツリーを「未登録」として拾ってしまう。
+    let repoPath: string;
     try {
       const valid = await invoke<boolean>("git_validate_repo", { path: selected });
       if (!valid) return "notARepo";
+      repoPath = await invoke<string>("git_repo_root", { path: selected });
     } catch {
       return "notARepo";
     }
 
-    if (settings.value.repositories.some((r) => r.path === selected)) {
+    if (settings.value.repositories.some((r) => r.path === repoPath)) {
       return "alreadyRegistered";
     }
 
-    const name = selected.split(/[/\\]/).pop() ?? selected;
+    const name = repoPath.split(/[/\\]/).pop() ?? repoPath;
     settings.value.repositories.push({
-      id: selected,
+      id: repoPath,
       name,
-      path: selected,
+      path: repoPath,
     });
     // リポジトリ擬似ワークツリーを生成してランタイム配列にも反映する。
     // 自ウィンドウ発の settings-changed は無視されるためここで明示的に同期しないと、
@@ -41,6 +46,11 @@ export function useRepositoryActions() {
     syncRepositoryWorktrees();
     syncWorktreesFromSettings();
     scheduleSave();
+    // リポジトリ root で開いたターミナルでも oretachi プラグイン (通知フック + MCP) を効かせる。
+    // 失敗してもリポジトリ追加自体は成立させる（カードのメニューから再適用できる）。
+    void applyPluginConfig(repoPath, name).catch((e) => {
+      console.error("リポジトリのプラグイン設定書き込みに失敗:", e);
+    });
     return "added";
   }
 

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -4,7 +4,13 @@ import { emit } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { error } from "@tauri-apps/plugin-log";
 import { platform } from "@tauri-apps/plugin-os";
-import type { AppSettings, HotkeyBinding, HotkeySettings, Workgroup } from "../types/settings";
+import type {
+  AppSettings,
+  HotkeyBinding,
+  HotkeySettings,
+  NotificationHookEntry,
+  Workgroup,
+} from "../types/settings";
 import { setLocale } from "../i18n";
 import { setVerboseLogging } from "../utils/log";
 import { isHomeWorktree, makeHomeWorktreeEntry } from "../utils/homeWorktree";
@@ -232,6 +238,24 @@ export async function setupHomeClaudeDir(homePath: string, overwrite = false): P
   } catch (e) {
     console.error("ホームの .claude/ 準備に失敗:", e);
   }
+}
+
+/**
+ * 任意のディレクトリの .claude/settings.local.json に oretachi プラグイン設定を書く。
+ * write_plugin_config は既存 JSON をマージする冪等実装なので、何度呼んでも安全。
+ * ワークツリー追加時だけでなく、リポジトリ登録時や「再適用」操作からも使う。
+ * 失敗は呼び出し側に投げる（明示操作ではエラーを見せたいため）。
+ */
+export async function applyPluginConfig(
+  path: string,
+  name: string,
+  hooks: NotificationHookEntry[] = [],
+): Promise<void> {
+  await invoke("write_claude_plugin_config", {
+    worktreePath: path,
+    worktreeName: name,
+    hooks,
+  });
 }
 
 const settings = ref<AppSettings>({

--- a/src/utils/autoApproval.ts
+++ b/src/utils/autoApproval.ts
@@ -51,6 +51,7 @@ export function hasApprovalPrompt(content: string): boolean {
  * - oretachi_spawn_terminal / oretachi_write_terminal … 任意コマンドを PTY に流し込める
  *   (= 任意コード実行)。無条件承認すると安全ゲートが無効化される
  * - oretachi_add_task … 任意 prompt からワークツリー作成とエージェント実行を発火する
+ * - oretachi_import_worktree … settings を書き換えてワークツリーを登録する
  *
  * artifact_module は artifact より前に置く (正規表現の選択肢で長い方を優先させるため)。
  */
@@ -62,6 +63,7 @@ export const ORETACHI_AUTO_APPROVE_TOOLS = [
   "oretachi_set_description",
   "oretachi_get_worktree_status",
   "oretachi_get_app_options",
+  "oretachi_show_worktree",
   "oretachi_list_repository",
   "oretachi_list_terminals",
   "oretachi_read_terminal",


### PR DESCRIPTION
Closes #112

## 概要

Issue #112 の6項目を実装しました。あわせて、実装中に見つかったリポジトリ消失につながる経路を塞いでいます。

## 変更内容

### 1. ワークツリー一覧にワークグループを追加
`oretachi_get_worktree_status` の返却に `workgroupId` / `workgroupName` を追加しました。

`Workgroup.name` は `Option<String>` で、UI は生の name ではなく `displayName()` が並び順から生成した「グループ(N)」を表示しています。生の name をそのまま返すとリネームしていない既定グループが全部 `null` になるため、`workgroup_display_name()` で UI と同じ規則（i18n `workgroup.autoName` 相当、`settings.locale` で ja/en 切替）に揃えました。

`worktree-report` スキルも、`workgroupName` で章立てして出力するよう更新しています。

### 2. `oretachi_show_worktree` の追加
指定ワークツリーをフォーカスします。detached ならサブウィンドウを前面に、メイン側ならタブ切替＋所属グループ切替＋ウィンドウの `show()`→`unminimize()`→`setFocus()`。トレイ常駐でウィンドウが隠れている状態でも確実に出てきます。

### 3. `oretachi_import_worktree` の追加
git にはあるが oretachi 未登録のワークツリーを取り込みます。`git worktree list --porcelain` を全件パースするので、追加先ディレクトリの外にあるものも検出できます。引数なし / `dry_run` で候補列挙、`path` 指定で登録。登録は `oretachi_close_worktree` と同じ ACK 方式でフロントに行わせています。

### 4. ホーム / リポジトリへのプラグイン設定注入
リポジトリには注入経路が存在せず、リポジトリ root で開いた Claude では MCP も通知も効いていませんでした。リポジトリ登録時に注入するようにし、ホーム設定ダイアログ・リポジトリカード・ワークツリーカードの3箇所に「プラグイン設定を再適用」ボタンを追加しています。

### 5. ヘッダのボタン整列
`WorktreeHeader` の右端5ボタンが、寸法（28×28 vs 36×28）とアイコンサイズ（14px vs 12px）の両方でずれていました。共通クラス `.hdr-btn` に統一し、間隔も `gap-1` に一本化しています。

### 6. 管理エージェント欄のデフォルト値
空欄にフォーカスすると既定値全文が実値として入り、そこから追記できます。全消しすれば `undefined` に戻り「空 = 既定値」のセマンティクスは維持されます。

## バグレビューで見つかった問題の修正

### 🔴 メインワークツリーの取り込みによるリポジトリ消失

`validate_repo` は `git rev-parse --is-inside-work-tree` なのでリポジトリの**サブディレクトリ**でも成功し、`addRepository` はそれをルートへ正規化せず保存していました。その状態で `oretachi_import_worktree` を使うと、メインワークツリーのルートが「未登録のワークツリー」として候補に現れます。取り込むと `isHome`/`isRepository` が付かない通常エントリになるため削除ガードを通過し、`worktree_remove` が `fatal: '...' is a main working tree` を lock error と判定できずに `fs::remove_dir_all` へフォールバックして、`.git` ごとリポジトリ本体が消えます。

3層で塞ぎました。

1. `GitWorktreeInfo` に `is_main` を追加し、取り込み候補から確実に除外
2. `git_repo_root`（`git rev-parse --show-toplevel`）を追加し、リポジトリ登録時にルートへ正規化（根本原因）
3. `worktree_remove` がメインワークツリーのエラーでディレクトリ直接削除にフォールバックしないようガード

3 は「実体ディレクトリを手で消したワークツリーの掃除」という既存の正常系を壊さないよう、`is a main working tree` だけに限定しています（`is not a working tree` はフォールバック側の prune 処理に任せるのが正しい挙動のため）。

### 🟡 その他

- `prunable` なワークツリー（実体が消えている）を取り込み候補から除外
- `mcp-import-worktree` の ack を `commitWorktree` の前後で分離。登録成功後の後続処理が失敗しても `ok` を返し、「登録済みなのにエラーが返って再取り込みされる」状態をなくした
- パス比較規則を Rust の `normalize_path_for_match` と揃えた（`usePlatform.ts` に `isWindows` を追加）
- 取り込み時にも `worktreeDefaults.autoApproval` を適用し、手動追加と初期状態を統一

## リファクタリング

ワークツリー解決ロジックが5箇所にコピペされていたため `resolve_worktree()` へ集約しました。エラー文言・優先順位（id > name > project_dir）・同名複数時の ID 列挙は既存実装と同一です。

## テスト

- `cargo test` 70 passed（`parse_worktree_list` の prunable/locked/is_main、`is_main_worktree_error`、`workgroup_display_name` を新規追加）
- `pnpm test` 78 passed
- `cargo check` / `pnpm run type-check` エラーなし

## 未確認事項

**実機での動作確認はできていません。** 特に以下はレビュー時にご確認ください。

- ヘッダボタンの見た目（コードは揃えましたが、実際のウィンドウでの確認は未実施）
- `git_repo_root` が返す Windows パス形式（git は `C:/repo` 形式、ディレクトリ選択ダイアログは `C:\repo`）が既存のパス比較と噛み合うか
- `oretachi_import_worktree` の取り込み後、カード・タブ・カウントが再起動なしで反映されるか

また `git_repo_root` による正規化は**新規登録にのみ**効きます。既にサブディレクトリで登録済みのリポジトリがある環境では登録パスは食い違ったままですが、上記1と3で取り込み・削除の両方を塞いでいるため実害は出ません。

`session_context_handler` はリポジトリ擬似ワークツリーへのプロンプト注入を意図的に `None` にしているため、リポジトリでは「通知は飛ぶがプロンプトは注入されない」状態になります。`repositoryAgentPrompt` は Issue のスコープ外と判断し、既存の挙動を維持しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
