### PR TITLE
feat(terminal): terminal_id の発番・env 注入・hook 貫通・list_terminals 露出 (#122)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3674,6 +3674,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "uuid",
  "webview2-com",
  "windows 0.58.0",
  "windows-sys 0.59.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ dotenvy = "0.15"
 base64 = "0.22"
 sha2 = "0.10"
 rand = "0.8"
+uuid = { version = "1", features = ["v4"] }
 subtle = "2"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 sysinfo = "0.38"

--- a/src-tauri/notify/src/main.rs
+++ b/src-tauri/notify/src/main.rs
@@ -28,6 +28,12 @@ use std::path::PathBuf;
 
 const SERVER_INFO_FILE: &str = "mcp-server.json";
 
+/// oretachi が PTY spawn 時に発番してタブのシェルへ注入する terminal_id の env 名。
+/// hook は「PTY シェル → エージェント → hook」と辿る子孫プロセスなので env を継承する。
+/// CC 2.1.207 以降 hook へ oretachi 由来の情報を渡せる経路はこれだけ（`${user_config.*}` は
+/// 拒否され `pluginConfigs` も読まれない）。
+const TERMINAL_ID_ENV: &str = "ORETACHI_TERMINAL_ID";
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
@@ -52,21 +58,19 @@ fn main() {
     // 出さないよう何も出力せず必ず exit 0 する（--notify の exit(1) とは異なる方針）。
     if has_flag(&args, "--session-context", "-s") {
         let dir = resolve_project_dir(&args);
-        match fetch_session_context(&dir) {
-            Ok(Some(prompt)) => {
-                let out = serde_json::json!({
-                    "hookSpecificOutput": {
-                        "hookEventName": "SessionStart",
-                        "additionalContext": prompt
-                    }
-                });
-                println!("{}", out);
-            }
-            Ok(None) => {}
+        let terminal_id = read_terminal_id();
+        // サーバへの問い合わせが失敗しても、terminal_id だけは注入する（自己同定は
+        // グループ systemPrompt の設定有無やサーバ稼働状況と独立に成立させたい）。
+        let prompt = match fetch_session_context(&dir) {
+            Ok(p) => p,
             Err(_e) => {
                 #[cfg(debug_assertions)]
                 eprintln!("Session context fetch failed: {}", _e);
+                None
             }
+        };
+        if let Some(out) = build_session_context_output(prompt.as_deref(), terminal_id.as_deref()) {
+            println!("{}", out);
         }
         std::process::exit(0);
     }
@@ -150,6 +154,22 @@ fn resolve_project_dir(args: &[String]) -> String {
     }
 }
 
+/// env から自分が属する oretachi ターミナルタブの terminal_id を読む。
+/// oretachi 管理外のターミナルから起動された場合は未設定なので `None`。
+fn read_terminal_id() -> Option<String> {
+    std::env::var(TERMINAL_ID_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// payload に terminalId を付ける（未取得なら何もしない）。
+fn attach_terminal_id(payload: &mut serde_json::Value, terminal_id: Option<&str>) {
+    if let Some(id) = terminal_id {
+        payload["terminalId"] = serde_json::Value::String(id.to_string());
+    }
+}
+
 /// stdin がパイプ（非 TTY）の場合のみ読み取り、タイムアウト付きで返す。
 /// Claude Code ライフサイクルフックのコンテキスト JSON を body として受け取るために使用。
 fn read_stdin_if_piped() -> Option<String> {
@@ -191,6 +211,7 @@ fn send_notification(
     if let Some(a) = agent {
         payload["agent"] = serde_json::Value::String(a.to_string());
     }
+    attach_terminal_id(&mut payload, read_terminal_id().as_deref());
     post_json("/notify", &payload)
 }
 
@@ -210,7 +231,8 @@ fn send_set_description(project_dir: &str, hook_json: Option<&str>) -> Result<()
 /// /session-context からワークツリー所属グループの systemPrompt を取得する。
 /// 未管理ディレクトリやプロンプト未設定の場合はサーバーが prompt: null を返すので Ok(None)。
 fn fetch_session_context(project_dir: &str) -> Result<Option<String>, String> {
-    let payload = serde_json::json!({ "projectDir": project_dir });
+    let mut payload = serde_json::json!({ "projectDir": project_dir });
+    attach_terminal_id(&mut payload, read_terminal_id().as_deref());
     let body = post_json_read_body("/session-context", &payload)?;
     let v: serde_json::Value =
         serde_json::from_str(&body).map_err(|e| format!("Invalid response JSON: {}", e))?;
@@ -223,11 +245,40 @@ fn fetch_session_context(project_dir: &str) -> Result<Option<String>, String> {
 /// UserPromptSubmit フック用。/prompt-context から現在の description を取得し、
 /// stdout に出力すべき additionalContext JSON を返す。skip 時は Ok(None)。
 fn send_prompt_context(project_dir: &str) -> Result<Option<String>, String> {
-    let payload = serde_json::json!({
+    let mut payload = serde_json::json!({
         "projectDir": project_dir,
     });
+    attach_terminal_id(&mut payload, read_terminal_id().as_deref());
     let body = post_json_read_body("/prompt-context", &payload)?;
     Ok(build_prompt_context_output(&body))
+}
+
+/// SessionStart 用の additionalContext JSON を組み立てる。
+/// グループの systemPrompt と、自分が属するタブの terminal_id を続けて注入する。
+/// terminal_id を伝えるのは、エージェントが oretachi_list_terminals 等で
+/// 「自分自身のターミナル」を同定できるようにするため（同一ワークツリーに複数タブが
+/// あると cwd だけでは区別できない）。どちらも無ければ `None`（何も出力しない）。
+fn build_session_context_output(prompt: Option<&str>, terminal_id: Option<&str>) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(p) = prompt.map(str::trim).filter(|s| !s.is_empty()) {
+        parts.push(p.to_string());
+    }
+    if let Some(id) = terminal_id.map(str::trim).filter(|s| !s.is_empty()) {
+        parts.push(format!(
+            "[oretachi] このセッションが動いているターミナルの terminal_id は「{}」です。oretachi_list_terminals が返す terminalId と突合すれば自分自身のターミナルを同定できます（同一ワークツリーに複数タブがある場合、cwd だけでは区別できません）。",
+            id
+        ));
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    let output = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": parts.join("\n\n"),
+        }
+    });
+    Some(output.to_string())
 }
 
 /// /prompt-context のレスポンスボディから UserPromptSubmit 用の
@@ -453,6 +504,55 @@ mod tests {
         let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
         assert!(ctx.contains("未設定"));
         assert!(ctx.contains("oretachi_set_description"));
+    }
+
+    #[test]
+    fn test_attach_terminal_id_present() {
+        let mut payload = serde_json::json!({ "projectDir": "X:/wt/foo" });
+        attach_terminal_id(&mut payload, Some("11111111-2222-3333-4444-555555555555"));
+        assert_eq!(payload["terminalId"], "11111111-2222-3333-4444-555555555555");
+    }
+
+    #[test]
+    fn test_attach_terminal_id_absent() {
+        let mut payload = serde_json::json!({ "projectDir": "X:/wt/foo" });
+        attach_terminal_id(&mut payload, None);
+        assert!(payload.get("terminalId").is_none());
+    }
+
+    #[test]
+    fn test_build_session_context_output_prompt_only() {
+        let out = build_session_context_output(Some("グループのプロンプト"), None).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "SessionStart");
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert_eq!(ctx, "グループのプロンプト");
+    }
+
+    #[test]
+    fn test_build_session_context_output_terminal_id_only() {
+        // グループ systemPrompt が未設定でも terminal_id だけは注入する
+        let out = build_session_context_output(None, Some("abc-123")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.contains("abc-123"));
+        assert!(ctx.contains("terminal_id"));
+    }
+
+    #[test]
+    fn test_build_session_context_output_both() {
+        let out = build_session_context_output(Some("グループのプロンプト"), Some("abc-123")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.starts_with("グループのプロンプト"));
+        assert!(ctx.contains("abc-123"));
+    }
+
+    #[test]
+    fn test_build_session_context_output_none() {
+        assert_eq!(build_session_context_output(None, None), None);
+        // 空白のみは未指定と同じ扱い
+        assert_eq!(build_session_context_output(Some("  "), Some("")), None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1226,6 +1226,15 @@ pub fn run() {
         let _ = dotenvy::from_filename_override(".env.development.local");
     }
 
+    // 継承した ORETACHI_TERMINAL_ID を自プロセスの env から除去する。
+    // oretachi 自身を oretachi のターミナルタブから起動した場合（`pnpm run tauri dev` の
+    // 開発フローなど）、親タブの terminal_id がアプリの env に残る。子プロセスの spawn は
+    // すべて親 env を継承する（process_utils::make_command / make_async_command）ため、
+    // そのままだと AI 判定やタスク生成でヘッドレス起動される claude とその hook が、
+    // 無関係な別タブの terminal_id を自分の ID として報告してしまう。
+    // PTY タブ自身は spawn 時に cmd.env で必ず上書きするので、ここで消して困る経路はない。
+    std::env::remove_var("ORETACHI_TERMINAL_ID");
+
     // ORETACHI_DEBUG 環境変数でデバッグモードを判定（起動時点で確定）
     let env_debug = std::env::var("ORETACHI_DEBUG")
         .map(|v| v == "true" || v == "1")

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -370,6 +370,11 @@ pub struct NotifyPayload {
     pub kind: Option<String>,
     pub body: Option<String>,
     pub agent: Option<String>,
+    /// 発火元 PTY タブの `terminal_id`。サイドカーが env `ORETACHI_TERMINAL_ID` から拾って付ける。
+    /// 同一ワークツリーに複数タブがある場合に発火元を確定するために使う。
+    /// oretachi 管理外のターミナルから起動されたエージェントでは付かない（`None`）。
+    #[serde(default, rename = "terminalId")]
+    pub terminal_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -390,6 +395,9 @@ pub struct SessionContextPayload {
     /// SessionStart フックの oretachi-notify が送る ${CLAUDE_PROJECT_DIR}。
     #[serde(default, rename = "projectDir")]
     pub project_dir: Option<String>,
+    /// 発火元 PTY タブの `terminal_id`（env `ORETACHI_TERMINAL_ID` 由来）。
+    #[serde(default, rename = "terminalId")]
+    pub terminal_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -406,6 +414,9 @@ pub struct SetWorktreeDescriptionEvent {
 pub struct PromptContextPayload {
     #[serde(default, rename = "projectDir")]
     pub project_dir: Option<String>,
+    /// 発火元 PTY タブの `terminal_id`（env `ORETACHI_TERMINAL_ID` 由来）。
+    #[serde(default, rename = "terminalId")]
+    pub terminal_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1855,7 +1866,7 @@ impl NotifyService {
         }
     }
 
-    #[tool(description = "現在の PTY セッション一覧を返す。session_id, cwd, isAiAgent, ワークツリー名/ID を含む。oretachi_kill_terminal を呼ぶ前の確認に使う", annotations(read_only_hint = true))]
+    #[tool(description = "現在の PTY セッション一覧を返す。sessionId, terminalId, cwd, isAiAgent, agentName, agentSessionId, ワークツリー名/ID を含む。terminalId は oretachi がタブ毎に発番する UUID で、SessionStart 時に自分の terminal_id が伝えられているので、それと突合すれば自分自身のターミナルを同定できる。oretachi_kill_terminal を呼ぶ前の確認に使う", annotations(read_only_hint = true))]
     fn oretachi_list_terminals(
         &self,
         Parameters(ListTerminalsParams { worktree_name, worktree_id }): Parameters<ListTerminalsParams>,
@@ -1906,8 +1917,11 @@ impl NotifyService {
             let status = if info.exit_code.is_some() { "exited" } else { "running" };
             items.push(serde_json::json!({
                 "sessionId": info.session_id,
+                "terminalId": info.terminal_id,
                 "cwd": info.cwd,
                 "isAiAgent": info.is_ai_agent,
+                "agentName": info.agent_name,
+                "agentSessionId": info.agent_session_id,
                 "worktreeId": matched_wt_id,
                 "worktreeName": matched_wt.map(|w| w.name.clone()),
                 "status": status,
@@ -2405,7 +2419,13 @@ async fn notify_handler(
         body: payload.body,
         agent: payload.agent,
     };
-    log::info!("[notify] worktree={} kind={}", event.worktree_name, event.kind);
+    // terminal_id は現状ログのみ（発火元タブの同定に使う）。購読機構 (#123 以降) で消費する。
+    log::info!(
+        "[notify] worktree={} kind={} terminal={:?}",
+        event.worktree_name,
+        event.kind,
+        payload.terminal_id
+    );
 
     let manager = app_handle.state::<McpServerManager>();
     // hook: 3秒 / approval: 1秒 で (worktree, kind) 単位に送信制限。
@@ -2563,13 +2583,14 @@ async fn session_context_handler(
             }
         })
         .filter(|s| !s.trim().is_empty());
-    if let Some(p) = &prompt {
-        log::info!(
-            "[session-context] projectDir={:?} prompt_len={}",
-            payload.project_dir,
-            p.len()
-        );
-    }
+    // terminal_id はサイドカーが env から拾って送ってくる。additionalContext への
+    // 自己 ID 注入はサイドカー側で行うため、ここではログのみ（発火元タブの確認用）。
+    log::info!(
+        "[session-context] projectDir={:?} terminal={:?} prompt_len={:?}",
+        payload.project_dir,
+        payload.terminal_id,
+        prompt.as_ref().map(|p| p.len())
+    );
     Json(serde_json::json!({ "prompt": prompt }))
 }
 
@@ -2614,8 +2635,9 @@ async fn prompt_context_handler(
     }
 
     log::info!(
-        "[prompt-context] worktree={} description={:?}",
+        "[prompt-context] worktree={} terminal={:?} description={:?}",
         wt.name,
+        payload.terminal_id,
         wt.description
     );
     Json(serde_json::json!({

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -17,6 +17,10 @@ const OUTPUT_HISTORY_BYTES: usize = 65_536;
 const EXITED_SESSION_TTL: Duration = Duration::from_secs(30);
 
 struct PtySession {
+    /// oretachi が spawn 時に発番する UUID。タブと 1:1 で、`ORETACHI_TERMINAL_ID` として
+    /// PTY の子プロセス（シェル → エージェント → hook）へ env 継承される。
+    /// hook 通知や MCP からの同定に使う。`session_id` (u32) と違いアプリ再起動を跨いで衝突しない。
+    terminal_id: String,
     /// PTY 入力の送信キュー。書き込み本体はセッション毎の writer スレッドが行う。
     /// ConPTY の入力パイプへの write は子プロセスが stdin を読まないと無期限に
     /// ブロックしうるため、Tauri コマンド（メインスレッド）からは enqueue のみ行い、
@@ -29,6 +33,11 @@ struct PtySession {
     alive: Arc<Mutex<bool>>,
     watcher_handle: Option<std::thread::JoinHandle<()>>,
     is_ai_agent: bool,
+    /// ポーリング (`start_polling`) が検出した AI エージェント名（"claude" 等）。未検出なら `None`。
+    agent_name: Option<String>,
+    /// `agent_name == "claude"` のときポーリングが取得する Claude Code のセッション UUID。
+    /// hook の stdin JSON の `session_id` と同一値（#120 で実測済み）。
+    agent_session_id: Option<String>,
     cwd: Option<String>,
     output_history: Arc<Mutex<VecDeque<u8>>>,
     /// flush ループへ渡す未配送バッファ。reader が append し、16ms 周期の flush が
@@ -102,8 +111,12 @@ fn flush_session_output(app: &AppHandle, session_id: u32, pending: &Arc<Mutex<Ve
 #[derive(Clone)]
 pub struct SessionInfo {
     pub session_id: u32,
+    /// spawn 時に発番した UUID（`ORETACHI_TERMINAL_ID`）。hook 側が運んでくる値と突合できる。
+    pub terminal_id: String,
     pub cwd: Option<String>,
     pub is_ai_agent: bool,
+    pub agent_name: Option<String>,
+    pub agent_session_id: Option<String>,
     pub exit_code: Option<i64>,
     pub last_command_exit_code: Option<i64>,
 }
@@ -474,11 +487,20 @@ impl PtyManagerCore {
                     new_infos.push((session_id, is_agent, info));
                 }
 
-                // 内部状態を更新
+                // 内部状態を更新。
+                // exited セッション（EXITED_SESSION_TTL の間 map に残る死体）は子プロセスが
+                // 既に居ないため検出結果が必ず「エージェント無し」になる。TTL 中は exit code /
+                // 最終ログを参照できるという既存方針に合わせ、エージェント情報も最終値を凍結する。
                 if let Ok(mut sessions) = sessions_arc.lock() {
-                    for (id, is_agent, _) in &new_infos {
+                    for (id, is_agent, info) in &new_infos {
                         if let Some(session) = sessions.get_mut(id) {
+                            let exited = session.exited_at.lock().ok().and_then(|g| *g).is_some();
+                            if exited {
+                                continue;
+                            }
                             session.is_ai_agent = *is_agent;
+                            session.agent_name = info.agent_name.clone();
+                            session.agent_session_id = info.session_id.clone();
                         }
                     }
                 }
@@ -550,8 +572,23 @@ impl PtyManagerCore {
             }
         });
 
+        // セッション ID / terminal_id は CommandBuilder より **前** に確定させる。
+        // terminal_id を子プロセスの env に載せる必要があるため、spawn 後の採番では間に合わない。
+        // spawn に失敗するとこの session_id は空費されるが、単調増加カウンタなので実害はない。
+        let session_id = {
+            let mut id = self.next_id.lock().map_err(|e| format!("lock error: {}", e))?;
+            let current = *id;
+            *id += 1;
+            current
+        };
+        let terminal_id = uuid::Uuid::new_v4().to_string();
+
         let mut cmd = CommandBuilder::new(&shell_cmd);
         cmd.env("TERM", "xterm-256color");
+        // タブ（シェル）が親なので、ユーザーが手で `claude` と打っても、MCP 経由で
+        // コマンドを流し込んでも、その先の hook まで env として継承される。
+        // CC 2.1.207 以降 hook へ oretachi 由来の情報を渡せる経路はこれだけ。
+        cmd.env("ORETACHI_TERMINAL_ID", &terminal_id);
 
         // シェル統合: OSC 777 で終了コードをフロントエンドに通知
         let shell_name = std::path::Path::new(&shell_cmd)
@@ -623,13 +660,6 @@ impl PtyManagerCore {
             .master
             .try_clone_reader()
             .map_err(|e| format!("Reader error: {}", e))?;
-
-        let session_id = {
-            let mut id = self.next_id.lock().map_err(|e| format!("lock error: {}", e))?;
-            let current = *id;
-            *id += 1;
-            current
-        };
 
         let alive = Arc::new(Mutex::new(true));
 
@@ -816,6 +846,7 @@ impl PtyManagerCore {
         });
 
         let session = PtySession {
+            terminal_id: terminal_id.clone(),
             input_tx,
             master: master_arc,
             child_killer,
@@ -823,6 +854,8 @@ impl PtyManagerCore {
             alive,
             watcher_handle: Some(watcher_handle),
             is_ai_agent: false,
+            agent_name: None,
+            agent_session_id: None,
             cwd,
             output_history,
             output_pending,
@@ -834,7 +867,10 @@ impl PtyManagerCore {
 
         self.sessions.lock().map_err(|e| format!("lock error: {}", e))?.insert(session_id, session);
 
-        log::debug!("[Terminal] pty_manager::spawn done session_id={} rows={} cols={}", session_id, rows, cols);
+        log::debug!(
+            "[Terminal] pty_manager::spawn done session_id={} terminal_id={} rows={} cols={}",
+            session_id, terminal_id, rows, cols
+        );
         Ok(session_id)
     }
 
@@ -1137,8 +1173,11 @@ impl PtyManagerCore {
             .iter()
             .map(|(id, s)| SessionInfo {
                 session_id: *id,
+                terminal_id: s.terminal_id.clone(),
                 cwd: s.cwd.clone(),
                 is_ai_agent: s.is_ai_agent,
+                agent_name: s.agent_name.clone(),
+                agent_session_id: s.agent_session_id.clone(),
                 exit_code: s.exit_status.lock().ok().and_then(|g| *g),
                 last_command_exit_code: s.last_command_exit_code.lock().ok().and_then(|g| *g),
             })

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -491,11 +491,12 @@ impl PtyManagerCore {
                 // exited セッション（EXITED_SESSION_TTL の間 map に残る死体）は子プロセスが
                 // 既に居ないため検出結果が必ず「エージェント無し」になる。TTL 中は exit code /
                 // 最終ログを参照できるという既存方針に合わせ、エージェント情報も最終値を凍結する。
+                let mut exited_ids: std::collections::HashSet<u32> = std::collections::HashSet::new();
                 if let Ok(mut sessions) = sessions_arc.lock() {
                     for (id, is_agent, info) in &new_infos {
                         if let Some(session) = sessions.get_mut(id) {
-                            let exited = session.exited_at.lock().ok().and_then(|g| *g).is_some();
-                            if exited {
+                            if session.exited_at.lock().ok().and_then(|g| *g).is_some() {
+                                exited_ids.insert(*id);
                                 continue;
                             }
                             session.is_ai_agent = *is_agent;
@@ -505,10 +506,16 @@ impl PtyManagerCore {
                     }
                 }
 
-                // 前回との差分を検出（is_agent または session_id が変わった場合）
+                // 前回との差分を検出（is_agent または session_id が変わった場合）。
+                // 凍結した exited セッションは emit からも外し、フロントの表示と
+                // バックエンドが保持する最終値が食い違わないようにする
+                // （タブ自体は pty-exit で既に消えているので通知する相手も居ない）。
                 let changed: HashMap<u32, AiAgentInfo> = new_infos
                     .into_iter()
                     .filter(|(id, _, info)| {
+                        if exited_ids.contains(id) {
+                            return false;
+                        }
                         let prev = last_status.get(id);
                         match prev {
                             None => true,


### PR DESCRIPTION
Closes #122 （親: #120 Phase 0.5）

## 概要

oretachi 発番の `terminal_id`（PTY spawn 時に UUID を発番 → 子プロセスの env に注入）を導入し、**タブ ↔ hook ↔ MCP を1つの ID で結ぶ**。

現状 `notify_handler` は `projectDir` の逆引きだけでセッションを見ていないため、同一ワークツリーにタブが2つあるとどちらの `Stop` か区別できなかった。この曖昧性を解消する。購読機構（#123 以降）の基盤だが、購読機能なしでも単体で価値がある。

CC 2.1.207 以降 hook へ oretachi 由来の情報を渡す手段は env 経由しかない（shell-form の `${user_config.*}` は拒否され `pluginConfigs` も読まれない）ため、env 注入が唯一の実装可能経路。**hooks.json（`claude_plugin.rs`）は変更していない。**

## 変更内容

### 1. `terminal_id` の発番と env 注入（`pty_manager.rs`）
- PTY セッション ID の採番を `CommandBuilder` 構築より**前**へ移し、同じ位置で UUID を発番して `cmd.env("ORETACHI_TERMINAL_ID", ...)` を注入
- `PtySession` に `terminal_id` を保持
- `uuid` crate を追加（未依存だった）

### 2. エージェント情報の保持と露出（`pty_manager.rs`）
- ポーリングが検出した `agent_name` / Claude セッション UUID を `PtySession` に保存（従来は emit するだけで捨てていた）
- `SessionInfo` に `terminal_id` / `agent_name` / `agent_session_id` を追加
- exited セッション（`EXITED_SESSION_TTL` の間 map に残る死体）は子プロセスが居ないため検出が必ず「エージェント無し」になる。TTL 中に最終状態を参照できるという既存方針に合わせ、**exited セッションはポーリングによる状態更新をスキップして最終値を凍結**する

### 3. hook 経路への貫通（`notify/src/main.rs`）
- env `ORETACHI_TERMINAL_ID` を読み、`/notify` `/session-context` `/prompt-context` の payload に `terminalId` を添付
- SessionStart の `additionalContext` に自分の `terminal_id` を注入（`build_session_context_output` として純粋関数に切り出し）。**グループ systemPrompt 未設定でも、サーバ問い合わせが失敗しても terminal_id だけは注入する**
- 純粋関数のユニットテストを追加（計 25 件パス）

### 4. サーバ側の受け取り（`mcp_server.rs`）
- 3つのペイロード構造体に `terminalId` を追加し、各ハンドラのログに出力（今は受け取るだけ。消費は Phase 1 以降）
- `oretachi_list_terminals` が `terminalId` / `agentName` / `agentSessionId` を返す

## 判断: 逆引き規則の差分は本 issue では埋めない

`resolve_worktree_by_dir`（正規化後の完全一致）と `oretachi_list_terminals`（前方一致＋最長一致）の差は残した。サブディレクトリで `claude` を起動すると前者が解決できない問題は認識しているが、

- 逆引き規則の変更は notify / set-description / session-context / prompt-context の**全 hook 経路の挙動を変える**。ホーム擬似ワークツリーが全ワークツリーの祖先であるため、前方一致化は過剰マッチの副作用リスクを持つ（`mcp_server.rs` の最長一致採用コメントが指摘している問題）
- Phase 0.5 の責務は「terminal_id を運ぶこと」であり、`terminal_id` → worktree 解決が実際に必要になるのは購読を実装する Phase 1（#123）

## その他の影響

- セッション ID の採番を前倒ししたため、`spawn_command` 失敗時に `session_id` が1つ空費される。単調増加カウンタなので実害なし
- `SessionInfo` はフロントに公開されていない（参照元は `mcp_server.rs` のみ）ためフロント側の変更は不要

## 検証

- `cd src-tauri && cargo check` ✅
- `cargo test -p oretachi-notify` ✅（25 件）
- `pnpm run type-check` ✅
- **実機確認**（dev ビルドを別ポートで起動し、同一ワークツリー `oretachi-6f29` に2タブを spawn）
  - `oretachi_list_terminals` が両タブに**異なる** `terminalId` を返す（`957964c4-…` / `006cde67-…`）
  - 各タブの CC が SessionStart 注入により**自分の terminal_id を正しく答えた**（それぞれ上記の値）
  - 各タブの `Stop` フックのログが**異なる** terminal_id を運んだ:
    ```
    [notify] worktree=oretachi-6f29 kind=completed terminal=Some("957964c4-920b-440f-ab3e-de374318317e")
    [notify] worktree=oretachi-6f29 kind=completed terminal=Some("006cde67-cf8b-445a-92f0-12e2a7acde5a")
    ```
    （旧サイドカー経由の通知は `terminal=None` となり、対照として機能した）
  - 別タブで `claude` を対話起動し `agentName: "claude"` / `isAiAgent: true` が `list_terminals` に載ることを確認。終了後は `null` に戻ることも確認
  - `agentSessionId` は検証時 `~/.claude/sessions/<pid>.json` が生成されず `null` のままだった。値の取得は既存の `get_claude_session_id_by_pid`（本 PR で未変更）に依存しており、本 PR の追加分は `agentName` と同一の経路で保持・露出している

## 補足

CLAUDE.md の開発フローに従い `codex review` を実行したが、`Your workspace is out of credits` で実行できなかったため、差分の自己精査で代替した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
