### PR TITLE
feat(mcp): oretachi_add_task にワークグループ指定を追加し、oretachi_list_workgroups を新設 (#116)

### DIFF
--- a/src-tauri/skills-home/worktree-assign/SKILL.md
+++ b/src-tauri/skills-home/worktree-assign/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: worktree-assign
 description: 新しい作業のためにワークツリーを作成し、AI エージェントにタスクを割り当てる。「〜をやりたい」「〜を直して」といった作業依頼を受けたときに、適切なリポジトリを選んで oretachi_add_task でワークツリー作成とエージェント起動を任せる。
-allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_list_repository, mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status, mcp__plugin_oretachi_oretachi__oretachi_add_task, mcp__plugin_oretachi_oretachi__notify_worktree
+allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_list_repository, mcp__plugin_oretachi_oretachi__oretachi_get_worktree_status, mcp__plugin_oretachi_oretachi__oretachi_list_workgroups, mcp__plugin_oretachi_oretachi__oretachi_add_task, mcp__plugin_oretachi_oretachi__notify_worktree
 ---
 
 # worktree-assign スキル
@@ -14,8 +14,14 @@ allowed-tools: mcp__plugin_oretachi_oretachi__oretachi_list_repository, mcp__plu
 2. `oretachi_get_worktree_status` で、**同じ作業のワークツリーが既に無いか**確認する。
    description やブランチ名が近いものがあれば、新規作成せずそちらを使うようユーザーに提案する。
 3. 作業内容が曖昧なら、着手前に 1〜2 点だけ確認する（対象リポジトリ・スコープ）。
-4. `oretachi_add_task` にプロンプトを渡す。oretachi 側が
+4. ユーザーが追加先ワークグループを指定している場合のみ、`oretachi_list_workgroups` で
+   一覧を取得して該当する `name`（または `id`）を確認する。
+   指定が無ければ引数を省略する。この場合の追加先は **UI で現在選択中のワークグループ**で、
+   `isDefault: true` のグループとは限らない。どこに入ったかを断定して報告しないこと。
+5. `oretachi_add_task` にプロンプトを渡す。oretachi 側が
    ワークツリー作成 → セットアップスクリプト実行 → エージェント起動まで非同期で行う。
+   追加先を指定する場合は `workgroup_name`（表示名）か `workgroup_id` を併せて渡す。
+   一致しない名前を渡すとエラーになり、タスクは作成されない。
 
 ## プロンプトの書き方
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -532,6 +532,9 @@ pub struct ArtifactModuleParams {
 pub struct ListRepositoryParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListWorkgroupsParams {}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetWorktreeStatusParams {
     #[schemars(description = "絞り込みキーワード（name / branchName / description の部分一致、大文字小文字は区別しない）。省略時は全件")]
     pub query: Option<String>,
@@ -556,12 +559,18 @@ pub struct AddTaskParams {
     pub prompt: String,
     #[schemars(description = "リモート実行するかどうか (省略時は false)")]
     pub remote_exec: Option<bool>,
+    #[schemars(description = "追加先ワークグループのID (oretachi_list_workgroups の id)。省略時はUIで現在選択中のワークグループに入る (isDefault のグループとは限らない)")]
+    pub workgroup_id: Option<String>,
+    #[schemars(description = "追加先ワークグループの表示名 (oretachi_list_workgroups の name)。workgroup_id 指定時は無視される")]
+    pub workgroup_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
 struct AddTaskEvent {
     prompt: String,
     remote_exec: bool,
+    /// 追加先ワークグループID。None ならフロントに委ね、UI で現在選択中の WG に入る。
+    workgroup_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1341,6 +1350,35 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
+    #[tool(description = "登録済みワークグループの一覧を返す。各エントリは id・表示名(name)・色(color)・タスク実行エージェント(taskAddAgent)・isDefault を含む。oretachi_add_task で追加先ワークグループを指定する前に、利用可能なワークグループを確認するために使う。isDefault は「ワークグループ未設定のワークツリーが表示上フォールバックする先頭グループ」を意味し、oretachi_add_task で指定を省略したときの追加先ではない (省略時はUIで現在選択中のワークグループに入る)", annotations(read_only_hint = true))]
+    fn oretachi_list_workgroups(
+        &self,
+        Parameters(_params): Parameters<ListWorkgroupsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let settings_manager = self.app_handle.state::<SettingsManager>();
+        let settings = settings_manager.get();
+        // 先頭グループが既定（未所属ワークツリーのフォールバック先）。
+        // resolve_workgroup / フロントの useWorkgroups.resolvedGroupId と同じ規則。
+        let groups: Vec<serde_json::Value> = settings
+            .workgroups
+            .iter()
+            .enumerate()
+            .map(|(i, g)| {
+                serde_json::json!({
+                    "id": g.id,
+                    "name": workgroup_display_name(&settings, g),
+                    "color": g.color,
+                    "taskAddAgent": g.task_add_agent,
+                    "isDefault": i == 0,
+                })
+            })
+            .collect();
+        let json = serde_json::to_string_pretty(&groups)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        log::info!("[mcp] oretachi_list_workgroups: {} groups", groups.len());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
     #[tool(description = "アーティファクトを検索する。queryを省略すると全件返却。title/content/type/languageを対象に部分一致検索。結果はcontentを除いたメタデータのみ。検索対象は project_dir(現在の作業ディレクトリ)で指定するのが最も確実。HOMEタブやリポジトリルートで作業している場合は project_dir が必須", annotations(read_only_hint = true))]
     async fn search_artifact(
         &self,
@@ -1435,24 +1473,36 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(description = "タスク追加リクエストを送信する。AIがタスクコードを生成し、ワークツリー作成やエージェント実行を非同期で行う")]
+    #[tool(description = "タスク追加リクエストを送信する。AIがタスクコードを生成し、ワークツリー作成やエージェント実行を非同期で行う。追加先ワークグループを指定したい場合は oretachi_list_workgroups で一覧を取得してから workgroup_id / workgroup_name を渡す")]
     fn oretachi_add_task(
         &self,
-        Parameters(AddTaskParams { prompt, remote_exec }): Parameters<AddTaskParams>,
+        Parameters(AddTaskParams { prompt, remote_exec, workgroup_id, workgroup_name }): Parameters<AddTaskParams>,
     ) -> Result<CallToolResult, McpError> {
         let prompt = prompt.trim().to_string();
         if prompt.is_empty() {
             return Err(McpError::invalid_params("prompt must not be empty", None));
         }
+        let resolved_workgroup_id = {
+            let settings_manager = self.app_handle.state::<SettingsManager>();
+            let settings = settings_manager.get();
+            resolve_workgroup_target(&settings, workgroup_id.as_deref(), workgroup_name.as_deref())
+                .map_err(|e| McpError::invalid_params(e, None))?
+        };
         let remote = remote_exec.unwrap_or(false);
         let event = AddTaskEvent {
             prompt: prompt.clone(),
             remote_exec: remote,
+            workgroup_id: resolved_workgroup_id.clone(),
         };
         self.app_handle
             .emit("mcp-add-task", &event)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        log::info!("[mcp] oretachi_add_task: prompt={} remote_exec={}", prompt, remote);
+        log::info!(
+            "[mcp] oretachi_add_task: prompt={} remote_exec={} workgroup_id={}",
+            prompt,
+            remote,
+            resolved_workgroup_id.as_deref().unwrap_or("(default)")
+        );
         Ok(CallToolResult::success(vec![Content::text(
             "タスク追加リクエストを送信しました。タスクの生成・実行は非同期に行われます。",
         )]))
@@ -2178,6 +2228,69 @@ fn workgroup_display_name(settings: &AppSettings, group: &Workgroup) -> String {
     match settings.locale.as_deref() {
         Some("en") => format!("Group ({})", n),
         _ => format!("グループ({})", n),
+    }
+}
+
+/// MCP から指定された workgroup_id / workgroup_name を settings 上のワークグループIDに解決する。
+/// どちらも未指定なら `Ok(None)` を返し、追加先はフロントに委ねる
+/// （UI で現在選択中の WG = useWorkgroups.activeWorkgroupId に入る）。
+/// 解決できない・曖昧な場合は先頭 WG へ暗黙にフォールバックせずエラーにする
+/// （意図しないワークグループへタスクが入るのを防ぐため）。
+fn resolve_workgroup_target(
+    settings: &AppSettings,
+    workgroup_id: Option<&str>,
+    workgroup_name: Option<&str>,
+) -> Result<Option<String>, String> {
+    fn non_empty(s: Option<&str>) -> Option<&str> {
+        s.map(str::trim).filter(|v| !v.is_empty())
+    }
+    let id = non_empty(workgroup_id);
+    let name = non_empty(workgroup_name);
+
+    // エージェントが自己修復できるよう、エラー時は利用可能な WG を列挙する。
+    let available = || {
+        if settings.workgroups.is_empty() {
+            return "(ワークグループが未定義です)".to_string();
+        }
+        settings
+            .workgroups
+            .iter()
+            .map(|g| format!("{} ({})", workgroup_display_name(settings, g), g.id))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    if let Some(id) = id {
+        return match settings.workgroups.iter().find(|g| g.id == id) {
+            Some(g) => Ok(Some(g.id.clone())),
+            None => Err(format!(
+                "workgroup_id '{}' に一致するワークグループがありません。利用可能: {}",
+                id,
+                available()
+            )),
+        };
+    }
+
+    let Some(name) = name else {
+        return Ok(None);
+    };
+    let matched: Vec<&Workgroup> = settings
+        .workgroups
+        .iter()
+        .filter(|g| workgroup_display_name(settings, g).trim().eq_ignore_ascii_case(name))
+        .collect();
+    match matched.as_slice() {
+        [g] => Ok(Some(g.id.clone())),
+        [] => Err(format!(
+            "workgroup_name '{}' に一致するワークグループがありません。利用可能: {}",
+            name,
+            available()
+        )),
+        _ => Err(format!(
+            "workgroup_name '{}' に一致するワークグループが複数あります。workgroup_id で指定してください。利用可能: {}",
+            name,
+            available()
+        )),
     }
 }
 
@@ -3056,6 +3169,79 @@ mod tests {
         assert_eq!(workgroup_display_name(&settings, &settings.workgroups[0]), "Group (1)");
     }
 
+    fn wg_settings() -> AppSettings {
+        let mut settings = AppSettings::default();
+        settings.workgroups = vec![
+            Workgroup { id: "wg-1".into(), name: None, ..Default::default() },
+            Workgroup { id: "wg-2".into(), name: Some("リリース準備".into()), ..Default::default() },
+            Workgroup { id: "wg-3".into(), name: Some("Bug Fix".into()), ..Default::default() },
+        ];
+        settings
+    }
+
+    /// 未指定なら追加先はフロント既定の WG に委ねる（従来挙動の維持）。
+    #[test]
+    fn resolve_workgroup_target_defaults_to_none() {
+        let settings = wg_settings();
+        assert_eq!(resolve_workgroup_target(&settings, None, None), Ok(None));
+        // 空文字・空白のみは未指定扱い
+        assert_eq!(resolve_workgroup_target(&settings, Some(""), Some("  ")), Ok(None));
+    }
+
+    #[test]
+    fn resolve_workgroup_target_matches_id_and_name() {
+        let settings = wg_settings();
+        // id 優先（name が別グループを指していても id が勝つ）
+        assert_eq!(
+            resolve_workgroup_target(&settings, Some("wg-2"), Some("Bug Fix")),
+            Ok(Some("wg-2".into()))
+        );
+        // 表示名の完全一致
+        assert_eq!(
+            resolve_workgroup_target(&settings, None, Some("リリース準備")),
+            Ok(Some("wg-2".into()))
+        );
+        // 前後空白と大文字小文字は無視
+        assert_eq!(
+            resolve_workgroup_target(&settings, None, Some("  bug fix  ")),
+            Ok(Some("wg-3".into()))
+        );
+        // 自動生成された表示名でも指定できる
+        assert_eq!(
+            resolve_workgroup_target(&settings, None, Some("グループ(1)")),
+            Ok(Some("wg-1".into()))
+        );
+    }
+
+    /// 解決できない指定は先頭 WG へ暗黙フォールバックせずエラーにし、
+    /// エージェントが言い直せるよう利用可能な WG を列挙する。
+    #[test]
+    fn resolve_workgroup_target_errors_instead_of_falling_back() {
+        let settings = wg_settings();
+
+        let err = resolve_workgroup_target(&settings, Some("wg-404"), None).unwrap_err();
+        assert!(err.contains("wg-404"), "{}", err);
+        assert!(err.contains("リリース準備 (wg-2)"), "{}", err);
+
+        let err = resolve_workgroup_target(&settings, None, Some("存在しない")).unwrap_err();
+        assert!(err.contains("存在しない"), "{}", err);
+        assert!(err.contains("グループ(1) (wg-1)"), "{}", err);
+    }
+
+    /// 同名 WG が複数ある場合は、どちらに入るか予測できないのでエラーにする。
+    #[test]
+    fn resolve_workgroup_target_rejects_ambiguous_name() {
+        let mut settings = wg_settings();
+        settings.workgroups.push(Workgroup {
+            id: "wg-4".into(),
+            name: Some("リリース準備".into()),
+            ..Default::default()
+        });
+        let err = resolve_workgroup_target(&settings, None, Some("リリース準備")).unwrap_err();
+        assert!(err.contains("複数"), "{}", err);
+        assert!(err.contains("workgroup_id"), "{}", err);
+    }
+
     /// Claude Code は plan モードで `readOnlyHint` が立っていない MCP ツールを
     /// permissions.allow に関わらず一律 ask にする。ここで advertise 内容を固定しておく。
     #[test]
@@ -3068,6 +3254,7 @@ mod tests {
             "oretachi_inspect_worktree",
             "oretachi_get_app_options",
             "oretachi_list_repository",
+            "oretachi_list_workgroups",
             "oretachi_list_terminals",
             "oretachi_read_terminal",
             "oretachi_show_worktree",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1368,9 +1368,16 @@ onMounted(async () => {
   });
 
   // MCPからのタスク追加
-  await listen<{ prompt: string; remote_exec: boolean }>("mcp-add-task", (event) => {
-    onAddTaskConfirm(event.payload.prompt, event.payload.remote_exec);
-  });
+  await listen<{ prompt: string; remote_exec: boolean; workgroup_id?: string | null }>(
+    "mcp-add-task",
+    (event) => {
+      onAddTaskConfirm(
+        event.payload.prompt,
+        event.payload.remote_exec,
+        event.payload.workgroup_id ?? undefined,
+      );
+    },
+  );
 
   // ワークツリーの description セット
   // - plan あり (ExitPlanMode フック由来): AI 要約してからセット

--- a/src/utils/autoApproval.test.ts
+++ b/src/utils/autoApproval.test.ts
@@ -90,6 +90,11 @@ describe('detectOretachiToolPrompt', () => {
       .toBe('oretachi_read_terminal')
   })
 
+  it('detects read-only list_workgroups', () => {
+    expect(detectOretachiToolPrompt(ccPrompt('plugin:oretachi:oretachi - oretachi_list_workgroups')))
+      .toBe('oretachi_list_workgroups')
+  })
+
   it('returns null for destructive close_worktree', () => {
     expect(detectOretachiToolPrompt(ccPrompt('plugin:oretachi:oretachi - oretachi_close_worktree')))
       .toBeNull()

--- a/src/utils/autoApproval.ts
+++ b/src/utils/autoApproval.ts
@@ -65,6 +65,7 @@ export const ORETACHI_AUTO_APPROVE_TOOLS = [
   "oretachi_get_app_options",
   "oretachi_show_worktree",
   "oretachi_list_repository",
+  "oretachi_list_workgroups",
   "oretachi_list_terminals",
   "oretachi_read_terminal",
 ] as const;


### PR DESCRIPTION
Closes #116

## 背景

MCP ツール `oretachi_add_task` は `prompt` / `remote_exec` の 2 引数しか受け取らず、作成されるワークツリーの追加先ワークグループ (WG) を指定できなかった。

フロントの `onAddTaskConfirm(prompt, remoteExec, workgroupId)` は既に第 3 引数で WG を受け取り、`activeWorkgroupId` の切り替えと `add_worktree` ステップへの反映を実装済みだが、`mcp-add-task` の listener だけが第 3 引数を渡していなかったため、タスク追加ダイアログと MCP で機能差が出ていた。

また、エージェントが WG を指定するには id / 表示名を知る必要があるが、それを返すツールが無く、ワークツリーが 1 つも無い WG は発見できなかった。

## 変更内容

### `oretachi_list_workgroups`（新規・read-only）

`id` / `name` / `color` / `taskAddAgent` / `isDefault` を返す。`name` は既存の `workgroup_display_name()` を再利用し、未リネームの WG は UI と同じ `グループ(1)` / `Group (1)` にフォールバックする。機微情報を含みやすい `systemPrompt` / `execPrompt` は返さない。

### `oretachi_add_task` に WG 指定を追加

- `AddTaskParams` に `workgroup_id` / `workgroup_name`、`AddTaskEvent` に `workgroup_id` を追加
- `resolve_workgroup_target()`: `workgroup_id` 優先 → 表示名の完全一致（trim + 大文字小文字無視）の順に解決
- **解決できない指定・同名 WG が複数ある指定は、先頭 WG へ暗黙にフォールバックせず `invalid_params`**。意図しない WG へタスクが入るのを防ぐため。エラー文に利用可能な WG を `name (id)` 形式で列挙し、エージェントが自己修復できるようにしている
- 両方省略時は従来どおり未指定のまま emit する

### その他

- `App.vue` の `mcp-add-task` listener が `workgroup_id` を第 3 引数に渡す（`useAddTaskDialog.ts` は既存実装のまま変更なし）
- `oretachi_list_workgroups` を `ORETACHI_AUTO_APPROVE_TOOLS`（自動承認リスト）と `worktree-assign` スキルの `allowed-tools` / 手順に追加

## 実装メモ

- Issue で再利用を挙げていた `resolve_workgroup()` は引数に `&WorktreeEntry` を取るワークツリー起点の関数なので、新ツールからは再利用せず `settings.workgroups` を直接走査している。`isDefault = 先頭要素` という仕様は同関数およびフロントの `resolvedGroupId` と一致
- **WG 指定を省略した場合の追加先は「UI で現在選択中のワークグループ」であり `isDefault` のグループとは限らない**（`useTaskExecution.ts` が `activeWorkgroupId` にフォールバックするため）。エージェントが追加先を誤って報告しないよう、ツール description とスキル手順にその旨を明記した
- Issue 補足のとおり、MCP 経由でも UI のアクティブ WG が切り替わる副作用は既存挙動としてそのまま踏襲している

## 確認

- `cargo check` パス
- `cargo test --lib` 91 passed / 0 failed（`resolve_workgroup_target` の新規テスト 4 件、`read_only_tools_advertise_read_only_hint` 更新を含む）
- `pnpm run type-check` パス
- `pnpm run test` 84 passed / 0 failed

実機確認（WG を 2 つ以上用意し、`workgroup_name` 指定でのタスク追加とアクティブ WG の切り替えを目視確認）は未実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
