### PR TITLE
feat(event): event_db と購読/inbox で worktree.closed を配送する (#123)

### DIFF
--- a/src-tauri/notify/src/main.rs
+++ b/src-tauri/notify/src/main.rs
@@ -61,15 +61,19 @@ fn main() {
         let terminal_id = read_terminal_id();
         // サーバへの問い合わせが失敗しても、terminal_id だけは注入する（自己同定は
         // グループ systemPrompt の設定有無やサーバ稼働状況と独立に成立させたい）。
-        let prompt = match fetch_session_context(&dir) {
-            Ok(p) => p,
+        let ctx = match fetch_session_context(&dir) {
+            Ok(c) => c,
             Err(_e) => {
                 #[cfg(debug_assertions)]
                 eprintln!("Session context fetch failed: {}", _e);
-                None
+                SessionContext::default()
             }
         };
-        if let Some(out) = build_session_context_output(prompt.as_deref(), terminal_id.as_deref()) {
+        if let Some(out) = build_session_context_output(
+            ctx.prompt.as_deref(),
+            terminal_id.as_deref(),
+            ctx.inbox.as_deref(),
+        ) {
             println!("{}", out);
         }
         std::process::exit(0);
@@ -228,18 +232,37 @@ fn send_set_description(project_dir: &str, hook_json: Option<&str>) -> Result<()
     post_json("/set-description", &payload)
 }
 
-/// /session-context からワークツリー所属グループの systemPrompt を取得する。
-/// 未管理ディレクトリやプロンプト未設定の場合はサーバーが prompt: null を返すので Ok(None)。
-fn fetch_session_context(project_dir: &str) -> Result<Option<String>, String> {
+/// /session-context のレスポンス。
+/// - `prompt`: ワークツリー所属グループの systemPrompt（未管理ディレクトリ・未設定なら None）
+/// - `inbox`: 購読していたワークツリーイベントの未確認メッセージ（無ければ None）
+#[derive(Debug, Default, PartialEq)]
+struct SessionContext {
+    prompt: Option<String>,
+    inbox: Option<String>,
+}
+
+/// /session-context からグループの systemPrompt と未確認の購読メッセージを取得する。
+fn fetch_session_context(project_dir: &str) -> Result<SessionContext, String> {
     let mut payload = serde_json::json!({ "projectDir": project_dir });
     attach_terminal_id(&mut payload, read_terminal_id().as_deref());
     let body = post_json_read_body("/session-context", &payload)?;
+    Ok(parse_session_context(&body)?)
+}
+
+/// /session-context のレスポンスボディをパースする。
+fn parse_session_context(body: &str) -> Result<SessionContext, String> {
     let v: serde_json::Value =
-        serde_json::from_str(&body).map_err(|e| format!("Invalid response JSON: {}", e))?;
-    Ok(v.get("prompt")
-        .and_then(|p| p.as_str())
-        .map(str::to_string)
-        .filter(|s| !s.trim().is_empty()))
+        serde_json::from_str(body).map_err(|e| format!("Invalid response JSON: {}", e))?;
+    let field = |key: &str| {
+        v.get(key)
+            .and_then(|p| p.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty())
+    };
+    Ok(SessionContext {
+        prompt: field("prompt"),
+        inbox: field("inbox"),
+    })
 }
 
 /// UserPromptSubmit フック用。/prompt-context から現在の description を取得し、
@@ -257,8 +280,15 @@ fn send_prompt_context(project_dir: &str) -> Result<Option<String>, String> {
 /// グループの systemPrompt と、自分が属するタブの terminal_id を続けて注入する。
 /// terminal_id を伝えるのは、エージェントが oretachi_list_terminals 等で
 /// 「自分自身のターミナル」を同定できるようにするため（同一ワークツリーに複数タブが
-/// あると cwd だけでは区別できない）。どちらも無ければ `None`（何も出力しない）。
-fn build_session_context_output(prompt: Option<&str>, terminal_id: Option<&str>) -> Option<String> {
+/// あると cwd だけでは区別できない）。いずれも無ければ `None`（何も出力しない）。
+///
+/// 購読メッセージ (`inbox`) を最後に置くのは、それが「今このターンで着手すべきこと」であり
+/// 前段の systemPrompt / 自己 ID より新しい指示だから。
+fn build_session_context_output(
+    prompt: Option<&str>,
+    terminal_id: Option<&str>,
+    inbox: Option<&str>,
+) -> Option<String> {
     let mut parts: Vec<String> = Vec::new();
     if let Some(p) = prompt.map(str::trim).filter(|s| !s.is_empty()) {
         parts.push(p.to_string());
@@ -268,6 +298,9 @@ fn build_session_context_output(prompt: Option<&str>, terminal_id: Option<&str>)
             "[oretachi] このセッションが動いているターミナルの terminal_id は「{}」です。oretachi_list_terminals が返す terminalId と突合すれば自分自身のターミナルを同定できます（同一ワークツリーに複数タブがある場合、cwd だけでは区別できません）。",
             id
         ));
+    }
+    if let Some(i) = inbox.map(str::trim).filter(|s| !s.is_empty()) {
+        parts.push(i.to_string());
     }
     if parts.is_empty() {
         return None;
@@ -522,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_build_session_context_output_prompt_only() {
-        let out = build_session_context_output(Some("グループのプロンプト"), None).unwrap();
+        let out = build_session_context_output(Some("グループのプロンプト"), None, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["hookSpecificOutput"]["hookEventName"], "SessionStart");
         let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
@@ -532,7 +565,7 @@ mod tests {
     #[test]
     fn test_build_session_context_output_terminal_id_only() {
         // グループ systemPrompt が未設定でも terminal_id だけは注入する
-        let out = build_session_context_output(None, Some("abc-123")).unwrap();
+        let out = build_session_context_output(None, Some("abc-123"), None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
         assert!(ctx.contains("abc-123"));
@@ -541,7 +574,8 @@ mod tests {
 
     #[test]
     fn test_build_session_context_output_both() {
-        let out = build_session_context_output(Some("グループのプロンプト"), Some("abc-123")).unwrap();
+        let out =
+            build_session_context_output(Some("グループのプロンプト"), Some("abc-123"), None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
         assert!(ctx.starts_with("グループのプロンプト"));
@@ -549,10 +583,61 @@ mod tests {
     }
 
     #[test]
+    fn test_build_session_context_output_inbox_only() {
+        // グループ systemPrompt も terminal_id も無くても購読メッセージだけは注入する
+        let out = build_session_context_output(None, None, Some("[oretachi] 1 件届いています")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.contains("1 件届いています"));
+    }
+
+    #[test]
+    fn test_build_session_context_output_inbox_comes_last() {
+        let out = build_session_context_output(
+            Some("グループのプロンプト"),
+            Some("abc-123"),
+            Some("[oretachi] 購読メッセージ"),
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.starts_with("グループのプロンプト"));
+        assert!(ctx.ends_with("[oretachi] 購読メッセージ"));
+        // terminal_id は inbox より前
+        assert!(ctx.find("abc-123").unwrap() < ctx.find("購読メッセージ").unwrap());
+    }
+
+    #[test]
     fn test_build_session_context_output_none() {
-        assert_eq!(build_session_context_output(None, None), None);
+        assert_eq!(build_session_context_output(None, None, None), None);
         // 空白のみは未指定と同じ扱い
-        assert_eq!(build_session_context_output(Some("  "), Some("")), None);
+        assert_eq!(build_session_context_output(Some("  "), Some(""), Some(" ")), None);
+    }
+
+    #[test]
+    fn test_parse_session_context_full() {
+        let ctx = parse_session_context(r#"{"prompt":"p","inbox":"i"}"#).unwrap();
+        assert_eq!(ctx.prompt.as_deref(), Some("p"));
+        assert_eq!(ctx.inbox.as_deref(), Some("i"));
+    }
+
+    #[test]
+    fn test_parse_session_context_nulls_and_blanks() {
+        let ctx = parse_session_context(r#"{"prompt":null,"inbox":"   "}"#).unwrap();
+        assert_eq!(ctx, SessionContext::default());
+    }
+
+    #[test]
+    fn test_parse_session_context_missing_inbox_field() {
+        // inbox を返さない旧サーバとの後方互換
+        let ctx = parse_session_context(r#"{"prompt":"p"}"#).unwrap();
+        assert_eq!(ctx.prompt.as_deref(), Some("p"));
+        assert_eq!(ctx.inbox, None);
+    }
+
+    #[test]
+    fn test_parse_session_context_invalid_json() {
+        assert!(parse_session_context("not json").is_err());
     }
 
     #[test]

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -1,0 +1,1241 @@
+//! ワークツリー間イベントの発行・購読・蓄積を担う DB レイヤ（issue #120 / #123）。
+//!
+//! 「あるワークツリーがクローズされたことを知りたいのは、そのクローズを実行した側が
+//! 知らない第三者」であることが多いため、送信側が宛先を指定する push 方式ではなく
+//! **知りたい側が subscribe する方式**を採る。
+//!
+//! ```text
+//! 発行(events) → 照合(subscriptions) → 蓄積(inbox) → 配送(SessionStart / poll)
+//! ```
+//!
+//! 購読の主キーは `terminal_id`（PTY spawn 時に oretachi が発番する UUID。issue #122）。
+//! ワークツリー単位にすると同一ワークツリーの複数タブを区別できず、A タブ宛のメッセージを
+//! B タブが抜き取る誤配送が発生する。
+//!
+//! settings.json には置かない: ワークツリー削除で settings が書き換わる最中に `closed`
+//! イベントが飛ぶのでレースする。加えてワークツリーは settings（カウント用）と runtime
+//! （表示用）の2配列で管理されており、この二重管理を増やすと分裂事故を招く。
+//!
+//! `sqlx` に `macros` / `migrate` feature が無いため `query!` マクロと `sqlx::migrate!` は
+//! 使えない。`CREATE TABLE IF NOT EXISTS` を毎起動流す方式（task_db / archive_db と同じ）。
+
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use tauri::Manager;
+
+/// `manage()` で複数の SqlitePool を区別するためのnewtypeラッパー
+pub struct EventPool(pub SqlitePool);
+
+/// イベント種別: ワークツリーがクローズ（アーカイブ / 削除）された。
+pub const KIND_WORKTREE_CLOSED: &str = "worktree.closed";
+
+/// Phase 1 で受け付けるイベント種別。`worktree.created` / `worktree.message` は #126。
+pub const SUPPORTED_EVENT_KINDS: &[&str] = &[KIND_WORKTREE_CLOSED];
+
+/// 配送戦略。`interrupt`（即 PTY 押し込み）は #125 で追加する。
+pub const DELIVERY_TURN_END: &str = "turn_end";
+pub const DELIVERY_PASSIVE: &str = "passive";
+pub const SUPPORTED_DELIVERIES: &[&str] = &[DELIVERY_TURN_END, DELIVERY_PASSIVE];
+
+pub const STATE_ACTIVE: &str = "active";
+pub const STATE_PENDING: &str = "pending";
+pub const STATE_ACKED: &str = "acked";
+
+/// inbox の保持期限。積みっぱなしで肥大するのを防ぐ（#120 §5.6）。
+/// ack 済み・未 ack を問わず `created_at` からこの期間で削除する。
+pub const INBOX_RETENTION_DAYS: i64 = 30;
+pub const INBOX_RETENTION_MS: i64 = INBOX_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+/// sqlite の書き込みロック待ち上限。SessionStart フックのリクエストパスから触るため、
+/// サイドカーの読み取りタイムアウト（2 秒）より短くする。
+const BUSY_TIMEOUT_MS: u64 = 800;
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow, Clone)]
+pub struct SubscriptionRow {
+    pub id: String,
+    /// 購読主体。PTY タブと 1:1 の UUID（`ORETACHI_TERMINAL_ID`）
+    pub subscriber_terminal_id: String,
+    /// タブが死んだ後の復活先の解決用（不変）。逆引き不能なら None
+    pub subscriber_worktree_id: Option<String>,
+    /// 最後に見た Claude Code の session UUID（監査・resume 追跡用）
+    pub subscriber_agent_session: Option<String>,
+    /// 購読対象。Phase 1 はワークツリー ID 固定（`*` / `workgroup:` / `repo:` は #126）
+    pub target: String,
+    /// JSON string: string[]
+    pub event_kinds: String,
+    pub delivery: String,
+    /// 0 / 1。Phase 1 では保存するだけで消費しない（#125 で spawn する）
+    pub spawn_if_closed: i64,
+    pub created_at: i64,
+    /// None は無期限
+    pub expires_at: Option<i64>,
+    /// active | orphaned（orphaned への遷移は #125）
+    pub state: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow, Clone)]
+pub struct EventRow {
+    pub id: String,
+    pub source_worktree_id: String,
+    /// 発火元タブ。`worktree.closed` は close 経路が terminal_id を運んでいないため None
+    pub source_terminal_id: Option<String>,
+    pub kind: String,
+    /// JSON string: 種別ごとの本体
+    pub body: String,
+    pub actor: Option<String>,
+    pub created_at: i64,
+}
+
+/// inbox 1件と、それが指すイベントを結合した配送単位。
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow, Clone)]
+pub struct InboxItem {
+    pub id: String,
+    pub subscriber_terminal_id: String,
+    /// 積んだ時点の購読者ワークツリー。購読が先に消えても掃除できるよう inbox 側にも持つ
+    pub subscriber_worktree_id: Option<String>,
+    pub event_id: String,
+    pub state: String,
+    pub created_at: i64,
+    pub delivered_at: Option<i64>,
+    pub acked_at: Option<i64>,
+    // events からの結合分
+    pub kind: String,
+    pub body: String,
+    pub source_worktree_id: String,
+    pub actor: Option<String>,
+}
+
+/// UNIX epoch からのミリ秒。task/archive DB と同じ `i64` 流儀で時刻を持つ。
+pub fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+pub async fn init_event_db(
+    app: &tauri::AppHandle,
+) -> Result<SqlitePool, Box<dyn std::error::Error>> {
+    let app_data_dir = app.path().app_data_dir()?;
+    std::fs::create_dir_all(&app_data_dir)?;
+    let db_path = app_data_dir.join("events.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    // この DB は SessionStart フックのリクエストパス（`/session-context`）から読み書きされる。
+    // サイドカーの読み取りタイムアウトは 2 秒なので、書き込みロック競合で sqlx 既定の
+    // 5 秒待つとレスポンスが届かない。それより短く切ってエラーで返し、
+    // 「配送済みにしたのに注入されなかった」状態を作らないようにする。
+    let options = db_url
+        .parse::<sqlx::sqlite::SqliteConnectOptions>()?
+        .busy_timeout(std::time::Duration::from_millis(BUSY_TIMEOUT_MS));
+    let pool = SqlitePool::connect_with(options).await?;
+    run_migrations(&pool).await?;
+    Ok(pool)
+}
+
+async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS subscriptions (
+            id                       TEXT PRIMARY KEY,
+            subscriber_terminal_id   TEXT NOT NULL,
+            subscriber_worktree_id   TEXT,
+            subscriber_agent_session TEXT,
+            target                   TEXT NOT NULL,
+            event_kinds              TEXT NOT NULL DEFAULT '[]',
+            delivery                 TEXT NOT NULL,
+            spawn_if_closed          INTEGER NOT NULL DEFAULT 0,
+            created_at               INTEGER NOT NULL,
+            expires_at               INTEGER,
+            state                    TEXT NOT NULL DEFAULT 'active'
+        )"#,
+    )
+    .execute(pool)
+    .await?;
+    // 同じタブが同じ対象を二重購読しないようにする（再 subscribe は上書き）
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_subs_terminal_target ON subscriptions(subscriber_terminal_id, target)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_subs_target ON subscriptions(target, state)")
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_subs_worktree ON subscriptions(subscriber_worktree_id)",
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS events (
+            id                 TEXT PRIMARY KEY,
+            source_worktree_id TEXT NOT NULL,
+            source_terminal_id TEXT,
+            kind               TEXT NOT NULL,
+            body               TEXT NOT NULL DEFAULT '{}',
+            actor              TEXT,
+            created_at         INTEGER NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at DESC)")
+        .execute(pool)
+        .await?;
+
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS inbox (
+            id                     TEXT PRIMARY KEY,
+            subscriber_terminal_id TEXT NOT NULL,
+            subscriber_worktree_id TEXT,
+            event_id               TEXT NOT NULL,
+            state                  TEXT NOT NULL DEFAULT 'pending',
+            created_at             INTEGER NOT NULL,
+            delivered_at           INTEGER,
+            acked_at               INTEGER,
+            UNIQUE(subscriber_terminal_id, event_id)
+        )"#,
+    )
+    .execute(pool)
+    .await?;
+    // 既存 DB 向けマイグレーション: 購読者ワークツリー（購読行が先に消えても掃除できるように
+    // inbox 側にも持たせる）。既にあればエラーを握りつぶす。
+    let _ = sqlx::query("ALTER TABLE inbox ADD COLUMN subscriber_worktree_id TEXT")
+        .execute(pool)
+        .await;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_inbox_terminal ON inbox(subscriber_terminal_id, state)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_inbox_worktree ON inbox(subscriber_worktree_id)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_inbox_created_at ON inbox(created_at)")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+// ─── 購読 ─────────────────────────────────────────────────────────────────────
+
+/// 購読を登録する。`(subscriber_terminal_id, target)` が既にあれば内容を更新する。
+///
+/// `INSERT OR REPLACE` ではなく `ON CONFLICT DO UPDATE` を使う。前者は既存行を
+/// 「削除して挿入」するため id が変わり、エージェントが握っていた `subscription_id` で
+/// 解除できなくなる。id を保つことで再購読しても解除手段が失われない。
+///
+/// 戻り値は**実際に DB に入っている購読 ID**。既存行を更新した場合は `sub.id` ではなく
+/// 既存の id が返るので、呼び出し元はこれをエージェントへ返すこと。
+pub async fn upsert_subscription(pool: &SqlitePool, sub: &SubscriptionRow) -> Result<String, String> {
+    sqlx::query(
+        "INSERT INTO subscriptions (id, subscriber_terminal_id, subscriber_worktree_id, subscriber_agent_session, target, event_kinds, delivery, spawn_if_closed, created_at, expires_at, state) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(subscriber_terminal_id, target) DO UPDATE SET \
+           subscriber_worktree_id = excluded.subscriber_worktree_id, \
+           subscriber_agent_session = excluded.subscriber_agent_session, \
+           event_kinds = excluded.event_kinds, \
+           delivery = excluded.delivery, \
+           spawn_if_closed = excluded.spawn_if_closed, \
+           expires_at = excluded.expires_at, \
+           state = excluded.state",
+    )
+    .bind(&sub.id)
+    .bind(&sub.subscriber_terminal_id)
+    .bind(&sub.subscriber_worktree_id)
+    .bind(&sub.subscriber_agent_session)
+    .bind(&sub.target)
+    .bind(&sub.event_kinds)
+    .bind(&sub.delivery)
+    .bind(sub.spawn_if_closed)
+    .bind(sub.created_at)
+    .bind(sub.expires_at)
+    .bind(&sub.state)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let stored: (String,) = sqlx::query_as(
+        "SELECT id FROM subscriptions WHERE subscriber_terminal_id = ? AND target = ?",
+    )
+    .bind(&sub.subscriber_terminal_id)
+    .bind(&sub.target)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(stored.0)
+}
+
+/// 購読 ID で解除する。渡された terminal_id の購読だけを対象にする（誤って他タブの購読を
+/// 消さないためのスコープ制約。呼び出し元の本人性は MCP 経路では保証できない）。
+/// 戻り値は削除件数。
+pub async fn delete_subscription(
+    pool: &SqlitePool,
+    id: &str,
+    terminal_id: &str,
+) -> Result<u64, String> {
+    let result =
+        sqlx::query("DELETE FROM subscriptions WHERE id = ? AND subscriber_terminal_id = ?")
+            .bind(id)
+            .bind(terminal_id)
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?;
+    Ok(result.rows_affected())
+}
+
+/// 購読対象で解除する。戻り値は削除件数。
+pub async fn delete_subscription_by_target(
+    pool: &SqlitePool,
+    terminal_id: &str,
+    target: &str,
+) -> Result<u64, String> {
+    let result =
+        sqlx::query("DELETE FROM subscriptions WHERE subscriber_terminal_id = ? AND target = ?")
+            .bind(terminal_id)
+            .bind(target)
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?;
+    Ok(result.rows_affected())
+}
+
+/// 指定タブの有効な購読を返す（失効分は除外。行の削除は `purge_expired` に任せる）。
+pub async fn list_subscriptions(
+    pool: &SqlitePool,
+    terminal_id: &str,
+    now: i64,
+) -> Result<Vec<SubscriptionRow>, String> {
+    sqlx::query_as::<_, SubscriptionRow>(
+        "SELECT * FROM subscriptions WHERE subscriber_terminal_id = ? AND (expires_at IS NULL OR expires_at > ?) ORDER BY created_at DESC",
+    )
+    .bind(terminal_id)
+    .bind(now)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+// ─── イベント発行と照合 ───────────────────────────────────────────────────────
+
+pub async fn insert_event(pool: &SqlitePool, event: &EventRow) -> Result<(), String> {
+    sqlx::query(
+        "INSERT OR REPLACE INTO events (id, source_worktree_id, source_terminal_id, kind, body, actor, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&event.id)
+    .bind(&event.source_worktree_id)
+    .bind(&event.source_terminal_id)
+    .bind(&event.kind)
+    .bind(&event.body)
+    .bind(&event.actor)
+    .bind(event.created_at)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// `event_kinds`（JSON 配列文字列）に `kind` が含まれるか。
+/// 空配列 / パース失敗は「絞り込み無し」とはみなさず false（意図しない全配送を防ぐ）。
+pub fn event_kinds_match(event_kinds_json: &str, kind: &str) -> bool {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(event_kinds_json) else {
+        return false;
+    };
+    let Some(arr) = parsed.as_array() else {
+        return false;
+    };
+    arr.iter().any(|v| v.as_str() == Some(kind))
+}
+
+/// 自己エコー抑止（#120 §5.4）。発火元へ配り返すと往復ループの起点になる。
+///
+/// - 同じタブが発火元なら配送しない
+/// - 発火元ワークツリーに属するタブへも配送しない。`worktree.closed` は close 経路が
+///   terminal_id を運んでいないので `source_terminal_id` が None であり、実質こちらが効く
+///   （そもそも閉じたワークツリーのタブは既に存在しないので配送先として無意味）
+pub fn is_self_echo(sub: &SubscriptionRow, event: &EventRow) -> bool {
+    if event.source_terminal_id.as_deref() == Some(sub.subscriber_terminal_id.as_str()) {
+        return true;
+    }
+    sub.subscriber_worktree_id.as_deref() == Some(event.source_worktree_id.as_str())
+}
+
+/// イベントを購読と照合し、該当する購読者の inbox へ積む。戻り値は積んだ件数。
+///
+/// SQL では target / state / 失効までを絞り、`event_kinds` の突合と自己エコー抑止は
+/// Rust 側の純粋関数で行う（JSON カラムは SQL で扱いづらい。task_db の
+/// `steps_match_worktree` と同じ流儀）。
+///
+/// 複数の購読が同じイベントを拾ったときの重複は `inbox` の
+/// `UNIQUE(subscriber_terminal_id, event_id)` + `INSERT OR IGNORE` でマージされる。
+pub async fn fanout(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usize, String> {
+    let candidates = sqlx::query_as::<_, SubscriptionRow>(
+        "SELECT * FROM subscriptions WHERE target = ? AND state = ? AND (expires_at IS NULL OR expires_at > ?)",
+    )
+    .bind(&event.source_worktree_id)
+    .bind(STATE_ACTIVE)
+    .bind(now)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let mut delivered = 0usize;
+    for sub in candidates {
+        if !event_kinds_match(&sub.event_kinds, &event.kind) {
+            continue;
+        }
+        if is_self_echo(&sub, event) {
+            log::debug!(
+                "[event-db] self-echo suppressed: sub={} terminal={} event={}",
+                sub.id,
+                sub.subscriber_terminal_id,
+                event.id
+            );
+            continue;
+        }
+        let result = sqlx::query(
+            "INSERT OR IGNORE INTO inbox (id, subscriber_terminal_id, subscriber_worktree_id, event_id, state, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(&sub.subscriber_terminal_id)
+        .bind(&sub.subscriber_worktree_id)
+        .bind(&event.id)
+        .bind(STATE_PENDING)
+        .bind(now)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+        delivered += result.rows_affected() as usize;
+    }
+    Ok(delivered)
+}
+
+// ─── inbox ────────────────────────────────────────────────────────────────────
+
+/// `list_inbox` の絞り込み条件。
+///
+/// 「注入したら消す」ではなく `delivered_at`（送った）と `acked_at`（AI が確認した）を
+/// 分けて残す方針（#120 §5.2）。**再送はしない**が未 ack は残るので、サイドカー失敗で
+/// 注入が消えても人間が気づける（at-least-once は狙わない割り切り）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InboxFilter {
+    /// まだ一度も送っていないもの。自動注入（SessionStart）はこれだけを使う。
+    /// 未 ack 全件を毎セッション再掲すると「再送はしない」方針に反する。
+    Undelivered,
+    /// 未 ack のもの。エージェントが自分で取りに来る `oretachi_poll_inbox` 用。
+    /// 自動注入を取りこぼしても、ここから必ず回収できる。
+    Unacked,
+    /// ack 済みも含む全件（監査・確認用）。
+    All,
+}
+
+impl InboxFilter {
+    fn where_clause(self) -> &'static str {
+        match self {
+            InboxFilter::Undelivered => " AND i.delivered_at IS NULL",
+            InboxFilter::Unacked => " AND i.acked_at IS NULL",
+            InboxFilter::All => "",
+        }
+    }
+}
+
+/// 指定タブの inbox を条件付きで返す。
+pub async fn list_inbox(
+    pool: &SqlitePool,
+    terminal_id: &str,
+    filter: InboxFilter,
+) -> Result<Vec<InboxItem>, String> {
+    let sql = format!(
+        "SELECT i.id, i.subscriber_terminal_id, i.subscriber_worktree_id, i.event_id, i.state, i.created_at, i.delivered_at, i.acked_at, e.kind, e.body, e.source_worktree_id, e.actor \
+         FROM inbox i JOIN events e ON e.id = i.event_id \
+         WHERE i.subscriber_terminal_id = ?{} ORDER BY i.created_at ASC",
+        filter.where_clause()
+    );
+    sqlx::query_as::<_, InboxItem>(&sql)
+        .bind(terminal_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// 未 ack 件数（未配送 / 配送済み未 ack の内訳付き）を返す。
+pub async fn count_unacked(pool: &SqlitePool, terminal_id: &str) -> Result<(i64, i64), String> {
+    let row: (i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*), COALESCE(SUM(CASE WHEN delivered_at IS NULL THEN 1 ELSE 0 END), 0) FROM inbox WHERE subscriber_terminal_id = ? AND acked_at IS NULL",
+    )
+    .bind(terminal_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(row)
+}
+
+/// `?, ?, ?` 形式のプレースホルダを件数分作る（sqlx のランタイム版に配列バインドは無い）。
+fn placeholders(n: usize) -> String {
+    vec!["?"; n].join(", ")
+}
+
+/// 「送った」印を打つ。既に打刻済みの行は触らない（初回配送時刻を保つ）。
+///
+/// 1件ずつ UPDATE すると書き込みロックの取得を件数分繰り返し、競合時の待ち時間が
+/// 件数倍になる。SessionStart フックのリクエストパスから呼ばれるので1文にまとめる。
+pub async fn mark_delivered(pool: &SqlitePool, ids: &[String], now: i64) -> Result<u64, String> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let sql = format!(
+        "UPDATE inbox SET delivered_at = ? WHERE delivered_at IS NULL AND id IN ({})",
+        placeholders(ids.len())
+    );
+    let mut q = sqlx::query(&sql).bind(now);
+    for id in ids {
+        q = q.bind(id);
+    }
+    Ok(q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected())
+}
+
+/// 「AI が確認した」印を打つ。ack 済みの再 ack は 0 件更新で成功扱い（冪等）。
+/// 他タブ宛のメッセージは `subscriber_terminal_id` で弾かれるので件数に入らない。
+pub async fn ack(
+    pool: &SqlitePool,
+    ids: &[String],
+    terminal_id: &str,
+    now: i64,
+) -> Result<u64, String> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let sql = format!(
+        "UPDATE inbox SET acked_at = ?, state = ? WHERE subscriber_terminal_id = ? AND acked_at IS NULL AND id IN ({})",
+        placeholders(ids.len())
+    );
+    let mut q = sqlx::query(&sql).bind(now).bind(STATE_ACKED).bind(terminal_id);
+    for id in ids {
+        q = q.bind(id);
+    }
+    Ok(q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected())
+}
+
+// ─── 掃除 ─────────────────────────────────────────────────────────────────────
+
+/// 購読者ワークツリーがクローズされたときに、そのワークツリーのタブが持っていた
+/// subscriptions / inbox を掃除する（#120 §5.6。しないとゴミが永久に残る）。
+///
+/// inbox は `subscriber_worktree_id` を自分で持っているので、購読行が先に消えていても
+/// （unsubscribe 済み・失効削除済み）取り残さない。旧スキーマで積まれた
+/// `subscriber_worktree_id IS NULL` の行だけは subscriptions 経由で引く。
+pub async fn purge_subscriber_worktree(
+    pool: &SqlitePool,
+    worktree_id: &str,
+) -> Result<(u64, u64), String> {
+    let mut inbox_deleted = sqlx::query("DELETE FROM inbox WHERE subscriber_worktree_id = ?")
+        .bind(worktree_id)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected();
+
+    // 後方互換: subscriber_worktree_id カラム追加前に積まれた行
+    inbox_deleted += sqlx::query(
+        "DELETE FROM inbox WHERE subscriber_worktree_id IS NULL AND subscriber_terminal_id IN (SELECT subscriber_terminal_id FROM subscriptions WHERE subscriber_worktree_id = ?)",
+    )
+    .bind(worktree_id)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?
+    .rows_affected();
+
+    let subs_deleted = sqlx::query("DELETE FROM subscriptions WHERE subscriber_worktree_id = ?")
+        .bind(worktree_id)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected();
+
+    Ok((subs_deleted, inbox_deleted))
+}
+
+/// 購読対象がクローズされたので、その対象を指す購読を削除する。
+///
+/// ワークツリー ID は再利用されないため、クローズ済み target を指す購読は二度と
+/// マッチしない。放置すると `list_subscriptions` に `targetWorktreeName: null` の
+/// 死んだ行として残り続ける（既定の購読は無期限なので `purge_expired` でも消えない）。
+/// **配送（`fanout`）を終えた後に呼ぶこと。**
+pub async fn delete_subscriptions_for_target(
+    pool: &SqlitePool,
+    target: &str,
+) -> Result<u64, String> {
+    Ok(sqlx::query("DELETE FROM subscriptions WHERE target = ?")
+        .bind(target)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected())
+}
+
+/// 生存しているターミナルに紐づかない購読とその inbox を削除する。
+///
+/// `terminal_id` は PTY spawn ごとに発番され永続化されないため、**アプリを再起動すると
+/// 既存の全購読はどのターミナルにも到達できなくなる**（`resolve_subscriber` が
+/// 生存セッションしか受け付けないので list / unsubscribe / poll すべて不能）。
+/// そのまま残すと `fanout` が死んだ宛先へ inbox を積み続け、既定が無期限の購読は
+/// 単調増加する。到達不能な行は掃除して `list_subscriptions` を実態に合わせる。
+///
+/// 起動時は生存セッションが 0 件なので全購読が対象になる（これは仕様どおり:
+/// 再起動を挟んだ購読は復活できない。タブ死亡時の復活は #125 の担当）。
+pub async fn purge_orphaned_subscribers(
+    pool: &SqlitePool,
+    live_terminal_ids: &[String],
+) -> Result<(u64, u64), String> {
+    let keep = if live_terminal_ids.is_empty() {
+        String::new()
+    } else {
+        format!(
+            " AND subscriber_terminal_id NOT IN ({})",
+            placeholders(live_terminal_ids.len())
+        )
+    };
+
+    let inbox_sql = format!("DELETE FROM inbox WHERE 1=1{}", keep);
+    let mut q = sqlx::query(&inbox_sql);
+    for id in live_terminal_ids {
+        q = q.bind(id);
+    }
+    let inbox_deleted = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+    let subs_sql = format!("DELETE FROM subscriptions WHERE 1=1{}", keep);
+    let mut q = sqlx::query(&subs_sql);
+    for id in live_terminal_ids {
+        q = q.bind(id);
+    }
+    let subs_deleted = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+    Ok((subs_deleted, inbox_deleted))
+}
+
+/// 失効した購読と保持期限切れの inbox / 参照されなくなった events を削除する。
+/// 起動時と各 fanout 後に回す。戻り値は (subscriptions, inbox, events) の削除件数。
+pub async fn purge_expired(
+    pool: &SqlitePool,
+    now: i64,
+    inbox_retention_ms: i64,
+) -> Result<(u64, u64, u64), String> {
+    // 失効した購読の inbox を先に落とす（購読行が消えた後では
+    // `purge_subscriber_worktree` の後方互換パスから引けなくなる）。
+    // 同じターミナルの**他の**購読宛のメッセージを巻き込まないよう event 単位で絞る。
+    let mut inbox = sqlx::query(
+        "DELETE FROM inbox WHERE EXISTS ( \
+           SELECT 1 FROM subscriptions s JOIN events e ON e.id = inbox.event_id \
+           WHERE s.subscriber_terminal_id = inbox.subscriber_terminal_id \
+             AND s.target = e.source_worktree_id \
+             AND s.expires_at IS NOT NULL AND s.expires_at <= ? )",
+    )
+    .bind(now)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?
+    .rows_affected();
+
+    let subs = sqlx::query("DELETE FROM subscriptions WHERE expires_at IS NOT NULL AND expires_at <= ?")
+        .bind(now)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected();
+
+    inbox += sqlx::query("DELETE FROM inbox WHERE created_at <= ?")
+        .bind(now - inbox_retention_ms)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected();
+
+    // どの inbox からも参照されなくなった古いイベントを落とす（events だけ残しても使い道がない）
+    let events = sqlx::query(
+        "DELETE FROM events WHERE created_at <= ? AND id NOT IN (SELECT event_id FROM inbox)",
+    )
+    .bind(now - inbox_retention_ms)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?
+    .rows_affected();
+
+    Ok((subs, inbox, events))
+}
+
+// ─── 表示用の整形 ─────────────────────────────────────────────────────────────
+
+/// `worktree.closed` の body。
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WorktreeClosedBody {
+    #[serde(rename = "worktreeId")]
+    pub worktree_id: String,
+    #[serde(rename = "worktreeName")]
+    pub worktree_name: String,
+    #[serde(rename = "branchName")]
+    pub branch_name: String,
+}
+
+/// inbox 1件を人間 / AI が読める1行に整形する。
+pub fn format_inbox_line(item: &InboxItem) -> String {
+    let detail = match item.kind.as_str() {
+        KIND_WORKTREE_CLOSED => serde_json::from_str::<WorktreeClosedBody>(&item.body)
+            .map(|b| {
+                let branch = if b.branch_name.trim().is_empty() {
+                    String::new()
+                } else {
+                    format!("（ブランチ: {}）", b.branch_name)
+                };
+                format!(
+                    "ワークツリー '{}' {} がクローズされました",
+                    b.worktree_name, branch
+                )
+            })
+            .unwrap_or_else(|_| format!("ワークツリー ID '{}' がクローズされました", item.source_worktree_id)),
+        other => format!("イベント '{}': {}", other, item.body),
+    };
+    format!("- [{}] {}", item.id, detail)
+}
+
+/// SessionStart 注入用のテキストを組み立てる。
+///
+/// - `items`: 今回初めて配送する未配送分。本文を列挙する
+/// - `carryover`: 既に配送済みだが未 ack のまま残っている件数。**本文は再掲しない**
+///   （#120 §5.2 の「再送はしない」）が、件数だけは毎回知らせる。注入が失われた場合の
+///   唯一の気付き手段がこれ（Phase 1 には UI が無い）。
+///
+/// どちらも空なら None（呼び出し側で注入をスキップできるようにする）。
+pub fn format_inbox_digest(items: &[InboxItem], carryover: i64) -> Option<String> {
+    if items.is_empty() && carryover <= 0 {
+        return None;
+    }
+    if items.is_empty() {
+        return Some(format!(
+            "[oretachi] 未確認（未 ack）のワークツリーイベントが {} 件残っています。\
+             oretachi_poll_inbox で内容を確認し、oretachi_ack_message で ack してください。",
+            carryover
+        ));
+    }
+    let lines: Vec<String> = items.iter().map(format_inbox_line).collect();
+    let carryover_note = if carryover > 0 {
+        format!(
+            "\nこのほかに未 ack のまま残っているものが {} 件あります（oretachi_poll_inbox で確認できます）。",
+            carryover
+        )
+    } else {
+        String::new()
+    };
+    Some(format!(
+        "[oretachi] 購読していたワークツリーイベントが {} 件届いています。\n{}\n\n\
+         購読していた作業が完了したということなので、必要な動作確認や後続作業を進めてください。\
+         内容を確認したら oretachi_ack_message に上記の [] 内の ID を渡して ack してください。\
+         この本文は自動では再掲されません（ack しないまま忘れた場合は oretachi_poll_inbox で取り直せます）。{}",
+        items.len(),
+        lines.join("\n"),
+        carryover_note
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sub(terminal: &str, worktree: Option<&str>, kinds: &str) -> SubscriptionRow {
+        SubscriptionRow {
+            id: "sub-1".to_string(),
+            subscriber_terminal_id: terminal.to_string(),
+            subscriber_worktree_id: worktree.map(str::to_string),
+            subscriber_agent_session: None,
+            target: "wt-target".to_string(),
+            event_kinds: kinds.to_string(),
+            delivery: DELIVERY_TURN_END.to_string(),
+            spawn_if_closed: 0,
+            created_at: 0,
+            expires_at: None,
+            state: STATE_ACTIVE.to_string(),
+        }
+    }
+
+    fn event(source_worktree: &str, source_terminal: Option<&str>) -> EventRow {
+        EventRow {
+            id: "ev-1".to_string(),
+            source_worktree_id: source_worktree.to_string(),
+            source_terminal_id: source_terminal.map(str::to_string),
+            kind: KIND_WORKTREE_CLOSED.to_string(),
+            body: r#"{"worktreeId":"wt-target","worktreeName":"oretachi-abcd","branchName":"feature/x"}"#
+                .to_string(),
+            actor: Some("archive".to_string()),
+            created_at: 100,
+        }
+    }
+
+    #[test]
+    fn test_event_kinds_match() {
+        assert!(event_kinds_match(r#"["worktree.closed"]"#, KIND_WORKTREE_CLOSED));
+        assert!(event_kinds_match(
+            r#"["worktree.created","worktree.closed"]"#,
+            KIND_WORKTREE_CLOSED
+        ));
+        assert!(!event_kinds_match(r#"["worktree.created"]"#, KIND_WORKTREE_CLOSED));
+        // 空配列・不正 JSON・配列でない値はすべて「一致しない」（意図しない全配送を防ぐ）
+        assert!(!event_kinds_match("[]", KIND_WORKTREE_CLOSED));
+        assert!(!event_kinds_match("not json", KIND_WORKTREE_CLOSED));
+        assert!(!event_kinds_match(r#""worktree.closed""#, KIND_WORKTREE_CLOSED));
+    }
+
+    #[test]
+    fn test_is_self_echo_same_terminal() {
+        let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+        let e = event("wt-target", Some("term-a"));
+        assert!(is_self_echo(&s, &e));
+    }
+
+    #[test]
+    fn test_is_self_echo_same_worktree() {
+        // 発火元ワークツリーに属するタブには配らない
+        let s = sub("term-a", Some("wt-target"), r#"["worktree.closed"]"#);
+        let e = event("wt-target", None);
+        assert!(is_self_echo(&s, &e));
+    }
+
+    #[test]
+    fn test_is_self_echo_third_party() {
+        let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+        let e = event("wt-target", Some("term-b"));
+        assert!(!is_self_echo(&s, &e));
+    }
+
+    #[test]
+    fn test_is_self_echo_unresolved_worktree() {
+        // 購読者のワークツリーが逆引きできなかった場合は worktree 比較では抑止しない
+        let s = sub("term-a", None, r#"["worktree.closed"]"#);
+        let e = event("wt-target", None);
+        assert!(!is_self_echo(&s, &e));
+    }
+
+    fn inbox_item(kind: &str, body: &str) -> InboxItem {
+        InboxItem {
+            id: "inbox-1".to_string(),
+            subscriber_terminal_id: "term-a".to_string(),
+            subscriber_worktree_id: Some("wt-subscriber".to_string()),
+            event_id: "ev-1".to_string(),
+            state: STATE_PENDING.to_string(),
+            created_at: 100,
+            delivered_at: None,
+            acked_at: None,
+            kind: kind.to_string(),
+            body: body.to_string(),
+            source_worktree_id: "wt-target".to_string(),
+            actor: None,
+        }
+    }
+
+    #[test]
+    fn test_format_inbox_line_worktree_closed() {
+        let item = inbox_item(
+            KIND_WORKTREE_CLOSED,
+            r#"{"worktreeId":"wt-target","worktreeName":"oretachi-abcd","branchName":"feature/x"}"#,
+        );
+        let line = format_inbox_line(&item);
+        assert!(line.contains("inbox-1"));
+        assert!(line.contains("oretachi-abcd"));
+        assert!(line.contains("feature/x"));
+    }
+
+    #[test]
+    fn test_format_inbox_line_body_broken_falls_back_to_id() {
+        let item = inbox_item(KIND_WORKTREE_CLOSED, "{broken");
+        let line = format_inbox_line(&item);
+        assert!(line.contains("wt-target"));
+    }
+
+    #[test]
+    fn test_format_inbox_line_omits_empty_branch() {
+        let item = inbox_item(
+            KIND_WORKTREE_CLOSED,
+            r#"{"worktreeId":"wt-target","worktreeName":"oretachi-abcd","branchName":""}"#,
+        );
+        let line = format_inbox_line(&item);
+        assert!(line.contains("oretachi-abcd"));
+        assert!(!line.contains("ブランチ"));
+    }
+
+    #[test]
+    fn test_format_inbox_digest_empty_is_none() {
+        assert_eq!(format_inbox_digest(&[], 0), None);
+    }
+
+    /// 未配送が無くても未 ack が残っていれば件数だけは伝える
+    /// （注入喪失に気づく唯一の手段。本文は再掲しない）。
+    #[test]
+    fn test_format_inbox_digest_carryover_only_mentions_count_without_body() {
+        let digest = format_inbox_digest(&[], 3).unwrap();
+        assert!(digest.contains("3 件"));
+        assert!(digest.contains("oretachi_poll_inbox"));
+        assert!(!digest.contains("がクローズされました"));
+    }
+
+    #[test]
+    fn test_format_inbox_digest_appends_carryover_note() {
+        let items = vec![inbox_item(
+            KIND_WORKTREE_CLOSED,
+            r#"{"worktreeId":"a","worktreeName":"wt-a","branchName":"b1"}"#,
+        )];
+        let digest = format_inbox_digest(&items, 2).unwrap();
+        assert!(digest.contains("wt-a"));
+        assert!(digest.contains("2 件"));
+    }
+
+    /// インメモリ DB を1本の接続で開く。`sqlite::memory:` は接続ごとに別 DB になるため
+    /// `max_connections(1)` が必須（プールが2本目を張ると空の DB を見てしまう）。
+    ///
+    /// `tokio` に `macros` / `rt` feature が無く `#[tokio::test]` が使えないので、
+    /// 同期テストの中から `tauri::async_runtime::block_on` で回す。
+    fn with_pool<F, T>(f: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        tauri::async_runtime::block_on(f)
+    }
+
+    async fn memory_pool() -> SqlitePool {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect");
+        run_migrations(&pool).await.expect("migrate");
+        pool
+    }
+
+    /// SQL 文と FromRow のマッピングを一通り通す往復テスト（cargo check では検出できない）。
+    #[test]
+    fn test_roundtrip_subscribe_fanout_deliver_ack() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let mut s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            let first_id = upsert_subscription(&pool, &s).await.unwrap();
+            assert_eq!(first_id, s.id);
+            // 同じ (terminal, target) の再購読は増えず内容だけ更新される。
+            // id は既存のものが維持され、エージェントが持っている subscription_id が生き残る
+            s.id = "ignored-new-id".to_string();
+            s.delivery = DELIVERY_PASSIVE.to_string();
+            let second_id = upsert_subscription(&pool, &s).await.unwrap();
+            assert_eq!(second_id, first_id);
+            let subs = list_subscriptions(&pool, "term-a", now).await.unwrap();
+            assert_eq!(subs.len(), 1);
+            assert_eq!(subs[0].id, first_id);
+            assert_eq!(subs[0].delivery, DELIVERY_PASSIVE);
+            s.delivery = DELIVERY_TURN_END.to_string();
+
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+            // 同じイベントの再 fanout は UNIQUE 制約でマージされる
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 0);
+
+            let items = list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap();
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0].kind, KIND_WORKTREE_CLOSED);
+            assert_eq!(items[0].source_worktree_id, "wt-target");
+            assert!(items[0].delivered_at.is_none());
+            assert_eq!(count_unacked(&pool, "term-a").await.unwrap(), (1, 1));
+
+            let ids = vec![items[0].id.clone()];
+            assert_eq!(mark_delivered(&pool, &ids, now).await.unwrap(), 1);
+            // 二度目は初回配送時刻を保つため更新しない
+            assert_eq!(mark_delivered(&pool, &ids, now + 5).await.unwrap(), 0);
+            assert_eq!(count_unacked(&pool, "term-a").await.unwrap(), (1, 0));
+
+            assert_eq!(ack(&pool, &ids, "term-a", now).await.unwrap(), 1);
+            assert_eq!(ack(&pool, &ids, "term-a", now).await.unwrap(), 0); // 冪等
+            assert!(list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap().is_empty());
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 1);
+            assert_eq!(count_unacked(&pool, "term-a").await.unwrap(), (0, 0));
+        });
+    }
+
+    /// 自動注入（SessionStart）は「再送しない」（#120 §5.2）。
+    /// 一度配送したものは Undelivered に出てこないが、Unacked（明示 pull）には残る。
+    #[test]
+    fn test_roundtrip_undelivered_is_not_resent_but_stays_unacked() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+
+            // 1回目の自動注入では拾える
+            let first = list_inbox(&pool, "term-a", InboxFilter::Undelivered).await.unwrap();
+            assert_eq!(first.len(), 1);
+            mark_delivered(&pool, &[first[0].id.clone()], now).await.unwrap();
+
+            // 2回目の自動注入では拾わない（再送しない）
+            assert!(list_inbox(&pool, "term-a", InboxFilter::Undelivered)
+                .await
+                .unwrap()
+                .is_empty());
+            // ただし未 ack として残るので明示 pull では取り直せる
+            assert_eq!(
+                list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap().len(),
+                1
+            );
+        });
+    }
+
+    /// 同一ワークツリーの2タブがそれぞれ購読しても、相手の inbox を覗けない。
+    #[test]
+    fn test_roundtrip_two_tabs_same_worktree_are_isolated() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let mut a = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &a).await.unwrap();
+            // タブ2 は購読していない
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap().len(), 1);
+            assert!(list_inbox(&pool, "term-b", InboxFilter::Unacked).await.unwrap().is_empty());
+            // 他タブの ID を渡しても ack できない
+            let items = list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap();
+            let ids = vec![items[0].id.clone()];
+            assert_eq!(ack(&pool, &ids, "term-b", now).await.unwrap(), 0);
+
+            // タブ2 も購読すれば両方に届く
+            a.id = "sub-b".to_string();
+            a.subscriber_terminal_id = "term-b".to_string();
+            upsert_subscription(&pool, &a).await.unwrap();
+            let e2 = EventRow { id: "ev-2".to_string(), ..event("wt-target", None) };
+            insert_event(&pool, &e2).await.unwrap();
+            assert_eq!(fanout(&pool, &e2, now).await.unwrap(), 2);
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_expired_subscription_is_not_delivered_and_purged() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let mut s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            s.expires_at = Some(now - 1);
+            upsert_subscription(&pool, &s).await.unwrap();
+
+            assert!(list_subscriptions(&pool, "term-a", now).await.unwrap().is_empty());
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 0);
+
+            let (subs, _, _) = purge_expired(&pool, now, INBOX_RETENTION_MS).await.unwrap();
+            assert_eq!(subs, 1);
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_purge_subscriber_worktree_removes_subs_and_inbox() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+
+            let (subs, inbox) = purge_subscriber_worktree(&pool, "wt-subscriber").await.unwrap();
+            assert_eq!((subs, inbox), (1, 1));
+            assert!(list_subscriptions(&pool, "term-a", now).await.unwrap().is_empty());
+            assert!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().is_empty());
+        });
+    }
+
+    /// 購読が先に消えていても（unsubscribe 済み）、購読者ワークツリーのクローズで
+    /// inbox が取り残されない（inbox 側が subscriber_worktree_id を持っているため）。
+    #[test]
+    fn test_roundtrip_purge_subscriber_worktree_after_unsubscribe() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+
+            // 先に購読だけ解除する
+            delete_subscription_by_target(&pool, "term-a", &s.target).await.unwrap();
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 1);
+
+            let (subs, inbox) = purge_subscriber_worktree(&pool, "wt-subscriber").await.unwrap();
+            assert_eq!((subs, inbox), (0, 1));
+            assert!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().is_empty());
+        });
+    }
+
+    /// 失効した購読の inbox は保持期限を待たずに落とす。
+    /// ただし同じタブの**別の**購読宛のメッセージは巻き込まない。
+    #[test]
+    fn test_roundtrip_purge_expired_drops_only_its_own_inbox() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let mut expiring = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            expiring.target = "wt-expiring".to_string();
+            expiring.expires_at = Some(now - 1);
+            upsert_subscription(&pool, &expiring).await.unwrap();
+
+            let mut alive = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            alive.id = "sub-alive".to_string();
+            alive.target = "wt-alive".to_string();
+            upsert_subscription(&pool, &alive).await.unwrap();
+
+            // 失効前に届いていた分と、生きている購読の分を1件ずつ積む
+            let e1 = EventRow { id: "ev-expiring".to_string(), ..event("wt-expiring", None) };
+            let e2 = EventRow { id: "ev-alive".to_string(), ..event("wt-alive", None) };
+            insert_event(&pool, &e1).await.unwrap();
+            insert_event(&pool, &e2).await.unwrap();
+            // 失効購読の分は fanout では積まれないので直接入れる（失効前に届いた状況の再現）
+            sqlx::query("INSERT INTO inbox (id, subscriber_terminal_id, subscriber_worktree_id, event_id, state, created_at) VALUES (?, ?, ?, ?, ?, ?)")
+                .bind("inbox-expiring")
+                .bind("term-a")
+                .bind("wt-subscriber")
+                .bind("ev-expiring")
+                .bind(STATE_PENDING)
+                .bind(now)
+                .execute(&pool)
+                .await
+                .unwrap();
+            assert_eq!(fanout(&pool, &e2, now).await.unwrap(), 1);
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 2);
+
+            let (subs, inbox, _) = purge_expired(&pool, now, INBOX_RETENTION_MS).await.unwrap();
+            assert_eq!((subs, inbox), (1, 1));
+            let left = list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap();
+            assert_eq!(left.len(), 1);
+            assert_eq!(left[0].event_id, "ev-alive");
+        });
+    }
+
+    /// 生存ターミナルに紐づかない購読と inbox は掃除される（再起動後の到達不能行）。
+    #[test]
+    fn test_roundtrip_purge_orphaned_subscribers() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let a = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &a).await.unwrap();
+            let mut b = sub("term-b", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            b.id = "sub-b".to_string();
+            upsert_subscription(&pool, &b).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 2);
+
+            // term-a だけ生存している
+            let (subs, inbox) =
+                purge_orphaned_subscribers(&pool, &["term-a".to_string()]).await.unwrap();
+            assert_eq!((subs, inbox), (1, 1));
+            assert_eq!(list_subscriptions(&pool, "term-a", now).await.unwrap().len(), 1);
+            assert!(list_subscriptions(&pool, "term-b", now).await.unwrap().is_empty());
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 1);
+            assert!(list_inbox(&pool, "term-b", InboxFilter::All).await.unwrap().is_empty());
+
+            // 生存 0 件（起動直後）なら全部消える
+            let (subs, inbox) = purge_orphaned_subscribers(&pool, &[]).await.unwrap();
+            assert_eq!((subs, inbox), (1, 1));
+        });
+    }
+
+    /// クローズされた target を指す購読は配送後に削除される。
+    #[test]
+    fn test_roundtrip_delete_subscriptions_for_target() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+
+            assert_eq!(delete_subscriptions_for_target(&pool, "wt-target").await.unwrap(), 1);
+            assert!(list_subscriptions(&pool, "term-a", now).await.unwrap().is_empty());
+            // 既に積まれた inbox は残る（購読解除は配送済みメッセージを消さない）
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap().len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_inbox_retention_drops_old_rows_and_orphan_events() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let old = 1_000_000i64;
+            let now = old + INBOX_RETENTION_MS + 1;
+
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, old).await.unwrap();
+
+            let (_, inbox, events) = purge_expired(&pool, now, INBOX_RETENTION_MS).await.unwrap();
+            assert_eq!((inbox, events), (1, 1));
+            // 無期限の購読自体は残る
+            assert_eq!(list_subscriptions(&pool, "term-a", now).await.unwrap().len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_delete_subscription_scoped_to_own_terminal() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+
+            // 他タブからは消せない
+            assert_eq!(delete_subscription(&pool, &s.id, "term-b").await.unwrap(), 0);
+            assert_eq!(
+                delete_subscription_by_target(&pool, "term-b", &s.target).await.unwrap(),
+                0
+            );
+            assert_eq!(list_subscriptions(&pool, "term-a", now).await.unwrap().len(), 1);
+
+            assert_eq!(
+                delete_subscription_by_target(&pool, "term-a", &s.target).await.unwrap(),
+                1
+            );
+            assert!(list_subscriptions(&pool, "term-a", now).await.unwrap().is_empty());
+        });
+    }
+
+    #[test]
+    fn test_format_inbox_digest_mentions_ack_and_count() {
+        let items = vec![
+            inbox_item(
+                KIND_WORKTREE_CLOSED,
+                r#"{"worktreeId":"a","worktreeName":"wt-a","branchName":"b1"}"#,
+            ),
+            inbox_item(
+                KIND_WORKTREE_CLOSED,
+                r#"{"worktreeId":"b","worktreeName":"wt-b","branchName":"b2"}"#,
+            ),
+        ];
+        let digest = format_inbox_digest(&items, 0).unwrap();
+        assert!(digest.contains("2 件"));
+        assert!(digest.contains("oretachi_ack_message"));
+        assert!(digest.contains("wt-a"));
+        assert!(digest.contains("wt-b"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod archive_db;
 mod artifact_url;
 mod claude_plugin;
 mod claude_plugin_skills;
+mod event_db;
 mod fs_watcher;
 mod git_worktree;
 mod home_skills;
@@ -1009,6 +1010,90 @@ async fn save_archive(
     archive_db::save(&pool.0, &archive).await
 }
 
+/// `worktree.closed` イベントを event_db へ発行する（issue #123）。
+///
+/// **fire-and-forget**。close フローは既に oneshot + timeout の複雑な経路
+/// （`CloseWorktreeAckRegistry`、ack タイムアウト 45 秒）なので、DB 書き込みと照合で
+/// クローズ処理をブロックしない。DB 未初期化・書き込み失敗はログのみで握りつぶす。
+///
+/// 呼び出し元は `git worktree remove` の成功確認後の経路だけ。フロントの
+/// `useWorktreeRemove.ts` は失敗・キャンセル・多重実行では afterRemove に到達しないため、
+/// `Cancelled` / `Busy` / `Failed` では構造的に発火しない。
+fn fire_worktree_closed(
+    app_handle: &tauri::AppHandle,
+    id: String,
+    name: String,
+    branch_name: String,
+    actor: &'static str,
+) {
+    let handle = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        let Some(pool) = handle.try_state::<event_db::EventPool>() else {
+            log::debug!("[event] Event DB not initialized; skipping worktree.closed for {}", name);
+            return;
+        };
+        let now = event_db::now_ms();
+        let body = serde_json::json!({
+            "worktreeId": id,
+            "worktreeName": name,
+            "branchName": branch_name,
+        })
+        .to_string();
+        let event = event_db::EventRow {
+            id: uuid::Uuid::new_v4().to_string(),
+            source_worktree_id: id.clone(),
+            // close 経路は terminal_id を運んでいない（クローズ実行者のタブは特定できない）。
+            // 自己エコー抑止は subscriber_worktree_id == source_worktree_id 側で効く。
+            source_terminal_id: None,
+            kind: event_db::KIND_WORKTREE_CLOSED.to_string(),
+            body,
+            actor: Some(actor.to_string()),
+            created_at: now,
+        };
+        if let Err(e) = event_db::insert_event(&pool.0, &event).await {
+            log::warn!("[event] failed to record worktree.closed for {}: {}", name, e);
+            return;
+        }
+        match event_db::fanout(&pool.0, &event, now).await {
+            Ok(count) => log::info!(
+                "[event] worktree.closed worktree={} actor={} delivered={}",
+                name,
+                actor,
+                count
+            ),
+            Err(e) => log::warn!("[event] fanout failed for {}: {}", name, e),
+        }
+        // このワークツリーを購読していた行はもう二度とマッチしない（ID は再利用されない）。
+        // 配送を終えた後に消して `list_subscriptions` に死んだ行を残さない。
+        match event_db::delete_subscriptions_for_target(&pool.0, &id).await {
+            Ok(n) if n > 0 => log::info!(
+                "[event] removed {} subscription(s) targeting closed worktree={}",
+                n,
+                name
+            ),
+            Ok(_) => {}
+            Err(e) => log::warn!("[event] delete_subscriptions_for_target failed for {}: {}", name, e),
+        }
+        // 購読者側がこのワークツリーだった場合のゴミ掃除。fanout の後に行う
+        // （自己エコー抑止があるため相互に干渉しない）。
+        match event_db::purge_subscriber_worktree(&pool.0, &id).await {
+            Ok((subs, inbox)) if subs > 0 || inbox > 0 => log::info!(
+                "[event] purged subscriber rows for closed worktree={} subscriptions={} inbox={}",
+                name,
+                subs,
+                inbox
+            ),
+            Ok(_) => {}
+            Err(e) => log::warn!("[event] purge_subscriber_worktree failed for {}: {}", name, e),
+        }
+        if let Err(e) =
+            event_db::purge_expired(&pool.0, now, event_db::INBOX_RETENTION_MS).await
+        {
+            log::warn!("[event] purge_expired failed: {}", e);
+        }
+    });
+}
+
 /// ワークツリーのアーカイブ（削除）が完了した後にMCPクライアントへ通知する。
 /// git worktree remove の成功確認後にフロントエンドから呼び出す。
 #[tauri::command]
@@ -1024,6 +1109,21 @@ fn notify_worktree_archived(
         "name": name,
         "branchName": branch_name,
     }));
+    fire_worktree_closed(&app_handle, id, name, branch_name, "archive");
+}
+
+/// アーカイブせずにワークツリーを削除したときの `worktree.closed` 発行用。
+/// `worktree-archived` の MCP ブロードキャストは行わない（アーカイブしていないため）が、
+/// 購読者にとっては「作業が終わった」という同じ意味を持つのでイベントは発行する。
+#[tauri::command]
+fn notify_worktree_closed(
+    app_handle: tauri::AppHandle,
+    id: String,
+    name: String,
+    branch_name: String,
+) {
+    let _bc = main_thread_watch::enter(main_thread_watch::Activity::NotifyWorktreeClosed);
+    fire_worktree_closed(&app_handle, id, name, branch_name, "delete");
 }
 
 /// ワークツリーの追加が完了した後にMCPクライアントへ通知する。
@@ -1431,6 +1531,7 @@ pub fn run() {
             path_exists,
             save_archive,
             notify_worktree_archived,
+            notify_worktree_closed,
             notify_worktree_added,
             list_archives,
             delete_archive,
@@ -1515,6 +1616,56 @@ pub fn run() {
                         }
                         Err(e) => {
                             log::warn!("[ArchiveDB] Failed to initialize: {}", e);
+                        }
+                    }
+                });
+            }
+
+            // イベント / 購読 / inbox DB を同期的に初期化（issue #123）。
+            // 失敗しても起動は続行する（購読機能だけが無効になる）。
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::block_on(async move {
+                    match event_db::init_event_db(&handle).await {
+                        Ok(pool) => {
+                            // `terminal_id` は PTY spawn ごとに発番され永続化されないため、
+                            // 前回起動時の購読はどのターミナルからも到達できない
+                            // （list / unsubscribe / poll がすべて不能になる）。放置すると
+                            // 死んだ宛先へ inbox を積み続け、既定が無期限の購読は単調増加する。
+                            // ここでは生存セッションが 0 件なので前回分がすべて対象になる。
+                            // 再起動を挟んだ購読の復活は #125（orphaned 遷移と再バインド）の担当。
+                            match event_db::purge_orphaned_subscribers(&pool, &[]).await {
+                                Ok((subs, inbox)) if subs > 0 || inbox > 0 => log::info!(
+                                    "[EventDB] purged unreachable subscriptions={} inbox={} (terminal_id は再起動で再発番されるため前回分は復活できない)",
+                                    subs, inbox
+                                ),
+                                Ok(_) => {}
+                                Err(e) => {
+                                    log::warn!("[EventDB] purge_orphaned_subscribers failed: {}", e)
+                                }
+                            }
+                            // 保持期限切れの inbox / 参照されない events をここで掃除する
+                            match event_db::purge_expired(
+                                &pool,
+                                event_db::now_ms(),
+                                event_db::INBOX_RETENTION_MS,
+                            )
+                            .await
+                            {
+                                Ok((subs, inbox, events)) if subs > 0 || inbox > 0 || events > 0 => {
+                                    log::info!(
+                                        "[EventDB] purged expired subscriptions={} inbox={} events={}",
+                                        subs, inbox, events
+                                    );
+                                }
+                                Ok(_) => {}
+                                Err(e) => log::warn!("[EventDB] purge_expired failed: {}", e),
+                            }
+                            handle.manage(event_db::EventPool(pool));
+                            log::debug!("[EventDB] Initialized successfully");
+                        }
+                        Err(e) => {
+                            log::warn!("[EventDB] Failed to initialize: {}", e);
                         }
                     }
                 });

--- a/src-tauri/src/main_thread_watch.rs
+++ b/src-tauri/src/main_thread_watch.rs
@@ -45,6 +45,7 @@ pub enum Activity {
     GetMcpStatus,
     PathExists,
     NotifyWorktreeArchived,
+    NotifyWorktreeClosed,
     NotifyWorktreeAdded,
     StartFsWatch,
     StopFsWatch,
@@ -55,7 +56,7 @@ pub enum Activity {
 }
 
 /// [`Activity`] の discriminant 順に並んだ表示ラベル。enum と順序を一致させること。
-const LABELS: [&str; 25] = [
+const LABELS: [&str; 26] = [
     "idle",
     "run-event",
     "watchdog-probe",
@@ -74,6 +75,7 @@ const LABELS: [&str; 25] = [
     "cmd:get_mcp_status",
     "cmd:path_exists",
     "cmd:notify_worktree_archived",
+    "cmd:notify_worktree_closed",
     "cmd:notify_worktree_added",
     "cmd:start_fs_watch",
     "cmd:stop_fs_watch",

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -696,6 +696,70 @@ pub struct WriteTerminalParams {
     pub submit: Option<bool>,
 }
 
+// ─── 購読 / inbox 系ツールのパラメータ (issue #123) ───────────────────────────
+
+// 各ツールの terminal_id / project_dir パラメータの説明文は schemars が文字列リテラルしか
+// 受け付けないため各構造体に直接書いている（定数に切り出せない）。
+// エージェントは自分の terminal_id を SessionStart の additionalContext から知る。
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SubscribeWorktreeParams {
+    #[schemars(description = "購読対象のワークツリー名または ID。このワークツリーがクローズされたら通知が届く")]
+    pub target: String,
+    #[schemars(description = "購読するイベント種別。現状 \"worktree.closed\" のみ対応（省略時 [\"worktree.closed\"]）")]
+    pub event_kinds: Option<Vec<String>>,
+    #[schemars(description = "配送戦略: \"turn_end\"(既定) / \"passive\"。現状どちらもセッション開始時の回収と oretachi_poll_inbox でのみ配送される（ターン境界での即時注入は未実装）")]
+    pub delivery: Option<String>,
+    #[schemars(description = "自分のターミナルが閉じていた場合に新しいターミナルを起動して通知するか（既定 false）。現状は記録のみで未実装")]
+    pub spawn_if_closed: Option<bool>,
+    #[schemars(description = "購読の有効期間（秒）。省略時は無期限")]
+    pub expires_in: Option<i64>,
+    #[schemars(description = "自分が動いているターミナルの terminal_id。セッション開始時に oretachi から注入されている値をそのまま渡す。省略時は project_dir から AI エージェント端末が1つだけのワークツリーとして推測する")]
+    pub terminal_id: Option<String>,
+    #[schemars(description = "自分の作業ディレクトリ絶対パス。terminal_id 省略時の推測に使う")]
+    pub project_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct UnsubscribeWorktreeParams {
+    #[schemars(description = "解除する購読 ID（oretachi_list_subscriptions で取得）")]
+    pub subscription_id: Option<String>,
+    #[schemars(description = "解除する購読対象のワークツリー名または ID（subscription_id を指定しない場合）")]
+    pub target: Option<String>,
+    #[schemars(description = "自分が動いているターミナルの terminal_id。セッション開始時に oretachi から注入されている値をそのまま渡す。省略時は project_dir から AI エージェント端末が1つだけのワークツリーとして推測する")]
+    pub terminal_id: Option<String>,
+    #[schemars(description = "自分の作業ディレクトリ絶対パス。terminal_id 省略時の推測に使う")]
+    pub project_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListSubscriptionsParams {
+    #[schemars(description = "自分が動いているターミナルの terminal_id。セッション開始時に oretachi から注入されている値をそのまま渡す。省略時は project_dir から AI エージェント端末が1つだけのワークツリーとして推測する")]
+    pub terminal_id: Option<String>,
+    #[schemars(description = "自分の作業ディレクトリ絶対パス。terminal_id 省略時の推測に使う")]
+    pub project_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PollInboxParams {
+    #[schemars(description = "自分が動いているターミナルの terminal_id。セッション開始時に oretachi から注入されている値をそのまま渡す。省略時は project_dir から AI エージェント端末が1つだけのワークツリーとして推測する")]
+    pub terminal_id: Option<String>,
+    #[schemars(description = "自分の作業ディレクトリ絶対パス。terminal_id 省略時の推測に使う")]
+    pub project_dir: Option<String>,
+    #[schemars(description = "true なら ack 済みも含めて返す（既定 false = 未 ack のみ）")]
+    pub include_acked: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct AckMessageParams {
+    #[schemars(description = "ack する inbox メッセージ ID。複数まとめて渡せる")]
+    pub ids: Vec<String>,
+    #[schemars(description = "自分が動いているターミナルの terminal_id。セッション開始時に oretachi から注入されている値をそのまま渡す。省略時は project_dir から AI エージェント端末が1つだけのワークツリーとして推測する")]
+    pub terminal_id: Option<String>,
+    #[schemars(description = "自分の作業ディレクトリ絶対パス。terminal_id 省略時の推測に使う")]
+    pub project_dir: Option<String>,
+}
+
 // ─── MCP Service ──────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -1626,6 +1690,388 @@ impl NotifyService {
         }
     }
 
+    #[tool(description = "指定ワークツリーのクローズを購読する。別ワークツリーで進めている関連作業が完了（クローズ）したことを、自分のセッションで検知したいときに使う。届いた通知は次のセッション開始時に自動で提示され、oretachi_poll_inbox でも取得できる")]
+    async fn oretachi_subscribe_worktree(
+        &self,
+        Parameters(SubscribeWorktreeParams {
+            target,
+            event_kinds,
+            delivery,
+            spawn_if_closed,
+            expires_in,
+            terminal_id,
+            project_dir,
+        }): Parameters<SubscribeWorktreeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let target = target.trim().to_string();
+        if target.is_empty() {
+            return Err(McpError::invalid_params("target must not be empty", None));
+        }
+
+        // 現状 Phase 1 では worktree.closed のみ。未対応種別を黙って受け付けると
+        // 「購読したのに来ない」という分かりにくい失敗になるので明示的に弾く。
+        let kinds = event_kinds
+            .unwrap_or_else(|| vec![crate::event_db::KIND_WORKTREE_CLOSED.to_string()]);
+        if kinds.is_empty() {
+            return Err(McpError::invalid_params(
+                "event_kinds must not be empty",
+                None,
+            ));
+        }
+        for k in &kinds {
+            if !crate::event_db::SUPPORTED_EVENT_KINDS.contains(&k.as_str()) {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "event_kind '{}' は未対応です。対応種別: [{}]",
+                        k,
+                        crate::event_db::SUPPORTED_EVENT_KINDS.join(", ")
+                    ),
+                    None,
+                ));
+            }
+        }
+
+        let delivery = delivery
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty())
+            .unwrap_or_else(|| crate::event_db::DELIVERY_TURN_END.to_string());
+        if !crate::event_db::SUPPORTED_DELIVERIES.contains(&delivery.as_str()) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "delivery '{}' は未対応です。対応値: [{}]",
+                    delivery,
+                    crate::event_db::SUPPORTED_DELIVERIES.join(", ")
+                ),
+                None,
+            ));
+        }
+
+        if let Some(secs) = expires_in {
+            if secs <= 0 {
+                return Err(McpError::invalid_params(
+                    "expires_in must be a positive number of seconds (省略すると無期限)",
+                    None,
+                ));
+            }
+        }
+
+        // await をまたいで State / settings の参照を保持しないよう、ここで所有権のある値へ確定させる
+        let (subscriber, target_id, target_name) = {
+            let subscriber = resolve_subscriber(
+                &self.app_handle,
+                terminal_id.as_deref(),
+                project_dir.as_deref(),
+            )?;
+            let settings = self.app_handle.state::<SettingsManager>().get();
+            let wt = resolve_worktree_by_name_or_id(&settings, target.as_str())?;
+            // ホーム / リポジトリ擬似ワークツリーは削除自体が禁止されているので
+            // worktree.closed は構造的に永久に発火しない。購読を受け付けると
+            // 「購読成功したのに一生通知が来ない」状態になるため拒否する。
+            if wt.is_home || wt.is_repository {
+                let kind = if wt.is_home { "ホーム" } else { "リポジトリ" };
+                return Err(McpError::invalid_params(
+                    format!(
+                        "'{}' は{}擬似ワークツリーでクローズされることがないため購読できません",
+                        wt.name, kind
+                    ),
+                    None,
+                ));
+            }
+            (subscriber, wt.id.clone(), wt.name.clone())
+        };
+
+        // 逆引きできないと自己エコー抑止も購読者クローズ時の掃除も効かないため受け付けない
+        let Some(subscriber_worktree_id) = subscriber.worktree_id.clone() else {
+            return Err(McpError::invalid_params(
+                "呼び出し元ターミナルの作業ディレクトリから oretachi 管理下のワークツリーを特定できませんでした。oretachi が管理しているワークツリー内で実行してください",
+                None,
+            ));
+        };
+        if subscriber_worktree_id == target_id {
+            return Err(McpError::invalid_params(
+                format!(
+                    "自分自身が居るワークツリー '{}' のクローズは購読できません（クローズされた時点でこのセッションも消えるため通知先がありません）",
+                    target_name
+                ),
+                None,
+            ));
+        }
+
+        let pool = event_pool(&self.app_handle)?;
+        let now = crate::event_db::now_ms();
+        let sub = crate::event_db::SubscriptionRow {
+            id: uuid::Uuid::new_v4().to_string(),
+            subscriber_terminal_id: subscriber.terminal_id.clone(),
+            subscriber_worktree_id: Some(subscriber_worktree_id),
+            subscriber_agent_session: subscriber.agent_session.clone(),
+            target: target_id.clone(),
+            event_kinds: serde_json::to_string(&kinds)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?,
+            delivery: delivery.clone(),
+            spawn_if_closed: i64::from(spawn_if_closed.unwrap_or(false)),
+            created_at: now,
+            // 巨大な値を渡されても panic させない（debug ビルドのオーバーフロー検査対策）
+            expires_at: expires_in.map(|secs| now.saturating_add(secs.saturating_mul(1000))),
+            state: crate::event_db::STATE_ACTIVE.to_string(),
+        };
+        // 既存の購読を更新した場合は既存の id が返る（再購読で解除手段を失わせない）
+        let subscription_id = crate::event_db::upsert_subscription(&pool, &sub)
+            .await
+            .map_err(|e| McpError::internal_error(e, None))?;
+
+        log::info!(
+            "[mcp] oretachi_subscribe_worktree: target={} ({}) terminal={} kinds={:?} delivery={} expires_at={:?} subscription_id={}",
+            target_name, target_id, subscriber.terminal_id, kinds, delivery, sub.expires_at, subscription_id
+        );
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::json!({
+                "subscriptionId": subscription_id,
+                "target": target_name,
+                "targetWorktreeId": target_id,
+                "eventKinds": kinds,
+                "delivery": delivery,
+                "expiresAt": sub.expires_at,
+                "subscriberTerminalId": subscriber.terminal_id,
+                "message": format!(
+                    "ワークツリー '{}' のクローズを購読しました。クローズされると次のセッション開始時に通知が提示されます（oretachi_poll_inbox でも取得できます）。",
+                    target_name
+                ),
+            })
+            .to_string(),
+        )]))
+    }
+
+    #[tool(description = "ワークツリーのクローズ購読を解除する。subscription_id か target のどちらかを指定する", annotations(idempotent_hint = true))]
+    async fn oretachi_unsubscribe_worktree(
+        &self,
+        Parameters(UnsubscribeWorktreeParams { subscription_id, target, terminal_id, project_dir }): Parameters<UnsubscribeWorktreeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let subscription_id = subscription_id.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+        let target = target.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+        if subscription_id.is_none() && target.is_none() {
+            return Err(McpError::invalid_params(
+                "subscription_id または target を指定してください",
+                None,
+            ));
+        }
+
+        let (subscriber, target_id) = {
+            let subscriber = resolve_subscriber(
+                &self.app_handle,
+                terminal_id.as_deref(),
+                project_dir.as_deref(),
+            )?;
+            // 購読対象が既にクローズ済みで settings から消えている場合もあるため、
+            // 逆引きできなければ渡された文字列をそのまま ID として扱う
+            let target_id = target.as_ref().map(|t| {
+                let settings = self.app_handle.state::<SettingsManager>().get();
+                resolve_worktree_by_name_or_id(&settings, t.as_str())
+                    .map(|w| w.id.clone())
+                    .unwrap_or_else(|_| t.clone())
+            });
+            (subscriber, target_id)
+        };
+
+        let pool = event_pool(&self.app_handle)?;
+        let deleted = if let Some(id) = subscription_id.as_deref() {
+            crate::event_db::delete_subscription(&pool, id, &subscriber.terminal_id).await
+        } else {
+            crate::event_db::delete_subscription_by_target(
+                &pool,
+                &subscriber.terminal_id,
+                target_id.as_deref().unwrap_or_default(),
+            )
+            .await
+        }
+        .map_err(|e| McpError::internal_error(e, None))?;
+
+        log::info!(
+            "[mcp] oretachi_unsubscribe_worktree: terminal={} subscription_id={:?} target={:?} deleted={}",
+            subscriber.terminal_id, subscription_id, target_id, deleted
+        );
+        Ok(CallToolResult::success(vec![Content::text(if deleted > 0 {
+            format!("購読を解除しました（{} 件）。", deleted)
+        } else {
+            "該当する購読はありませんでした（既に解除済み、または別のターミナルの購読です）。oretachi_list_subscriptions で確認してください。".to_string()
+        })]))
+    }
+
+    #[tool(description = "自分のターミナルが登録しているワークツリー購読の一覧と、未確認メッセージ件数を返す。自分が何を購読中か分からなくなったときに使う", annotations(read_only_hint = true))]
+    async fn oretachi_list_subscriptions(
+        &self,
+        Parameters(ListSubscriptionsParams { terminal_id, project_dir }): Parameters<ListSubscriptionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let subscriber = resolve_subscriber(
+            &self.app_handle,
+            terminal_id.as_deref(),
+            project_dir.as_deref(),
+        )?;
+        let pool = event_pool(&self.app_handle)?;
+        let now = crate::event_db::now_ms();
+        let subs = crate::event_db::list_subscriptions(&pool, &subscriber.terminal_id, now)
+            .await
+            .map_err(|e| McpError::internal_error(e, None))?;
+        let (unacked, undelivered) = crate::event_db::count_unacked(&pool, &subscriber.terminal_id)
+            .await
+            .map_err(|e| McpError::internal_error(e, None))?;
+
+        // ワークツリー名の付与は表示目的のみ。既にクローズ済みなら ID だけになる。
+        let settings = self.app_handle.state::<SettingsManager>().get();
+        let items: Vec<serde_json::Value> = subs
+            .iter()
+            .map(|s| {
+                let name = settings
+                    .worktrees
+                    .iter()
+                    .find(|w| w.id == s.target)
+                    .map(|w| w.name.clone());
+                serde_json::json!({
+                    "subscriptionId": s.id,
+                    "targetWorktreeId": s.target,
+                    "targetWorktreeName": name,
+                    "eventKinds": serde_json::from_str::<serde_json::Value>(&s.event_kinds).unwrap_or(serde_json::Value::Null),
+                    "delivery": s.delivery,
+                    "spawnIfClosed": s.spawn_if_closed != 0,
+                    "createdAt": s.created_at,
+                    "expiresAt": s.expires_at,
+                    "state": s.state,
+                })
+            })
+            .collect();
+
+        log::info!(
+            "[mcp] oretachi_list_subscriptions: terminal={} count={} unacked={}",
+            subscriber.terminal_id, items.len(), unacked
+        );
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::json!({
+                "terminalId": subscriber.terminal_id,
+                "subscriptions": items,
+                "unackedMessages": unacked,
+                "undeliveredMessages": undelivered,
+            })
+            .to_string(),
+        )]))
+    }
+
+    // `read_only_hint = true` は artifact 系ツール（本ファイル冒頭のコメント参照）と同じ理由で
+    // 意図的に付けている: plan モードで一律 ask になるのを避けるため。実際には
+    // `delivered_at` を UPDATE するが、`WHERE delivered_at IS NULL` ガード付きの冪等更新なので
+    // 並列実行されても破損しない。
+    #[tool(description = "購読していたワークツリーイベントの未確認メッセージを取得する。セッション開始時の自動提示を取りこぼした場合や、走行中に届いた分を自分で取りに行く場合に使う。読んだら oretachi_ack_message で ack すること", annotations(read_only_hint = true))]
+    async fn oretachi_poll_inbox(
+        &self,
+        Parameters(PollInboxParams { terminal_id, project_dir, include_acked }): Parameters<PollInboxParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let subscriber = resolve_subscriber(
+            &self.app_handle,
+            terminal_id.as_deref(),
+            project_dir.as_deref(),
+        )?;
+        let pool = event_pool(&self.app_handle)?;
+        // 明示的な pull なので未 ack 全件を返す（自動注入を取りこぼしてもここで必ず回収できる）
+        let filter = if include_acked.unwrap_or(false) {
+            crate::event_db::InboxFilter::All
+        } else {
+            crate::event_db::InboxFilter::Unacked
+        };
+        let mut items = crate::event_db::list_inbox(&pool, &subscriber.terminal_id, filter)
+            .await
+            .map_err(|e| McpError::internal_error(e, None))?;
+
+        // 取得した時点で「送った」印を打つ。ack とは分けているので、ack されない限り
+        // 行は残り、UI や再 poll から人間が気づける（#120 §5.2）。
+        let now = crate::event_db::now_ms();
+        let ids: Vec<String> = items
+            .iter()
+            .filter(|i| i.delivered_at.is_none())
+            .map(|i| i.id.clone())
+            .collect();
+        if let Err(e) = crate::event_db::mark_delivered(&pool, &ids, now).await {
+            log::warn!("[mcp] oretachi_poll_inbox: mark_delivered failed: {}", e);
+        } else {
+            // 打刻した値をレスポンスにも反映する（DB と表示のズレを残さない）
+            for item in items.iter_mut().filter(|i| i.delivered_at.is_none()) {
+                item.delivered_at = Some(now);
+            }
+        }
+
+        log::info!(
+            "[mcp] oretachi_poll_inbox: terminal={} count={}",
+            subscriber.terminal_id,
+            items.len()
+        );
+        let messages: Vec<serde_json::Value> = items
+            .iter()
+            .map(|i| {
+                serde_json::json!({
+                    "id": i.id,
+                    "kind": i.kind,
+                    "sourceWorktreeId": i.source_worktree_id,
+                    "body": serde_json::from_str::<serde_json::Value>(&i.body).unwrap_or(serde_json::Value::Null),
+                    "actor": i.actor,
+                    "createdAt": i.created_at,
+                    "deliveredAt": i.delivered_at,
+                    "ackedAt": i.acked_at,
+                    "text": crate::event_db::format_inbox_line(i),
+                })
+            })
+            .collect();
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::json!({
+                "terminalId": subscriber.terminal_id,
+                "messages": messages,
+                "hint": if messages.is_empty() {
+                    "未確認メッセージはありません。".to_string()
+                } else {
+                    "内容を確認したら oretachi_ack_message に id を渡して ack してください。ack しない限りこの一覧に残り続けます（セッション開始時の自動提示は一度だけなので、以後はこのツールで取り直します）。".to_string()
+                },
+            })
+            .to_string(),
+        )]))
+    }
+
+    #[tool(description = "受け取ったワークツリーイベントのメッセージを確認済み（ack）にする。ack しない限りセッション開始ごとに再掲される。既に ack 済みの ID を渡してもエラーにならない", annotations(idempotent_hint = true))]
+    async fn oretachi_ack_message(
+        &self,
+        Parameters(AckMessageParams { ids, terminal_id, project_dir }): Parameters<AckMessageParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ids: Vec<String> = ids
+            .into_iter()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if ids.is_empty() {
+            return Err(McpError::invalid_params("ids must not be empty", None));
+        }
+        let subscriber = resolve_subscriber(
+            &self.app_handle,
+            terminal_id.as_deref(),
+            project_dir.as_deref(),
+        )?;
+        let pool = event_pool(&self.app_handle)?;
+        let acked = crate::event_db::ack(
+            &pool,
+            &ids,
+            &subscriber.terminal_id,
+            crate::event_db::now_ms(),
+        )
+        .await
+        .map_err(|e| McpError::internal_error(e, None))?;
+
+        log::info!(
+            "[mcp] oretachi_ack_message: terminal={} requested={} acked={}",
+            subscriber.terminal_id,
+            ids.len(),
+            acked
+        );
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} 件を確認済みにしました（要求 {} 件。差分は既に ack 済みか、別のターミナル宛のメッセージです）。",
+            acked,
+            ids.len()
+        ))]))
+    }
+
     #[tool(description = "指定ワークツリーに新しいターミナルタブを追加し、与えられたコマンドを流し込む。pnpm dev / tauri dev / vite / next dev など長時間常駐するバックグラウンドコマンドを oretachi UI 上で起動するために使う")]
     fn oretachi_spawn_terminal(
         &self,
@@ -1898,16 +2344,10 @@ impl NotifyService {
 
         let mut items: Vec<serde_json::Value> = Vec::new();
         for info in raw {
-            // ホームの path はワークツリー追加先ディレクトリ = 全ワークツリーの祖先なので、
-            // 先頭一致で拾うと全ターミナルがホーム所属になってしまう。最長一致を採用する。
-            let matched_wt = info.cwd.as_deref().and_then(|c| {
-                let cp = std::path::Path::new(c);
-                settings
-                    .worktrees
-                    .iter()
-                    .filter(|w| cp.starts_with(std::path::Path::new(&w.path)))
-                    .max_by_key(|w| std::path::Path::new(&w.path).components().count())
-            });
+            let matched_wt = info
+                .cwd
+                .as_deref()
+                .and_then(|c| resolve_worktree_by_cwd(&settings, c));
             let matched_wt_id = matched_wt.map(|w| w.id.clone());
             if let Some(ref fid) = filter_id {
                 if matched_wt_id.as_deref() != Some(fid.as_str()) {
@@ -2076,6 +2516,21 @@ fn resolve_worktree_by_dir<'a>(settings: &'a AppSettings, dir: &str) -> Option<&
         .find(|w| normalize_path_for_match(&w.path) == target)
 }
 
+/// ターミナルの cwd からワークツリーを逆引きする（**前方一致＋最長一致**）。
+///
+/// `resolve_worktree_by_dir` の完全一致と違い、ワークツリーのサブディレクトリで
+/// エージェントを起動した場合も解決できる。ホームの path はワークツリー追加先
+/// ディレクトリ = 全ワークツリーの祖先なので、先頭一致だけで拾うと全ターミナルが
+/// ホーム所属になってしまう。最長一致を採用する。
+fn resolve_worktree_by_cwd<'a>(settings: &'a AppSettings, cwd: &str) -> Option<&'a WorktreeEntry> {
+    let cp = std::path::Path::new(cwd);
+    settings
+        .worktrees
+        .iter()
+        .filter(|w| cp.starts_with(std::path::Path::new(&w.path)))
+        .max_by_key(|w| std::path::Path::new(&w.path).components().count())
+}
+
 /// ワークツリーのパスから表示名（末尾ディレクトリ名）を取り出す。
 /// フロントのリポジトリ名導出（`path.split(/[/\\]/).pop()`）と同じ規則。
 fn worktree_name_from_path(path: &str) -> String {
@@ -2154,6 +2609,136 @@ fn resolve_worktree<'a>(
     }
 
     Err(McpError::invalid_params(missing_hint.to_string(), None))
+}
+
+/// 購読系ツールを呼んでいるタブの同定結果（issue #123）。
+struct SubscriberIdentity {
+    /// 購読の主キー。PTY spawn 時に発番された UUID
+    terminal_id: String,
+    /// タブの cwd からの逆引き。管理外ディレクトリなら None
+    worktree_id: Option<String>,
+    /// 最後に見た Claude Code の session UUID（監査用）
+    agent_session: Option<String>,
+}
+
+/// 購読系ツールの呼び出し元タブを同定する。
+///
+/// MCP ツール呼び出しからは呼び出し元セッションを特定できず、`project_dir` (cwd) は
+/// 同一ワークツリーの全タブで同じなので cwd では絞れない。そのため
+/// `ORETACHI_TERMINAL_ID`（SessionStart の additionalContext で本人に伝えている）を
+/// 渡してもらうのが本筋で、省略時のみ「そのワークツリーで走行中の AI エージェント端末が
+/// 1つだけ」という条件下で推測する。
+fn resolve_subscriber(
+    app_handle: &AppHandle,
+    terminal_id: Option<&str>,
+    project_dir: Option<&str>,
+) -> Result<SubscriberIdentity, McpError> {
+    let pty = app_handle.state::<crate::pty_manager::PtyManager>();
+    let sessions = pty.list_sessions();
+    let settings = app_handle.state::<SettingsManager>().get();
+
+    let resolve = |info: &crate::pty_manager::SessionInfo| SubscriberIdentity {
+        terminal_id: info.terminal_id.clone(),
+        worktree_id: info
+            .cwd
+            .as_deref()
+            .and_then(|c| resolve_worktree_by_cwd(&settings, c))
+            .map(|w| w.id.clone()),
+        agent_session: info.agent_session_id.clone(),
+    };
+
+    // 注意: ここで検証できるのは「その terminal_id が実在するか」だけで、呼び出し元本人か
+    // どうかは分からない（MCP ツール呼び出しから発信セッションを特定する手段が無い）。
+    // つまり terminal_id を差し替えれば他タブの inbox を読み・ack し、購読を解除できる。
+    // ローカルの信頼境界内なので許容しているが、`event_db` 側の
+    // 「自分のタブの購読しか消せない」は SQL のスコープ制約であって本人性の保証ではない。
+    if let Some(id) = terminal_id.map(str::trim).filter(|s| !s.is_empty()) {
+        return sessions
+            .iter()
+            .find(|s| s.terminal_id == id)
+            .map(resolve)
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    format!(
+                        "terminal_id '{}' に一致するターミナルがありません。セッション開始時に oretachi から注入された terminal_id をそのまま渡すか、oretachi_list_terminals で確認してください",
+                        id
+                    ),
+                    None,
+                )
+            });
+    }
+
+    // terminal_id 省略時のフォールバック: project_dir のワークツリーで走行中の AI 端末が
+    // 1つだけならそれを採用する。複数タブがある場合は誤配送に直結するので推測しない。
+    let Some(dir) = project_dir.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Err(McpError::invalid_params(
+            "terminal_id または project_dir を指定してください。terminal_id はセッション開始時に oretachi から注入されています",
+            None,
+        ));
+    };
+    let Some(wt) = resolve_worktree_by_cwd(&settings, dir) else {
+        return Err(McpError::invalid_params(
+            format!(
+                "project_dir '{}' に一致するワークツリーがありません。available: [{}]",
+                dir,
+                available_worktree_names(&settings)
+            ),
+            None,
+        ));
+    };
+    let candidates: Vec<&crate::pty_manager::SessionInfo> = sessions
+        .iter()
+        .filter(|s| s.exit_code.is_none() && s.is_ai_agent)
+        .filter(|s| {
+            s.cwd
+                .as_deref()
+                .and_then(|c| resolve_worktree_by_cwd(&settings, c))
+                .map(|w| w.id == wt.id)
+                .unwrap_or(false)
+        })
+        .collect();
+    match candidates.len() {
+        1 => Ok(resolve(candidates[0])),
+        0 => Err(McpError::invalid_params(
+            format!(
+                "ワークツリー '{}' に走行中の AI エージェント端末が見つかりません。terminal_id を明示してください（セッション開始時に oretachi から注入されています）",
+                wt.name
+            ),
+            None,
+        )),
+        n => Err(McpError::invalid_params(
+            format!(
+                "ワークツリー '{}' に AI エージェント端末が {} 個あるため呼び出し元を特定できません。terminal_id を明示してください（セッション開始時に oretachi から注入されています）",
+                wt.name, n
+            ),
+            None,
+        )),
+    }
+}
+
+/// 1つの文字列をワークツリー ID としても名前としても解決する（購読の `target` 用）。
+/// エージェントに「ID か名前か」を意識させないため両方試す。ID を優先する。
+fn resolve_worktree_by_name_or_id<'a>(
+    settings: &'a AppSettings,
+    value: &str,
+) -> Result<&'a WorktreeEntry, McpError> {
+    if let Some(wt) = settings.worktrees.iter().find(|w| w.id == value) {
+        return Ok(wt);
+    }
+    resolve_worktree(settings, None, Some(value), None, "specify a worktree name or id")
+}
+
+/// event_db のプールを取り出す。未初期化なら AI に伝わるエラーにする。
+fn event_pool(app_handle: &AppHandle) -> Result<sqlx::SqlitePool, McpError> {
+    app_handle
+        .try_state::<crate::event_db::EventPool>()
+        .map(|p| p.0.clone())
+        .ok_or_else(|| {
+            McpError::internal_error(
+                "イベント DB が初期化されていないため購読機能を利用できません（oretachi のログを確認してください）",
+                None,
+            )
+        })
 }
 
 /// artifact 系ツール（artifact / artifact_module / search_artifact）の保存先ワークツリーを解決する。
@@ -2556,6 +3141,10 @@ async fn set_description_handler(
 
 // ─── Simple REST endpoint (/session-context) ─────────────────────────────────
 
+/// SessionStart の inbox 取得に許す時間。サイドカーの読み取りタイムアウト（2 秒）より
+/// 十分に短くして、DB が詰まっても systemPrompt の注入まで巻き込まないようにする。
+const INBOX_DIGEST_BUDGET_MS: u64 = 1200;
+
 /// SessionStart フックから呼ばれ、ワークツリー所属グループの systemPrompt を返す。
 /// 解決を毎回ここで行うため、グループ設定の変更は次のセッション開始から自動反映される。
 /// 未解決（管理外ディレクトリ・プロンプト未設定）は prompt: null を返し、注入は行われない。
@@ -2583,15 +3172,84 @@ async fn session_context_handler(
             }
         })
         .filter(|s| !s.trim().is_empty());
-    // terminal_id はサイドカーが env から拾って送ってくる。additionalContext への
-    // 自己 ID 注入はサイドカー側で行うため、ここではログのみ（発火元タブの確認用）。
+    // terminal_id はサイドカーが env から拾って送ってくる。自己 ID そのものの
+    // additionalContext 注入はサイドカー側で行うが、購読メッセージの回収はここで行う。
+    // アプリ停止中に溜まった分もセッション開始のこのタイミングで回収できる（issue #123）。
+    // サイドカーの読み取りタイムアウトは 2 秒。それを超えるとレスポンス自体が捨てられ
+    // グループ systemPrompt の注入まで失う（`notify/src/main.rs` の Err → default 経路）。
+    // DB が詰まっている場合は inbox を諦めて prompt だけでも返す。諦めた分は打刻していない
+    // ので次のセッション開始で再度提示される。
+    let inbox = match tokio::time::timeout(
+        std::time::Duration::from_millis(INBOX_DIGEST_BUDGET_MS),
+        collect_inbox_digest(&app_handle, payload.terminal_id.as_deref()),
+    )
+    .await
+    {
+        Ok(inbox) => inbox,
+        Err(_) => {
+            log::warn!(
+                "[session-context] inbox の取得が {}ms を超えたため今回は注入を見送る (terminal={:?})",
+                INBOX_DIGEST_BUDGET_MS,
+                payload.terminal_id
+            );
+            None
+        }
+    };
     log::info!(
-        "[session-context] projectDir={:?} terminal={:?} prompt_len={:?}",
+        "[session-context] projectDir={:?} terminal={:?} prompt_len={:?} inbox_len={:?}",
         payload.project_dir,
         payload.terminal_id,
-        prompt.as_ref().map(|p| p.len())
+        prompt.as_ref().map(|p| p.len()),
+        inbox.as_ref().map(|s| s.len())
     );
-    Json(serde_json::json!({ "prompt": prompt }))
+    Json(serde_json::json!({ "prompt": prompt, "inbox": inbox }))
+}
+
+/// 指定タブ宛の inbox を SessionStart 注入用テキストにまとめ、本文を出した分に
+/// `delivered_at` を打つ。
+///
+/// terminal_id が無い（oretachi 管理外のターミナルから起動されたエージェント）場合や
+/// イベント DB が未初期化の場合は None を返し、既存の挙動を一切変えない。
+///
+/// 本文を列挙するのは **未配送のみ**。未 ack 全件を毎回再掲すると「再送はしない」方針
+/// （#120 §5.2）に反する。ただしそれだけだと、注入が失われたとき（サイドカーの読み取り
+/// タイムアウト等）にエージェントも人間も気づけなくなる（Phase 1 には UI が無い）。
+/// そこで**未 ack の残存件数だけは毎回伝える**。件数を見れば `oretachi_poll_inbox` で
+/// 取り直せるので、注入喪失が恒久的な取りこぼしにならない。
+async fn collect_inbox_digest(app_handle: &AppHandle, terminal_id: Option<&str>) -> Option<String> {
+    let terminal_id = terminal_id.map(str::trim).filter(|s| !s.is_empty())?;
+    let pool = app_handle
+        .try_state::<crate::event_db::EventPool>()
+        .map(|p| p.0.clone())?;
+    let items = match crate::event_db::list_inbox(
+        &pool,
+        terminal_id,
+        crate::event_db::InboxFilter::Undelivered,
+    )
+    .await
+    {
+        Ok(items) => items,
+        Err(e) => {
+            log::warn!("[session-context] inbox 取得に失敗: {}", e);
+            return None;
+        }
+    };
+    // 配送済みだが未 ack のまま残っている件数（今回本文を出す分は差し引く）
+    let carryover = match crate::event_db::count_unacked(&pool, terminal_id).await {
+        Ok((unacked, _)) => (unacked - items.len() as i64).max(0),
+        Err(e) => {
+            log::warn!("[session-context] 未 ack 件数の取得に失敗: {}", e);
+            0
+        }
+    };
+    let digest = crate::event_db::format_inbox_digest(&items, carryover)?;
+    let ids: Vec<String> = items.iter().map(|i| i.id.clone()).collect();
+    if let Err(e) = crate::event_db::mark_delivered(&pool, &ids, crate::event_db::now_ms()).await {
+        // 打刻に失敗しても本文は返す。未配送のまま残るので次回のセッション開始で再度出る
+        // （取りこぼすより一度重複するほうが安全）。
+        log::warn!("[session-context] mark_delivered に失敗: {}", e);
+    }
+    Some(digest)
 }
 
 // ─── Simple REST endpoint (/prompt-context) ──────────────────────────────────

--- a/src/composables/useWorktreeRemove.ts
+++ b/src/composables/useWorktreeRemove.ts
@@ -320,7 +320,31 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
     removeOptions: RemoveOptions,
     onSettled?: OnRemoveSettled,
   ): Promise<WorktreeRemoveResult> {
-    return await _execute(worktreeId, removeOptions, t("deletingText"), undefined, undefined, undefined, onSettled);
+    // アーカイブしていないので worktree-archived の MCP 通知は出さないが、
+    // 購読者にとっては「作業が終わった」という同じ意味を持つので
+    // worktree.closed イベントだけは発行する (issue #123)
+    const fireClosed = async (worktree: Worktree) => {
+      await invoke("notify_worktree_closed", {
+        id: worktree.id,
+        name: worktree.name,
+        branchName: worktree.branchName,
+      }).catch(() => { /* 通知失敗は削除の成否に影響しない */ });
+    };
+    return await _execute(
+      worktreeId,
+      removeOptions,
+      t("deletingText"),
+      undefined,
+      async (worktree) => {
+        // git 操作失敗時: ワークツリーが既に消えている（ブランチ削除失敗などの部分的失敗）
+        // ケースでは afterRemove に到達しないため、ここで発火する。
+        // archiveWorktree の onRemoveFailed と同じ判定。
+        const pathStillExists = await invoke<boolean>("path_exists", { path: worktree.path }).catch(() => false);
+        if (!pathStillExists) await fireClosed(worktree);
+      },
+      fireClosed,
+      onSettled,
+    );
   }
 
   return {


### PR DESCRIPTION
Closes #123 （親: #120 Phase 1）

## 概要

ワークツリー間イベントの**購読**機構を入れ、`worktree.closed` を第三者のセッションへ届ける。これで #120 の動機②「別ワークツリーの対応がクローズしたのを検知して改めて動作確認を行いたい」が成立する。

購読の主キーは #122 で貫通させた `terminal_id`。ワークツリー単位にすると同一ワークツリーの複数タブを区別できず、**A タブ宛のメッセージを B タブの回収が抜き取る**（#120 §2）。本 PR は terminal_id を実際に消費する最初の実装。

対象イベントは `worktree.closed` のみ。配送は `SessionStart` 回収と `oretachi_poll_inbox` まで（Stop フック配送は #124、PTY 押し込み / spawn は #125、`created` / `message` と target ワイルドカードは #126）。

## 変更内容

### 1. `src-tauri/src/event_db.rs`（新規）

テーブルは #120 §3 の DDL（`subscriptions` / `events` / `inbox`）。雛形は `task_db.rs` / `archive_db.rs`。`sqlx` に `macros` / `migrate` feature が無いのでランタイム版 `query` / `query_as` のみ、マイグレーションは毎起動 `CREATE TABLE IF NOT EXISTS`、後付けカラムは `ALTER TABLE` の握り潰し。`SqlitePool` は `EventPool` newtype で `manage`。`setup()` 内で `block_on` 初期化し、**失敗しても起動継続**。

- `inbox` の `UNIQUE(subscriber_terminal_id, event_id)` が「複数購読が同じイベントを拾ったときの重複マージ」を兼ねる
- `event_kinds` の突合と自己エコー抑止は純粋関数（`task_db.rs` の `steps_match_worktree` と同じ流儀）
- `busy_timeout` を 800ms に明示。この DB は SessionStart フックのリクエストパスから触るため、sqlx 既定の 5 秒待つとサイドカーの読み取りタイムアウト（2 秒）を超える

### 2. `worktree.closed` の発火（fire-and-forget）

発火点は `notify_worktree_archived`（`lib.rs`）。**UI 削除と MCP close の両経路が必ず通る唯一のチョークポイント**で、`git worktree remove` の成功確認後にフロントから呼ばれる。`Cancelled` / `Busy` / `Failed` では `useWorktreeRemove.ts` の `afterRemove` に到達しないため**構造的に発火しない**（`mcp_close_worktree_result` の分岐を見に行く必要がない）。

イベント発行は `tauri::async_runtime::spawn` の fire-and-forget で、`CloseWorktreeAckRegistry` の 45 秒 ack 経路をブロックしない。既存の `should_send_notify` debounce は通さない（`closed` が落ちると本 issue の動機そのものが壊れる）。MCP ピアへの broadcast は本 Phase では増やしていない。

アーカイブせず削除する経路（`removeWorktreeNoArchive`）には `worktree-archived` の broadcast を出さない専用コマンド `notify_worktree_closed` を用意した。購読者にとっては「作業が終わった」という同じ意味を持つため。

### 3. MCP ツール5本

| ツール | 用途 |
|---|---|
| `oretachi_subscribe_worktree` | 購読登録。`target` はワークツリー名 / ID 両対応 |
| `oretachi_unsubscribe_worktree` | `subscription_id` または `target` で解除 |
| `oretachi_list_subscriptions` | 自分の購読 + 未 ack / 未配送件数 |
| `oretachi_poll_inbox` | 取りこぼし回収（未 ack 全件） |
| `oretachi_ack_message` | ack（冪等） |

呼び出し元タブの同定は `resolve_subscriber`。`terminal_id` 明示が本筋で、省略時のみ「そのワークツリーで走行中の AI エージェント端末が1つだけ」の条件下で推測する。`terminal_id` → ワークツリーの逆引きは `oretachi_list_terminals` の**前方一致＋最長一致**ロジックを `resolve_worktree_by_cwd` に切り出して共用した（`resolve_worktree_by_dir` の完全一致ではサブディレクトリで `claude` を起動した端末を解決できない。#122 で意図的に残した差分をここで初めて消費する）。

### 4. `SessionStart` での回収

`/session-context` のレスポンスを `{prompt, inbox}` に拡張し、サイドカーの `build_session_context_output` が **prompt → terminal_id → inbox** の順で `additionalContext` を組む。アプリ稼働中にエージェント不在で溜まった分もここで回収できる。

`session_context_handler` にスロットルは無いのでそのまま載せた（`/prompt-context` の 600 秒スロットルには触っていない）。

### 5. 配送の冪等性（#120 §5.2）

`delivered_at`（送った）と `acked_at`（AI が確認した）を分け、**本文の再送はしない**。ただし本文だけを未配送に絞ると、注入が失われたときに誰も気づけない（Phase 1 には UI が無い）。そこで**未 ack の残存件数だけは毎回伝える**。件数を見れば `oretachi_poll_inbox` で取り直せるので、注入喪失が恒久的な取りこぼしにならない。

注入取得には 1200ms の締め切りを設けた。DB が詰まっても打刻せずに諦め、`systemPrompt` の注入まで巻き込まない（サイドカーはレスポンスを取り損ねると Err → default に落ちるため、prompt も失う）。

### 6. ライフサイクル管理

- 自己エコー抑止: `source_terminal_id == subscriber_terminal_id` と `subscriber_worktree_id == source_worktree_id` の両方
- 購読者ワークツリーのクローズで自分宛の subscriptions / inbox を掃除。`inbox` 側にも `subscriber_worktree_id` を持たせ、購読行が先に消えていても（unsubscribe 済み / 失効削除済み）取り残さない
- クローズ済み target を指す購読を配送後に削除（ID は再利用されないので二度とマッチしない）
- `expires_at` による失効（既定は無期限）と inbox の 30 日保持期限
- **起動時に、生存セッションに紐づかない購読と inbox を掃除**（下記「判断」参照）

## 判断: 再起動を挟んだ購読は復活させず、掃除する

`terminal_id` は PTY spawn ごとに発番され永続化されないため、アプリを再起動すると既存の全購読はどのターミナルからも到達できなくなる（`resolve_subscriber` は生存セッションしか受け付けないので list / unsubscribe / poll がすべて不能）。放置すると `fanout` が死んだ宛先へ inbox を積み続け、既定が無期限の購読は単調増加する。

`orphaned` 遷移と `subscriber_worktree_id` 経由の再バインドは #120 §4 で **Phase 3(#125)** の担当と決めているため、本 PR では起動時に到達不能な行を掃除して `list_subscriptions` を実態に一致させるだけに留めた。「購読は現在のセッション内で有効」という制約が残るが、無音で嘘の状態を見せるより良いと判断した。

## テスト

- `cd src-tauri && cargo check` ✅
- `cd src-tauri && cargo test` ✅ **114 件**（`event_db` 23 件を新規追加。純粋関数のほか、`tauri::async_runtime::block_on` + `sqlite::memory:` で SQL と `FromRow` を通す往復テストを 10 件。`tokio` に `macros` / `rt` feature が無いため `#[tokio::test]` は使えない）
- `cd src-tauri && cargo test -p oretachi-notify` ✅ 31 件
- `pnpm run type-check` ✅

## 実機確認

dev ビルドを別インスタンスで起動し、使い捨てワークツリー（oretachi リポジトリの throwaway ブランチ）を作って検証した。MCP は node の raw JSON-RPC で叩いた。検証後に settings / archives.db / events.db / git ワークツリー・ブランチはすべて元に戻している。

- 同一ワークツリー2タブで T1 のみ購読 → クローズ時に **T1 だけ受信、T2 は空**
- 2タブ両方が購読 → `delivered=2`。T1 の SessionStart 注入で **T2 の分は消費されない**（別 inbox 行）
- SessionStart 回収: 1回目は本文が注入され、**2回目は本文が出ない**（再送しない）。`poll_inbox` では未 ack として取り直せる
- ack はタブスコープ（他タブの ID を混ぜると `要求2件 / acked 1件`）、再 ack は 0 件で冪等
- 同時クローズで一方が **Busy** → `worktree.closed` は **1件しか記録されない**
- 購読者ワークツリーのクローズで `subscriptions=4 inbox=4` を掃除、`events` は監査用に残存
- バリデーション: 自ワークツリー購読拒否 / 未対応 `event_kinds` / 存在しない `terminal_id` / 未知の target
- close ツールの応答は 1.2 秒、`[event]` ログはその後（配送でブロックしていない）

### 未実施

- **セルフレビューでの指摘修正後の再実機確認**。上記の実機確認はレビュー前のコードに対するもの。修正後は静的検証のみ（レビュー指摘の対応でロジックが変わったのは主に掃除・打刻・締め切りの各パスで、いずれも `event_db` の往復テストで押さえている）
- `Cancelled`（UI でのリトライ中断が必要）と no-archive 削除経路（UI 操作が必要）はヘッドレスで再現できず、コード経路の確認に留めた

## セルフレビュー

`/bug-review` を実施し、warning 3 件 / suggestion 6 件を自己指摘して全件対応した。主なもの:

- no-archive 削除で「ワークツリーは消えたがブランチ削除が失敗」した場合に発火しない非対称（archive 経路は補償済みだった）→ 同型の `onRemoveFailed` を追加
- 再起動後の購読が到達不能なまま単調増加 → 起動時の掃除を追加（上記「判断」）
- SessionStart の打刻がレスポンス送出前で、喪失時に誰も気づけない → 締め切り・ロック取得の集約・未 ack 件数の通知
- ホーム / リポジトリ擬似ワークツリーは削除禁止なので `worktree.closed` が永久に発火しない → 購読を拒否
- 再購読で `subscription_id` が変わり解除できなくなる → `ON CONFLICT DO UPDATE` で id を維持

CLAUDE.md の `codex-review` はブランチ名が `feature/` 始まりでないため必須フローの対象外だが、上記の自己レビューで代替した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
