### PR TITLE
feat(event): 購読の再バインド + 待機中への PTY 押し込み + 暴走防止 + UI (#125)

### DIFF
--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -32,12 +32,20 @@ pub const KIND_WORKTREE_CLOSED: &str = "worktree.closed";
 /// Phase 1 で受け付けるイベント種別。`worktree.created` / `worktree.message` は #126。
 pub const SUPPORTED_EVENT_KINDS: &[&str] = &[KIND_WORKTREE_CLOSED];
 
-/// 配送戦略。`interrupt`（即 PTY 押し込み）は #125 で追加する。
+/// 配送戦略。
+/// - `turn_end`: 既定。`Stop` フック / `SessionStart` 回収でターン境界に届ける
+/// - `interrupt`: 待機中なら即 PTY へ押し込む（#125）
+/// - `passive`: 積むだけ。エージェントが `oretachi_poll_inbox` で自分から取る
 pub const DELIVERY_TURN_END: &str = "turn_end";
+pub const DELIVERY_INTERRUPT: &str = "interrupt";
 pub const DELIVERY_PASSIVE: &str = "passive";
-pub const SUPPORTED_DELIVERIES: &[&str] = &[DELIVERY_TURN_END, DELIVERY_PASSIVE];
+pub const SUPPORTED_DELIVERIES: &[&str] =
+    &[DELIVERY_TURN_END, DELIVERY_INTERRUPT, DELIVERY_PASSIVE];
 
 pub const STATE_ACTIVE: &str = "active";
+/// 購読者タブが生存していない状態。**配送（inbox への蓄積）は続けるが押し込みはしない**。
+/// 同じワークツリーで新しい AI タブが立った時点で `rebind_next_orphaned_group` が引き継ぐ。
+pub const STATE_ORPHANED: &str = "orphaned";
 pub const STATE_PENDING: &str = "pending";
 pub const STATE_ACKED: &str = "acked";
 
@@ -45,6 +53,29 @@ pub const STATE_ACKED: &str = "acked";
 /// ack 済み・未 ack を問わず `created_at` からこの期間で削除する。
 pub const INBOX_RETENTION_DAYS: i64 = 30;
 pub const INBOX_RETENTION_MS: i64 = INBOX_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+/// orphaned に落ちてから引き継がれずに残った購読 / inbox の保持期限。
+///
+/// active な購読は無期限（#120 本文どおり）だが、到達不能なまま残る行は有界にする必要がある。
+/// アプリを再起動して二度と開かないワークツリーの購読が単調増加するのを防ぐ。
+pub const ORPHANED_RETENTION_DAYS: i64 = 7;
+pub const ORPHANED_RETENTION_MS: i64 = ORPHANED_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+/// イベント連鎖の深さ上限（#120 §5.4 / #125 §3）。これを超えたイベントは配送せず破棄する。
+///
+/// 現状 `worktree.closed` はワークツリー削除操作からしか発火せず、配送がイベントを生む経路は
+/// 存在しないため実際には常に 0。自由文の `worktree.message`（#126）でエージェント同士が
+/// 往復し始めたときに効かせるためのガードを、#125 の要求どおり後付けではなく先に入れておく。
+pub const MAX_EVENT_DEPTH: i64 = 3;
+
+/// PTY 押し込みを許すイベントの鮮度。これより古いイベントは押し込まない。
+///
+/// 再起動直後に何日も前の未配送分が一斉に割り込むのを防ぐ。inbox には残るので
+/// `SessionStart` 回収 / `oretachi_poll_inbox` では取れる（取りこぼしにはならない）。
+pub const PUSH_TTL_MS: i64 = 10 * 60 * 1000;
+
+/// PTY へ流す1メッセージの最大文字数。`sanitize_for_pty` で切り詰める。
+const PTY_TEXT_MAX_CHARS: usize = 600;
 
 /// sqlite の書き込みロック待ち上限。SessionStart フックのリクエストパスから触るため、
 /// サイドカーの読み取りタイムアウト（2 秒）より短くする。
@@ -64,13 +95,16 @@ pub struct SubscriptionRow {
     /// JSON string: string[]
     pub event_kinds: String,
     pub delivery: String,
-    /// 0 / 1。Phase 1 では保存するだけで消費しない（#125 で spawn する）
+    /// 0 / 1。タブが死んでいる宛先へ新しいタブを立てて配送してよいか（明示オプトイン）
     pub spawn_if_closed: i64,
     pub created_at: i64,
     /// None は無期限
     pub expires_at: Option<i64>,
-    /// active | orphaned（orphaned への遷移は #125）
+    /// active | orphaned
     pub state: String,
+    /// orphaned に落ちた時刻。active なら None。保持期限と引き継ぎ順序に使う
+    #[sqlx(default)]
+    pub orphaned_at: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, sqlx::FromRow, Clone)]
@@ -84,6 +118,12 @@ pub struct EventRow {
     pub body: String,
     pub actor: Option<String>,
     pub created_at: i64,
+    /// 連鎖の深さ。`MAX_EVENT_DEPTH` を超えたら配送しない
+    #[sqlx(default)]
+    pub depth: i64,
+    /// 発生源の種別（`archive` / `mcp` / `delivery:<terminal_id>` 等）。監査とループ解析用
+    #[sqlx(default)]
+    pub origin: Option<String>,
 }
 
 /// inbox 1件と、それが指すイベントを結合した配送単位。
@@ -98,11 +138,37 @@ pub struct InboxItem {
     pub created_at: i64,
     pub delivered_at: Option<i64>,
     pub acked_at: Option<i64>,
+    /// 購読者タブが死んで宙に浮いた時刻。**inbox 側にも持つのが要点**:
+    /// `worktree.closed` は `fanout` 直後に `delete_subscriptions_for_target` で購読行が
+    /// 消えるため（`lib.rs` の `fire_worktree_closed`）、再起動を挟んだ回収を購読テーブル
+    /// 起点で行うと何も残っていない。再バインドの駆動元はこちら。
+    #[sqlx(default)]
+    pub orphaned_at: Option<i64>,
+    /// 積んだ時点の購読の配送戦略。購読行は先に消えるのでここに焼き付ける
+    #[sqlx(default)]
+    pub delivery: String,
+    /// 積んだ時点の `spawn_if_closed`（0 / 1）。同上
+    #[sqlx(default)]
+    pub spawn_if_closed: i64,
     // events からの結合分
     pub kind: String,
     pub body: String,
     pub source_worktree_id: String,
     pub actor: Option<String>,
+}
+
+/// 引き継ぎ待ちの1グループ（死亡した1タブが残した購読と未読）。
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow, Clone)]
+pub struct OrphanedGroup {
+    /// 死亡したタブの terminal_id
+    pub terminal_id: String,
+    pub worktree_id: String,
+    pub orphaned_at: i64,
+    /// グループ内の最も古い購読の作成時刻（引き継ぎ順序の tie-break 用）
+    pub created_at: i64,
+    pub subscriptions: i64,
+    /// 未 ack の inbox 件数
+    pub pending: i64,
 }
 
 /// UNIX epoch からのミリ秒。task/archive DB と同じ `i64` 流儀で時刻を持つ。
@@ -145,11 +211,16 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             spawn_if_closed          INTEGER NOT NULL DEFAULT 0,
             created_at               INTEGER NOT NULL,
             expires_at               INTEGER,
-            state                    TEXT NOT NULL DEFAULT 'active'
+            state                    TEXT NOT NULL DEFAULT 'active',
+            orphaned_at              INTEGER
         )"#,
     )
     .execute(pool)
     .await?;
+    // 既存 DB 向け（#125）。既にあればエラーを握りつぶす。
+    let _ = sqlx::query("ALTER TABLE subscriptions ADD COLUMN orphaned_at INTEGER")
+        .execute(pool)
+        .await;
     // 同じタブが同じ対象を二重購読しないようにする（再 subscribe は上書き）
     sqlx::query(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_subs_terminal_target ON subscriptions(subscriber_terminal_id, target)",
@@ -173,11 +244,20 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             kind               TEXT NOT NULL,
             body               TEXT NOT NULL DEFAULT '{}',
             actor              TEXT,
-            created_at         INTEGER NOT NULL
+            created_at         INTEGER NOT NULL,
+            depth              INTEGER NOT NULL DEFAULT 0,
+            origin             TEXT
         )"#,
     )
     .execute(pool)
     .await?;
+    // 既存 DB 向け（#125 の暴走防止）。既にあればエラーを握りつぶす。
+    let _ = sqlx::query("ALTER TABLE events ADD COLUMN depth INTEGER NOT NULL DEFAULT 0")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("ALTER TABLE events ADD COLUMN origin TEXT")
+        .execute(pool)
+        .await;
     sqlx::query("CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at DESC)")
         .execute(pool)
         .await?;
@@ -192,6 +272,9 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             created_at             INTEGER NOT NULL,
             delivered_at           INTEGER,
             acked_at               INTEGER,
+            orphaned_at            INTEGER,
+            delivery               TEXT NOT NULL DEFAULT 'turn_end',
+            spawn_if_closed        INTEGER NOT NULL DEFAULT 0,
             UNIQUE(subscriber_terminal_id, event_id)
         )"#,
     )
@@ -200,6 +283,19 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     // 既存 DB 向けマイグレーション: 購読者ワークツリー（購読行が先に消えても掃除できるように
     // inbox 側にも持たせる）。既にあればエラーを握りつぶす。
     let _ = sqlx::query("ALTER TABLE inbox ADD COLUMN subscriber_worktree_id TEXT")
+        .execute(pool)
+        .await;
+    // 同（#125）。再バインドの駆動元は購読ではなく inbox 側のこの列。
+    let _ = sqlx::query("ALTER TABLE inbox ADD COLUMN orphaned_at INTEGER")
+        .execute(pool)
+        .await;
+    // 配送戦略と spawn 可否は購読側にもあるが、`worktree.closed` は fanout 直後に
+    // `delete_subscriptions_for_target` で購読行が消えるため、積んだ時点の値を inbox に
+    // 焼き付けておかないと後から配送方法を決められない（#125）。
+    let _ = sqlx::query("ALTER TABLE inbox ADD COLUMN delivery TEXT NOT NULL DEFAULT 'turn_end'")
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("ALTER TABLE inbox ADD COLUMN spawn_if_closed INTEGER NOT NULL DEFAULT 0")
         .execute(pool)
         .await;
     sqlx::query(
@@ -230,7 +326,7 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 /// 既存の id が返るので、呼び出し元はこれをエージェントへ返すこと。
 pub async fn upsert_subscription(pool: &SqlitePool, sub: &SubscriptionRow) -> Result<String, String> {
     sqlx::query(
-        "INSERT INTO subscriptions (id, subscriber_terminal_id, subscriber_worktree_id, subscriber_agent_session, target, event_kinds, delivery, spawn_if_closed, created_at, expires_at, state) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+        "INSERT INTO subscriptions (id, subscriber_terminal_id, subscriber_worktree_id, subscriber_agent_session, target, event_kinds, delivery, spawn_if_closed, created_at, expires_at, state, orphaned_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
          ON CONFLICT(subscriber_terminal_id, target) DO UPDATE SET \
            subscriber_worktree_id = excluded.subscriber_worktree_id, \
            subscriber_agent_session = excluded.subscriber_agent_session, \
@@ -238,7 +334,8 @@ pub async fn upsert_subscription(pool: &SqlitePool, sub: &SubscriptionRow) -> Re
            delivery = excluded.delivery, \
            spawn_if_closed = excluded.spawn_if_closed, \
            expires_at = excluded.expires_at, \
-           state = excluded.state",
+           state = excluded.state, \
+           orphaned_at = excluded.orphaned_at",
     )
     .bind(&sub.id)
     .bind(&sub.subscriber_terminal_id)
@@ -251,6 +348,7 @@ pub async fn upsert_subscription(pool: &SqlitePool, sub: &SubscriptionRow) -> Re
     .bind(sub.created_at)
     .bind(sub.expires_at)
     .bind(&sub.state)
+    .bind(sub.orphaned_at)
     .execute(pool)
     .await
     .map_err(|e| e.to_string())?;
@@ -320,7 +418,7 @@ pub async fn list_subscriptions(
 
 pub async fn insert_event(pool: &SqlitePool, event: &EventRow) -> Result<(), String> {
     sqlx::query(
-        "INSERT OR REPLACE INTO events (id, source_worktree_id, source_terminal_id, kind, body, actor, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO events (id, source_worktree_id, source_terminal_id, kind, body, actor, created_at, depth, origin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&event.id)
     .bind(&event.source_worktree_id)
@@ -329,6 +427,8 @@ pub async fn insert_event(pool: &SqlitePool, event: &EventRow) -> Result<(), Str
     .bind(&event.body)
     .bind(&event.actor)
     .bind(event.created_at)
+    .bind(event.depth)
+    .bind(&event.origin)
     .execute(pool)
     .await
     .map_err(|e| e.to_string())?;
@@ -368,12 +468,27 @@ pub fn is_self_echo(sub: &SubscriptionRow, event: &EventRow) -> bool {
 ///
 /// 複数の購読が同じイベントを拾ったときの重複は `inbox` の
 /// `UNIQUE(subscriber_terminal_id, event_id)` + `INSERT OR IGNORE` でマージされる。
+///
+/// **`orphaned` な購読にも積む**（#125）。タブが死んでいた / アプリが止まっていた間に届いた
+/// イベントを捨てると、「別ワークツリーの対応がクローズしたのを後で検知したい」という
+/// #120 の動機②そのものが成立しない。押し込み（PTY 注入 / spawn）だけを保留する。
 pub async fn fanout(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usize, String> {
+    // 暴走防止（#120 §5.4）: 連鎖が深すぎるイベントは配送しない。
+    if event.depth > MAX_EVENT_DEPTH {
+        log::warn!(
+            "[event-db] depth {} > {} のイベントを破棄: id={} kind={} origin={:?}",
+            event.depth,
+            MAX_EVENT_DEPTH,
+            event.id,
+            event.kind,
+            event.origin
+        );
+        return Ok(0);
+    }
     let candidates = sqlx::query_as::<_, SubscriptionRow>(
-        "SELECT * FROM subscriptions WHERE target = ? AND state = ? AND (expires_at IS NULL OR expires_at > ?)",
+        "SELECT * FROM subscriptions WHERE target = ? AND state IN ('active', 'orphaned') AND (expires_at IS NULL OR expires_at > ?)",
     )
     .bind(&event.source_worktree_id)
-    .bind(STATE_ACTIVE)
     .bind(now)
     .fetch_all(pool)
     .await
@@ -393,8 +508,15 @@ pub async fn fanout(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usi
             );
             continue;
         }
+        // orphaned な購読へ積む行は最初から orphaned として印を付ける。そうしないと
+        // 「タブが死んでいる間に届いた分」が再バインドの対象から漏れる。
+        let orphaned_at = if sub.state == STATE_ORPHANED {
+            Some(sub.orphaned_at.unwrap_or(now))
+        } else {
+            None
+        };
         let result = sqlx::query(
-            "INSERT OR IGNORE INTO inbox (id, subscriber_terminal_id, subscriber_worktree_id, event_id, state, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT OR IGNORE INTO inbox (id, subscriber_terminal_id, subscriber_worktree_id, event_id, state, created_at, orphaned_at, delivery, spawn_if_closed) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(uuid::Uuid::new_v4().to_string())
         .bind(&sub.subscriber_terminal_id)
@@ -402,6 +524,9 @@ pub async fn fanout(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usi
         .bind(&event.id)
         .bind(STATE_PENDING)
         .bind(now)
+        .bind(orphaned_at)
+        .bind(&sub.delivery)
+        .bind(sub.spawn_if_closed)
         .execute(pool)
         .await
         .map_err(|e| e.to_string())?;
@@ -446,7 +571,7 @@ pub async fn list_inbox(
     filter: InboxFilter,
 ) -> Result<Vec<InboxItem>, String> {
     let sql = format!(
-        "SELECT i.id, i.subscriber_terminal_id, i.subscriber_worktree_id, i.event_id, i.state, i.created_at, i.delivered_at, i.acked_at, e.kind, e.body, e.source_worktree_id, e.actor \
+        "SELECT i.id, i.subscriber_terminal_id, i.subscriber_worktree_id, i.event_id, i.state, i.created_at, i.delivered_at, i.acked_at, i.orphaned_at, i.delivery, i.spawn_if_closed, e.kind, e.body, e.source_worktree_id, e.actor \
          FROM inbox i JOIN events e ON e.id = i.event_id \
          WHERE i.subscriber_terminal_id = ?{} ORDER BY i.created_at ASC",
         filter.where_clause()
@@ -516,6 +641,352 @@ pub async fn ack(
     Ok(q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected())
 }
 
+// ─── orphaned 遷移と再バインド（#125） ────────────────────────────────────────
+
+/// 生存タブに紐づかない購読と未 ack の inbox を `orphaned` にする（**削除しない**）。
+///
+/// `terminal_id` は PTY spawn ごとの発番で永続化されないため、アプリを再起動すると
+/// 前回の購読はどのタブからも到達できなくなる。Phase 1 はこれを全削除していたが、
+/// それでは #120 の動機②（数時間〜数日待って別ワークツリーのクローズを検知する）が
+/// 再起動を挟んだ瞬間に壊れる。行は保持し、同じワークツリーで新しい AI タブが立った
+/// 時点で `rebind_next_orphaned_group` が引き継ぐ。
+///
+/// `subscriber_worktree_id` が NULL の行だけは引き継ぎ先を解決できないので削除する
+/// （現行の `subscribe` は `Some` を強制するので実質レガシー行のみ）。
+///
+/// 起動時は生存タブが 0 件なので全行が orphaned になる。これは意図どおり。
+///
+/// 戻り値は (orphaned にした購読数, orphaned にした inbox 数, 削除した到達不能行数)。
+pub async fn mark_orphaned_subscribers(
+    pool: &SqlitePool,
+    live_terminal_ids: &[String],
+    now: i64,
+) -> Result<(u64, u64, u64), String> {
+    let not_live = if live_terminal_ids.is_empty() {
+        String::new()
+    } else {
+        format!(
+            " AND subscriber_terminal_id NOT IN ({})",
+            placeholders(live_terminal_ids.len())
+        )
+    };
+    // 引き継ぎ先を解決できない行は保持しても永久に到達できないので削除する。
+    let sql = format!(
+        "DELETE FROM inbox WHERE subscriber_worktree_id IS NULL{}",
+        not_live
+    );
+    let mut q = sqlx::query(&sql);
+    for id in live_terminal_ids {
+        q = q.bind(id);
+    }
+    let mut deleted = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+    let sql = format!(
+        "DELETE FROM subscriptions WHERE subscriber_worktree_id IS NULL{}",
+        not_live
+    );
+    let mut q = sqlx::query(&sql);
+    for id in live_terminal_ids {
+        q = q.bind(id);
+    }
+    deleted += q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+    let sql = format!(
+        "UPDATE subscriptions SET state = ?, orphaned_at = ? WHERE state = ?{}",
+        not_live
+    );
+    let mut q = sqlx::query(&sql)
+        .bind(STATE_ORPHANED)
+        .bind(now)
+        .bind(STATE_ACTIVE);
+    for id in live_terminal_ids {
+        q = q.bind(id);
+    }
+    let subs = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+    // ack 済みの行は引き継ぐ意味がない（監査証跡としてそのまま残す）。
+    let sql = format!(
+        "UPDATE inbox SET orphaned_at = ? WHERE orphaned_at IS NULL AND acked_at IS NULL{}",
+        not_live
+    );
+    let mut q = sqlx::query(&sql).bind(now);
+    for id in live_terminal_ids {
+        q = q.bind(id);
+    }
+    let inbox = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+    Ok((subs, inbox, deleted))
+}
+
+/// 指定ワークツリーの引き継ぎ待ちグループを、引き継ぎ順（先頭が次に引き継がれる）で返す。
+///
+/// **購読と inbox の和集合**をグループの母集合にするのが要点。`worktree.closed` は
+/// `fanout` 直後に `delete_subscriptions_for_target` で購読行が消えるため、本命シナリオ
+/// （待っていた対象がクローズしてから再起動）では inbox 行しか残っていない。
+///
+/// 並び順は `orphaned_at DESC, created_at DESC, terminal_id ASC` の**安定な全順序**。
+/// 起動時の一括遷移では `orphaned_at` が全グループで同値になるため tie-break が必須。
+pub async fn list_orphaned_groups(
+    pool: &SqlitePool,
+    worktree_id: &str,
+) -> Result<Vec<OrphanedGroup>, String> {
+    sqlx::query_as::<_, OrphanedGroup>(
+        "SELECT terminal_id, ? AS worktree_id, MAX(orphaned_at) AS orphaned_at, MIN(created_at) AS created_at, \
+                SUM(is_sub) AS subscriptions, SUM(1 - is_sub) AS pending \
+         FROM ( \
+           SELECT subscriber_terminal_id AS terminal_id, orphaned_at, created_at, 1 AS is_sub \
+             FROM subscriptions \
+            WHERE state = 'orphaned' AND orphaned_at IS NOT NULL AND subscriber_worktree_id = ? \
+           UNION ALL \
+           SELECT subscriber_terminal_id AS terminal_id, orphaned_at, created_at, 0 AS is_sub \
+             FROM inbox \
+            WHERE orphaned_at IS NOT NULL AND acked_at IS NULL AND subscriber_worktree_id = ? \
+         ) \
+         GROUP BY terminal_id \
+         ORDER BY orphaned_at DESC, created_at DESC, terminal_id ASC",
+    )
+    .bind(worktree_id)
+    .bind(worktree_id)
+    .bind(worktree_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// 死亡タブ1つ分の購読と未読を、生存している新しいタブへ引き継ぐ。
+///
+/// 粒度が「死亡タブ単位」なのは、同一ワークツリーの複数タブがそれぞれ別の対象を購読して
+/// いた場合に、新タブ1つが全部を吸い上げてタブ間の宛先分離が消えるのを避けるため
+/// （#120 §2 の「A タブ宛を B タブが抜き取らない」原則）。引き継がれずに残ったグループは
+/// UI に「引き継ぎ待ち」として出し、人間が任意のタブへ手動で引き継げるようにする。
+///
+/// 2つの UNIQUE 制約（`subscriptions(terminal_id, target)` / `inbox(terminal_id, event_id)`）
+/// と衝突しうるので `UPDATE OR IGNORE` + 残骸の DELETE にする。**孤児側を捨てるのが
+/// 両方向で正しい**:
+///
+/// | 生存側(新タブ) | 孤児側(旧タブ) | 孤児を捨てると |
+/// |---|---|---|
+/// | 配送済み | 未配送 | 新タブは既に本文を見ている。正しい |
+/// | 未配送 | 配送済み | 新タブは次の SessionStart で見る。正しい |
+/// | ack 済み | 任意 | 処理済み。正しい |
+///
+/// 一連の UPDATE / DELETE は1トランザクションで行う。分割すると、隙間に走った `fanout`
+/// （orphaned な購読にも積む）が死んだ terminal_id 宛の行を差し込んで取り残す。
+pub async fn rebind_orphaned_group(
+    pool: &SqlitePool,
+    worktree_id: &str,
+    dead_terminal_id: &str,
+    new_terminal_id: &str,
+) -> Result<(u64, u64), String> {
+    if dead_terminal_id == new_terminal_id {
+        return Ok((0, 0));
+    }
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+
+    let subs = sqlx::query(
+        "UPDATE OR IGNORE subscriptions SET subscriber_terminal_id = ?, state = ?, orphaned_at = NULL \
+         WHERE state = ? AND subscriber_worktree_id = ? AND subscriber_terminal_id = ?",
+    )
+    .bind(new_terminal_id)
+    .bind(STATE_ACTIVE)
+    .bind(STATE_ORPHANED)
+    .bind(worktree_id)
+    .bind(dead_terminal_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?
+    .rows_affected();
+
+    // UNIQUE(subscriber_terminal_id, target) に負けた残骸 = 新タブが既に同じ対象を購読済み
+    sqlx::query(
+        "DELETE FROM subscriptions WHERE state = ? AND subscriber_worktree_id = ? AND subscriber_terminal_id = ?",
+    )
+    .bind(STATE_ORPHANED)
+    .bind(worktree_id)
+    .bind(dead_terminal_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let inbox = sqlx::query(
+        "UPDATE OR IGNORE inbox SET subscriber_terminal_id = ?, orphaned_at = NULL \
+         WHERE orphaned_at IS NOT NULL AND acked_at IS NULL AND subscriber_worktree_id = ? AND subscriber_terminal_id = ?",
+    )
+    .bind(new_terminal_id)
+    .bind(worktree_id)
+    .bind(dead_terminal_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?
+    .rows_affected();
+
+    // UNIQUE(subscriber_terminal_id, event_id) に負けた残骸（上表の理由で捨ててよい）
+    sqlx::query(
+        "DELETE FROM inbox WHERE orphaned_at IS NOT NULL AND acked_at IS NULL AND subscriber_worktree_id = ? AND subscriber_terminal_id = ?",
+    )
+    .bind(worktree_id)
+    .bind(dead_terminal_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    tx.commit().await.map_err(|e| e.to_string())?;
+    Ok((subs, inbox))
+}
+
+/// 引き継ぎ待ちの先頭グループ1つを新しいタブへ引き継ぐ。自動トリガ（SessionStart /
+/// AI エージェント検出）はこちらを使う。引き継ぐものが無ければ `(0, 0)`（冪等なので
+/// 複数の経路から同時に呼ばれても無害）。
+pub async fn rebind_next_orphaned_group(
+    pool: &SqlitePool,
+    worktree_id: &str,
+    new_terminal_id: &str,
+) -> Result<(u64, u64), String> {
+    let groups = list_orphaned_groups(pool, worktree_id).await?;
+    let Some(group) = groups
+        .into_iter()
+        .find(|g| g.terminal_id != new_terminal_id)
+    else {
+        return Ok((0, 0));
+    };
+    rebind_orphaned_group(pool, worktree_id, &group.terminal_id, new_terminal_id).await
+}
+
+/// 引き継がれないまま保持期限を過ぎた orphaned 行を削除する。
+/// active な購読は無期限（#120 本文どおり）なので触らない。
+pub async fn purge_orphaned_expired(
+    pool: &SqlitePool,
+    now: i64,
+    orphaned_retention_ms: i64,
+) -> Result<(u64, u64), String> {
+    let deadline = now - orphaned_retention_ms;
+    let inbox = sqlx::query("DELETE FROM inbox WHERE orphaned_at IS NOT NULL AND orphaned_at <= ?")
+        .bind(deadline)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected();
+    let subs = sqlx::query(
+        "DELETE FROM subscriptions WHERE state = ? AND orphaned_at IS NOT NULL AND orphaned_at <= ?",
+    )
+    .bind(STATE_ORPHANED)
+    .bind(deadline)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?
+    .rows_affected();
+    Ok((subs, inbox))
+}
+
+// ─── 押し込み対象の抽出（#125） ───────────────────────────────────────────────
+
+/// PTY 押し込みの候補（未配送・未 ack・鮮度内・引き継ぎ済み）をタブごとにまとめて返す。
+///
+/// `orphaned_at IS NOT NULL` の行は宛先タブが存在しないので対象外（`spawn_if_closed` の
+/// 判断は購読側を見る）。`created_at` が `push_ttl_ms` より古いものも外す —— 再起動直後に
+/// 何日も前の未配送分が一斉に割り込むのを防ぐ。inbox には残るので `SessionStart` 回収や
+/// `oretachi_poll_inbox` では取れる。
+pub async fn list_pushable(
+    pool: &SqlitePool,
+    now: i64,
+    push_ttl_ms: i64,
+) -> Result<Vec<InboxItem>, String> {
+    sqlx::query_as::<_, InboxItem>(
+        "SELECT i.id, i.subscriber_terminal_id, i.subscriber_worktree_id, i.event_id, i.state, i.created_at, i.delivered_at, i.acked_at, i.orphaned_at, i.delivery, i.spawn_if_closed, e.kind, e.body, e.source_worktree_id, e.actor \
+         FROM inbox i JOIN events e ON e.id = i.event_id \
+         WHERE i.delivered_at IS NULL AND i.acked_at IS NULL AND i.orphaned_at IS NULL AND i.created_at > ? \
+         ORDER BY i.created_at ASC",
+    )
+    .bind(now - push_ttl_ms)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// 宛先タブが居ないまま未読が溜まっており、かつ `spawn_if_closed` が立っている
+/// ワークツリーと件数を返す（新しいタブを立てて配送する候補）。
+///
+/// 購読テーブルではなく inbox を見るのは、`worktree.closed` では購読行が fanout 直後に
+/// 消えているため。`spawn_if_closed` は積んだ時点の値が inbox に焼き付けてある。
+pub async fn list_spawn_candidates(
+    pool: &SqlitePool,
+    now: i64,
+    push_ttl_ms: i64,
+) -> Result<Vec<(String, i64)>, String> {
+    let rows: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT subscriber_worktree_id, COUNT(*) FROM inbox \
+         WHERE orphaned_at IS NOT NULL AND acked_at IS NULL AND delivered_at IS NULL \
+           AND spawn_if_closed = 1 AND subscriber_worktree_id IS NOT NULL AND created_at > ? \
+         GROUP BY subscriber_worktree_id",
+    )
+    .bind(now - push_ttl_ms)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(rows)
+}
+
+// ─── UI 向けの読み出し（#120 §7） ─────────────────────────────────────────────
+
+/// 全タブ分の有効な購読を返す。UI の購読一覧用（MCP 経由の `list_subscriptions` は
+/// 呼び出し元タブのぶんだけ返すので、人間向けには横断の一覧が要る）。
+pub async fn list_all_subscriptions(
+    pool: &SqlitePool,
+    now: i64,
+) -> Result<Vec<SubscriptionRow>, String> {
+    sqlx::query_as::<_, SubscriptionRow>(
+        "SELECT * FROM subscriptions WHERE expires_at IS NULL OR expires_at > ? ORDER BY created_at DESC",
+    )
+    .bind(now)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// タブごとの (未 ack 件数, うち未配送件数)。タブの未読バッジに使う。
+pub async fn count_unacked_by_terminal(pool: &SqlitePool) -> Result<Vec<(String, i64, i64)>, String> {
+    sqlx::query_as(
+        "SELECT subscriber_terminal_id, COUNT(*), COALESCE(SUM(CASE WHEN delivered_at IS NULL THEN 1 ELSE 0 END), 0) \
+         FROM inbox WHERE acked_at IS NULL GROUP BY subscriber_terminal_id",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// 全ワークツリーの引き継ぎ待ちグループ。UI の「引き継ぎ待ち」表示と手動引き継ぎ用。
+pub async fn list_all_orphaned_groups(pool: &SqlitePool) -> Result<Vec<OrphanedGroup>, String> {
+    sqlx::query_as::<_, OrphanedGroup>(
+        "SELECT terminal_id, worktree_id, MAX(orphaned_at) AS orphaned_at, MIN(created_at) AS created_at, \
+                SUM(is_sub) AS subscriptions, SUM(1 - is_sub) AS pending \
+         FROM ( \
+           SELECT subscriber_terminal_id AS terminal_id, subscriber_worktree_id AS worktree_id, orphaned_at, created_at, 1 AS is_sub \
+             FROM subscriptions \
+            WHERE state = 'orphaned' AND orphaned_at IS NOT NULL AND subscriber_worktree_id IS NOT NULL \
+           UNION ALL \
+           SELECT subscriber_terminal_id AS terminal_id, subscriber_worktree_id AS worktree_id, orphaned_at, created_at, 0 AS is_sub \
+             FROM inbox \
+            WHERE orphaned_at IS NOT NULL AND acked_at IS NULL AND subscriber_worktree_id IS NOT NULL \
+         ) \
+         GROUP BY terminal_id, worktree_id \
+         ORDER BY orphaned_at DESC, created_at DESC, terminal_id ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// UI からの購読解除。MCP 経由（`delete_subscription`）と違い呼び出し元タブに
+/// 縛られない —— 人間は引き継ぎ待ちの（＝どのタブからも触れない）購読も消せる必要がある。
+pub async fn delete_subscription_by_id(pool: &SqlitePool, id: &str) -> Result<u64, String> {
+    Ok(sqlx::query("DELETE FROM subscriptions WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected())
+}
+
 // ─── 掃除 ─────────────────────────────────────────────────────────────────────
 
 /// 購読者ワークツリーがクローズされたときに、そのワークツリーのタブが持っていた
@@ -571,46 +1042,6 @@ pub async fn delete_subscriptions_for_target(
         .await
         .map_err(|e| e.to_string())?
         .rows_affected())
-}
-
-/// 生存しているターミナルに紐づかない購読とその inbox を削除する。
-///
-/// `terminal_id` は PTY spawn ごとに発番され永続化されないため、**アプリを再起動すると
-/// 既存の全購読はどのターミナルにも到達できなくなる**（`resolve_subscriber` が
-/// 生存セッションしか受け付けないので list / unsubscribe / poll すべて不能）。
-/// そのまま残すと `fanout` が死んだ宛先へ inbox を積み続け、既定が無期限の購読は
-/// 単調増加する。到達不能な行は掃除して `list_subscriptions` を実態に合わせる。
-///
-/// 起動時は生存セッションが 0 件なので全購読が対象になる（これは仕様どおり:
-/// 再起動を挟んだ購読は復活できない。タブ死亡時の復活は #125 の担当）。
-pub async fn purge_orphaned_subscribers(
-    pool: &SqlitePool,
-    live_terminal_ids: &[String],
-) -> Result<(u64, u64), String> {
-    let keep = if live_terminal_ids.is_empty() {
-        String::new()
-    } else {
-        format!(
-            " AND subscriber_terminal_id NOT IN ({})",
-            placeholders(live_terminal_ids.len())
-        )
-    };
-
-    let inbox_sql = format!("DELETE FROM inbox WHERE 1=1{}", keep);
-    let mut q = sqlx::query(&inbox_sql);
-    for id in live_terminal_ids {
-        q = q.bind(id);
-    }
-    let inbox_deleted = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
-
-    let subs_sql = format!("DELETE FROM subscriptions WHERE 1=1{}", keep);
-    let mut q = sqlx::query(&subs_sql);
-    for id in live_terminal_ids {
-        q = q.bind(id);
-    }
-    let subs_deleted = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
-
-    Ok((subs_deleted, inbox_deleted))
 }
 
 /// 失効した購読と保持期限切れの inbox / 参照されなくなった events を削除する。
@@ -697,6 +1128,56 @@ pub fn format_inbox_line(item: &InboxItem) -> String {
     format!("- [{}] {}", item.id, detail)
 }
 
+/// PTY へ流す文字列から制御文字を落とし、長さを切り詰める。
+///
+/// ワークツリー名 / ブランチ名は利用者が自由に付けられる文字列で、`format_inbox_line` を
+/// 経由してそのまま PTY へ流れる。押し込みは `ESC[200~ … ESC[201~CR` のブラケットペーストで
+/// 囲むため、本文に `ESC[201~` や生の CR が混ざるとペーストを脱出して**任意のコマンドが
+/// そのまま実行される**。ESC と C0 制御文字を全部落として構造的に潰す。
+pub fn sanitize_for_pty(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| {
+            if c == '\n' || c == '\r' || c == '\t' {
+                ' '
+            } else {
+                c
+            }
+        })
+        // ESC(0x1b) を含む C0 制御文字と DEL を除去する
+        .filter(|c| !c.is_control())
+        .collect();
+    // 連続空白を1つに畳んでから長さで切る（改行を空白にした分が伸びるため）
+    let collapsed = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= PTY_TEXT_MAX_CHARS {
+        return collapsed;
+    }
+    let truncated: String = collapsed.chars().take(PTY_TEXT_MAX_CHARS).collect();
+    format!("{}…", truncated)
+}
+
+/// 待機中のエージェントへ PTY で押し込む1行テキストを組み立てる。
+///
+/// SessionStart 用の `format_inbox_digest` と分けているのは、押し込みは**1行**でなければ
+/// ならないため（改行はそのままターン送信になる）。本文は `sanitize_for_pty` を通す。
+pub fn format_inbox_push_text(items: &[InboxItem]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let body = items
+        .iter()
+        .map(format_inbox_line)
+        .collect::<Vec<_>>()
+        .join(" / ");
+    Some(sanitize_for_pty(&format!(
+        "[oretachi] 購読していたワークツリーイベントが {} 件届きました。{} \
+         購読していた作業が完了したということなので、必要な動作確認や後続作業を進めてください。\
+         確認したら oretachi_ack_message に [] 内の ID を渡して ack してください。",
+        items.len(),
+        body
+    )))
+}
+
 /// SessionStart 注入用のテキストを組み立てる。
 ///
 /// - `items`: 今回初めて配送する未配送分。本文を列挙する
@@ -753,6 +1234,7 @@ mod tests {
             created_at: 0,
             expires_at: None,
             state: STATE_ACTIVE.to_string(),
+            orphaned_at: None,
         }
     }
 
@@ -766,6 +1248,8 @@ mod tests {
                 .to_string(),
             actor: Some("archive".to_string()),
             created_at: 100,
+            depth: 0,
+            origin: Some("archive".to_string()),
         }
     }
 
@@ -823,6 +1307,9 @@ mod tests {
             created_at: 100,
             delivered_at: None,
             acked_at: None,
+            orphaned_at: None,
+            delivery: DELIVERY_TURN_END.to_string(),
+            spawn_if_closed: 0,
             kind: kind.to_string(),
             body: body.to_string(),
             source_worktree_id: "wt-target".to_string(),
@@ -1126,9 +1613,10 @@ mod tests {
         });
     }
 
-    /// 生存ターミナルに紐づかない購読と inbox は掃除される（再起動後の到達不能行）。
+    /// 生存ターミナルに紐づかない購読と inbox は**削除されず** orphaned になる。
+    /// 生存しているタブのぶんは触られない。
     #[test]
-    fn test_roundtrip_purge_orphaned_subscribers() {
+    fn test_roundtrip_mark_orphaned_spares_live_terminals() {
         with_pool(async {
             let pool = memory_pool().await;
             let now = 1_000_000i64;
@@ -1143,18 +1631,401 @@ mod tests {
             assert_eq!(fanout(&pool, &e, now).await.unwrap(), 2);
 
             // term-a だけ生存している
-            let (subs, inbox) =
-                purge_orphaned_subscribers(&pool, &["term-a".to_string()]).await.unwrap();
-            assert_eq!((subs, inbox), (1, 1));
-            assert_eq!(list_subscriptions(&pool, "term-a", now).await.unwrap().len(), 1);
-            assert!(list_subscriptions(&pool, "term-b", now).await.unwrap().is_empty());
-            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 1);
-            assert!(list_inbox(&pool, "term-b", InboxFilter::All).await.unwrap().is_empty());
+            let (subs, inbox, deleted) =
+                mark_orphaned_subscribers(&pool, &["term-a".to_string()], now).await.unwrap();
+            assert_eq!((subs, inbox, deleted), (1, 1, 0));
 
-            // 生存 0 件（起動直後）なら全部消える
-            let (subs, inbox) = purge_orphaned_subscribers(&pool, &[]).await.unwrap();
+            let live = list_subscriptions(&pool, "term-a", now).await.unwrap();
+            assert_eq!(live[0].state, STATE_ACTIVE);
+            assert_eq!(live[0].orphaned_at, None);
+            let dead = list_subscriptions(&pool, "term-b", now).await.unwrap();
+            assert_eq!(dead[0].state, STATE_ORPHANED, "削除ではなく orphaned へ遷移する");
+            assert_eq!(dead[0].orphaned_at, Some(now));
+            // inbox も両方残る（死んだ側は引き継ぎ待ちの印が付く）
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap()[0].orphaned_at, None);
+            assert_eq!(
+                list_inbox(&pool, "term-b", InboxFilter::All).await.unwrap()[0].orphaned_at,
+                Some(now)
+            );
+        });
+    }
+
+    /// 起動直後（生存 0 件）は全行が orphaned になるが、**1行も消えない**。
+    /// Phase 1 はここで全削除しており、それが「再起動を挟むと購読が消える」の直接原因だった。
+    #[test]
+    fn test_roundtrip_mark_orphaned_at_startup_keeps_everything() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+
+            let (subs, inbox, deleted) = mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+            assert_eq!((subs, inbox, deleted), (1, 1, 0));
+            assert_eq!(list_subscriptions(&pool, "term-a", now).await.unwrap().len(), 1);
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 1);
+
+            // 冪等: 二度目は既に orphaned なので 0 件
+            let (subs, inbox, _) = mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+            assert_eq!((subs, inbox), (0, 0));
+        });
+    }
+
+    /// ワークツリーを逆引きできない行は引き継ぎ先が決まらないので削除する。
+    #[test]
+    fn test_roundtrip_mark_orphaned_deletes_rows_without_worktree() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", None, r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+
+            let (subs, inbox, deleted) = mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+            assert_eq!((subs, inbox, deleted), (0, 0, 1));
+            assert!(list_subscriptions(&pool, "term-a", now).await.unwrap().is_empty());
+        });
+    }
+
+    /// 引き継がれないまま保持期限を過ぎた orphaned 行は削除される（単調増加の防止）。
+    #[test]
+    fn test_roundtrip_purge_orphaned_expired() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+
+            // 期限内は消えない
+            let (subs, inbox) = purge_orphaned_expired(&pool, now + 1000, ORPHANED_RETENTION_MS)
+                .await
+                .unwrap();
+            assert_eq!((subs, inbox), (0, 0));
+
+            let (subs, inbox) =
+                purge_orphaned_expired(&pool, now + ORPHANED_RETENTION_MS + 1, ORPHANED_RETENTION_MS)
+                    .await
+                    .unwrap();
             assert_eq!((subs, inbox), (1, 1));
         });
+    }
+
+    /// **本 issue の核心**: `worktree.closed` は fanout 直後に購読行が消えるため、
+    /// 再起動を挟んだ回収は inbox 行だけを頼りに行う必要がある。
+    #[test]
+    fn test_rebind_recovers_inbox_without_subscription() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-old", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+            // 対象がクローズされたので購読行は消える（fire_worktree_closed と同じ順序）
+            delete_subscriptions_for_target(&pool, "wt-target").await.unwrap();
+            assert!(list_subscriptions(&pool, "term-old", now).await.unwrap().is_empty());
+
+            // アプリ再起動
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+
+            // 同じワークツリーで新しいタブが立つ
+            let (subs, inbox) =
+                rebind_next_orphaned_group(&pool, "wt-subscriber", "term-new").await.unwrap();
+            assert_eq!((subs, inbox), (0, 1), "購読は既に無いが未読は引き継がれる");
+            let recovered = list_inbox(&pool, "term-new", InboxFilter::Undelivered).await.unwrap();
+            assert_eq!(recovered.len(), 1);
+            assert_eq!(recovered[0].orphaned_at, None, "引き継ぎ後は押し込み対象になる");
+            assert!(list_inbox(&pool, "term-old", InboxFilter::All).await.unwrap().is_empty());
+        });
+    }
+
+    /// 引き継ぎは死亡タブ単位で1グループずつ。新タブ1つが全部を吸い上げない。
+    #[test]
+    fn test_rebind_claims_one_group_at_a_time() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            for (i, term) in ["term-1", "term-2", "term-3"].iter().enumerate() {
+                let mut s = sub(term, Some("wt-subscriber"), r#"["worktree.closed"]"#);
+                s.id = format!("sub-{}", i);
+                s.target = format!("wt-target-{}", i);
+                upsert_subscription(&pool, &s).await.unwrap();
+            }
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+            assert_eq!(list_orphaned_groups(&pool, "wt-subscriber").await.unwrap().len(), 3);
+
+            let (subs, _) = rebind_next_orphaned_group(&pool, "wt-subscriber", "new-a").await.unwrap();
+            assert_eq!(subs, 1);
+            assert_eq!(list_orphaned_groups(&pool, "wt-subscriber").await.unwrap().len(), 2);
+
+            let (subs, _) = rebind_next_orphaned_group(&pool, "wt-subscriber", "new-b").await.unwrap();
+            assert_eq!(subs, 1);
+            assert_eq!(list_orphaned_groups(&pool, "wt-subscriber").await.unwrap().len(), 1);
+            // 引き継ぎ先の購読は active に戻っている
+            assert_eq!(
+                list_subscriptions(&pool, "new-a", now).await.unwrap()[0].state,
+                STATE_ACTIVE
+            );
+        });
+    }
+
+    /// 引き継ぎは購読者ワークツリーの中に閉じる（他ワークツリーの分を奪わない）。
+    #[test]
+    fn test_rebind_scoped_to_worktree() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let mut a = sub("term-a", Some("wt-a"), r#"["worktree.closed"]"#);
+            a.id = "sub-a".to_string();
+            upsert_subscription(&pool, &a).await.unwrap();
+            let mut b = sub("term-b", Some("wt-b"), r#"["worktree.closed"]"#);
+            b.id = "sub-b".to_string();
+            upsert_subscription(&pool, &b).await.unwrap();
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+
+            rebind_next_orphaned_group(&pool, "wt-a", "new-a").await.unwrap();
+            assert_eq!(list_subscriptions(&pool, "new-a", now).await.unwrap().len(), 1);
+            assert_eq!(list_orphaned_groups(&pool, "wt-b").await.unwrap().len(), 1);
+        });
+    }
+
+    /// 生存タブ（active）の購読は引き継ぎで奪われない。
+    #[test]
+    fn test_rebind_does_not_steal_from_active_subscription() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-live", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+
+            let (subs, inbox) =
+                rebind_next_orphaned_group(&pool, "wt-subscriber", "new-a").await.unwrap();
+            assert_eq!((subs, inbox), (0, 0));
+            assert_eq!(list_subscriptions(&pool, "term-live", now).await.unwrap().len(), 1);
+        });
+    }
+
+    /// 引き継ぐものが無ければ (0,0)。冪等なので複数経路から同時に呼ばれても無害。
+    #[test]
+    fn test_rebind_returns_zero_when_nothing_orphaned() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            assert_eq!(
+                rebind_next_orphaned_group(&pool, "wt-subscriber", "new-a").await.unwrap(),
+                (0, 0)
+            );
+        });
+    }
+
+    /// 新タブが既に同じ対象を購読していた場合、UNIQUE(terminal_id, target) に負けた
+    /// 孤児側を捨て、生存側の設定を保つ。
+    #[test]
+    fn test_rebind_subscription_unique_conflict_keeps_live_row() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let old = sub("term-old", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &old).await.unwrap();
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+
+            // 新タブが同じ target を購読（delivery が違う）
+            let mut new = sub("term-new", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            new.id = "sub-new".to_string();
+            new.delivery = DELIVERY_INTERRUPT.to_string();
+            upsert_subscription(&pool, &new).await.unwrap();
+
+            rebind_next_orphaned_group(&pool, "wt-subscriber", "term-new").await.unwrap();
+            let rows = list_subscriptions(&pool, "term-new", now).await.unwrap();
+            assert_eq!(rows.len(), 1, "重複せず1行だけ残る");
+            assert_eq!(rows[0].delivery, DELIVERY_INTERRUPT, "生存側の設定が勝つ");
+            assert!(list_subscriptions(&pool, "term-old", now).await.unwrap().is_empty());
+        });
+    }
+
+    /// 新タブが既に同じイベントを持っていた場合、UNIQUE(terminal_id, event_id) に負けた
+    /// 孤児側を捨てる。生存側の delivered_at が保たれる。
+    #[test]
+    fn test_rebind_inbox_unique_conflict_drops_orphan() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let old = sub("term-old", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &old).await.unwrap();
+            let mut new = sub("term-new", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            new.id = "sub-new".to_string();
+            upsert_subscription(&pool, &new).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 2);
+
+            // term-new は既に本文を受け取っている
+            let new_ids: Vec<String> = list_inbox(&pool, "term-new", InboxFilter::All)
+                .await
+                .unwrap()
+                .iter()
+                .map(|i| i.id.clone())
+                .collect();
+            mark_delivered(&pool, &new_ids, now).await.unwrap();
+            // term-old だけ死亡
+            mark_orphaned_subscribers(&pool, &["term-new".to_string()], now).await.unwrap();
+
+            rebind_orphaned_group(&pool, "wt-subscriber", "term-old", "term-new").await.unwrap();
+            let rows = list_inbox(&pool, "term-new", InboxFilter::All).await.unwrap();
+            assert_eq!(rows.len(), 1, "同じイベントが二重にならない");
+            assert_eq!(rows[0].delivered_at, Some(now), "生存側の打刻が保たれる");
+            assert!(list_inbox(&pool, "term-old", InboxFilter::All).await.unwrap().is_empty());
+        });
+    }
+
+    /// ack 済みの inbox は監査証跡なので引き継ぎでも動かさない / 消さない。
+    #[test]
+    fn test_rebind_ignores_acked_rows() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-old", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+            let ids: Vec<String> = list_inbox(&pool, "term-old", InboxFilter::All)
+                .await
+                .unwrap()
+                .iter()
+                .map(|i| i.id.clone())
+                .collect();
+            ack(&pool, &ids, "term-old", now).await.unwrap();
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+
+            let (_, inbox) =
+                rebind_next_orphaned_group(&pool, "wt-subscriber", "term-new").await.unwrap();
+            assert_eq!(inbox, 0);
+            assert_eq!(list_inbox(&pool, "term-old", InboxFilter::All).await.unwrap().len(), 1);
+        });
+    }
+
+    /// orphaned な購読にも配送は続ける（タブが死んでいた間のイベントを失わない）。
+    #[test]
+    fn test_fanout_delivers_to_orphaned_subscription() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+            // 積まれた行も引き継ぎ待ちの印が付いている（＝押し込みはされない）
+            let items = list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap();
+            assert_eq!(items[0].orphaned_at, Some(now));
+            assert!(list_pushable(&pool, now, PUSH_TTL_MS).await.unwrap().is_empty());
+
+            // 引き継げば押し込み対象になる
+            rebind_next_orphaned_group(&pool, "wt-subscriber", "term-new").await.unwrap();
+            assert_eq!(list_pushable(&pool, now, PUSH_TTL_MS).await.unwrap().len(), 1);
+        });
+    }
+
+    /// 古いイベントは押し込まない（再起動直後の一斉割り込みを防ぐ）。inbox には残る。
+    #[test]
+    fn test_list_pushable_excludes_stale_events() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+
+            assert_eq!(list_pushable(&pool, now, PUSH_TTL_MS).await.unwrap().len(), 1);
+            let later = now + PUSH_TTL_MS + 1;
+            assert!(list_pushable(&pool, later, PUSH_TTL_MS).await.unwrap().is_empty());
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap().len(), 1);
+        });
+    }
+
+    /// 連鎖が深すぎるイベントは配送しない（#120 §5.4）。
+    #[test]
+    fn test_fanout_drops_over_max_depth() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let mut e = event("wt-target", None);
+            e.depth = MAX_EVENT_DEPTH + 1;
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 0);
+        });
+    }
+
+    /// `spawn_if_closed` と `delivery` は積んだ時点の値が inbox に焼き付く
+    /// （購読行は fanout 直後に消えるので、後から参照できない）。
+    #[test]
+    fn test_spawn_candidates_use_inbox_snapshot() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let mut s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            s.spawn_if_closed = 1;
+            s.delivery = DELIVERY_INTERRUPT.to_string();
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+            delete_subscriptions_for_target(&pool, "wt-target").await.unwrap();
+
+            let items = list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap();
+            assert_eq!(items[0].spawn_if_closed, 1);
+            assert_eq!(items[0].delivery, DELIVERY_INTERRUPT);
+
+            // タブが死ねば spawn 候補になる
+            assert!(list_spawn_candidates(&pool, now, PUSH_TTL_MS).await.unwrap().is_empty());
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+            let candidates = list_spawn_candidates(&pool, now, PUSH_TTL_MS).await.unwrap();
+            assert_eq!(candidates, vec![("wt-subscriber".to_string(), 1)]);
+        });
+    }
+
+    /// ブランチ名にペースト終端シーケンスを埋め込んでも脱出できない。
+    #[test]
+    fn test_sanitize_for_pty_strips_escape_sequences() {
+        let evil = "feature/x\x1b[201~\rrm -rf /\r";
+        let cleaned = sanitize_for_pty(evil);
+        assert!(!cleaned.contains('\x1b'));
+        assert!(!cleaned.contains('\r'));
+        assert!(!cleaned.contains('\n'));
+        assert!(cleaned.contains("feature/x"));
+    }
+
+    #[test]
+    fn test_sanitize_for_pty_caps_length() {
+        let long = "あ".repeat(5000);
+        let cleaned = sanitize_for_pty(&long);
+        assert!(cleaned.chars().count() <= PTY_TEXT_MAX_CHARS + 1);
+    }
+
+    /// 押し込み用テキストは1行（改行が混ざるとその場でターン送信になる）。
+    #[test]
+    fn test_format_inbox_push_text_is_single_line() {
+        let items = vec![inbox_item(
+            KIND_WORKTREE_CLOSED,
+            r#"{"worktreeId":"a","worktreeName":"wt-a","branchName":"feature/x"}"#,
+        )];
+        let text = format_inbox_push_text(&items).unwrap();
+        assert!(!text.contains('\n') && !text.contains('\r'));
+        assert!(text.contains("wt-a"));
+        assert_eq!(format_inbox_push_text(&[]), None);
     }
 
     /// クローズされた target を指す購読は配送後に削除される。

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -1236,7 +1236,12 @@ pub fn format_inbox_push_text(items: &[InboxItem]) -> Option<(String, usize)> {
     let tail = " 購読していた作業が完了したということなので、必要な動作確認や後続作業を進めてください。\
                 確認したら oretachi_ack_message に [] 内の ID を渡して ack してください。";
     // 固定文言のぶんを引いた残りに、入る行だけを詰める（最低1件は必ず載せる）。
-    let budget = PTY_TEXT_MAX_CHARS.saturating_sub(head.chars().count() + tail.chars().count());
+    // 残件の告知（`more`）も後ろに付くので、そのぶんの余白も先に引いておく。引かないと
+    // 全体が上限を超え、`sanitize_for_pty` が**末尾から**切るせいで
+    // 「oretachi_ack_message で ack してください」という一番効かせたい指示が欠ける。
+    const MORE_ALLOWANCE: usize = 48;
+    let budget = PTY_TEXT_MAX_CHARS
+        .saturating_sub(head.chars().count() + tail.chars().count() + MORE_ALLOWANCE);
     let mut body = String::new();
     let mut used = 0usize;
     for item in items {
@@ -2128,6 +2133,8 @@ mod tests {
         let (text, used) = format_inbox_push_text(&items).unwrap();
         assert!(used > 0 && used < items.len(), "一部だけ載る想定 (used={})", used);
         assert!(text.chars().count() <= PTY_TEXT_MAX_CHARS + 1);
+        // 残件告知を足しても上限を超えず、末尾の ack 指示が切られていないこと
+        assert!(text.ends_with("ack してください。"), "末尾が切れている: {}", text);
         // 載った分だけが本文にあり、載らなかった分は残件として告知される
         assert!(text.contains(&format!("inbox-{:02}", used - 1)));
         assert!(!text.contains(&format!("inbox-{:02}", used)));

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -510,8 +510,13 @@ pub async fn fanout(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usi
         }
         // orphaned な購読へ積む行は最初から orphaned として印を付ける。そうしないと
         // 「タブが死んでいる間に届いた分」が再バインドの対象から漏れる。
+        //
+        // **時刻は購読の `orphaned_at` ではなく `now`。** 購読側の時刻を継承すると、
+        // 6日前に orphaned になった購読へ今届いたメッセージが「6日前から待っている」扱いに
+        // なり、保持期限（7日）まで数時間しか残らないまま消える。引き継ぎ順序
+        // （`orphaned_at DESC`）でも最後尾に回り、本命のメッセージほど後回しになる。
         let orphaned_at = if sub.state == STATE_ORPHANED {
-            Some(sub.orphaned_at.unwrap_or(now))
+            Some(now)
         } else {
             None
         };
@@ -714,6 +719,46 @@ pub async fn mark_orphaned_subscribers(
         q = q.bind(id);
     }
     let inbox = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+    // 逆遷移: 生存しているタブの行が orphaned のまま残っていたら active に戻す。
+    //
+    // ポーリングは生存タブ一覧をスナップショットしてから非同期に投げるため、その隙に
+    // spawn されたタブが subscribe すると**古い一覧**で orphaned に落とされうる。戻す道が
+    // 無いと、そのタブは生存しているのに `rebind_next_orphaned_group` が自分自身のグループを
+    // 除外する（`terminal_id != new_terminal_id`）ので永久に引き継げず、押し込みも
+    // `list_pushable` の `orphaned_at IS NULL` から外れて一切来なくなる。
+    if !live_terminal_ids.is_empty() {
+        let in_live = format!(
+            " AND subscriber_terminal_id IN ({})",
+            placeholders(live_terminal_ids.len())
+        );
+        let sql = format!(
+            "UPDATE subscriptions SET state = ?, orphaned_at = NULL WHERE state = ?{}",
+            in_live
+        );
+        let mut q = sqlx::query(&sql).bind(STATE_ACTIVE).bind(STATE_ORPHANED);
+        for id in live_terminal_ids {
+            q = q.bind(id);
+        }
+        let restored = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+
+        let sql = format!(
+            "UPDATE inbox SET orphaned_at = NULL WHERE orphaned_at IS NOT NULL AND acked_at IS NULL{}",
+            in_live
+        );
+        let mut q = sqlx::query(&sql);
+        for id in live_terminal_ids {
+            q = q.bind(id);
+        }
+        let restored_inbox = q.execute(pool).await.map_err(|e| e.to_string())?.rows_affected();
+        if restored > 0 || restored_inbox > 0 {
+            log::info!(
+                "[event-db] 生存タブの引き継ぎ待ちを解除: 購読 {} 件 / 未読 {} 件",
+                restored,
+                restored_inbox
+            );
+        }
+    }
 
     Ok((subs, inbox, deleted))
 }
@@ -1178,22 +1223,41 @@ pub fn sanitize_for_pty(s: &str) -> String {
 ///
 /// SessionStart 用の `format_inbox_digest` と分けているのは、押し込みは**1行**でなければ
 /// ならないため（改行はそのままターン送信になる）。本文は `sanitize_for_pty` を通す。
-pub fn format_inbox_push_text(items: &[InboxItem]) -> Option<String> {
+///
+/// 戻り値は `(本文, 本文に載せた件数)`。**載らなかった分は呼び出し元が打刻してはいけない。**
+/// 全件の ID を `mark_delivered` に渡すと、長さ上限で切り落とされた分が「配送済みだが
+/// 本文は誰も見ていない」状態になり、再送しない方針（#120 §5.2）のせいで二度と出てこない。
+/// 載らなかった分は未配送のまま残り、次の押し込み / SessionStart 回収で拾われる。
+pub fn format_inbox_push_text(items: &[InboxItem]) -> Option<(String, usize)> {
     if items.is_empty() {
         return None;
     }
-    let body = items
-        .iter()
-        .map(format_inbox_line)
-        .collect::<Vec<_>>()
-        .join(" / ");
-    Some(sanitize_for_pty(&format!(
-        "[oretachi] 購読していたワークツリーイベントが {} 件届きました。{} \
-         購読していた作業が完了したということなので、必要な動作確認や後続作業を進めてください。\
-         確認したら oretachi_ack_message に [] 内の ID を渡して ack してください。",
-        items.len(),
-        body
-    )))
+    let head = "[oretachi] 購読していたワークツリーイベントが届きました。";
+    let tail = " 購読していた作業が完了したということなので、必要な動作確認や後続作業を進めてください。\
+                確認したら oretachi_ack_message に [] 内の ID を渡して ack してください。";
+    // 固定文言のぶんを引いた残りに、入る行だけを詰める（最低1件は必ず載せる）。
+    let budget = PTY_TEXT_MAX_CHARS.saturating_sub(head.chars().count() + tail.chars().count());
+    let mut body = String::new();
+    let mut used = 0usize;
+    for item in items {
+        let line = sanitize_for_pty(&format_inbox_line(item));
+        let sep = if used == 0 { "" } else { " / " };
+        if used > 0 && body.chars().count() + sep.len() + line.chars().count() > budget {
+            break;
+        }
+        body.push_str(sep);
+        body.push_str(&line);
+        used += 1;
+    }
+    let more = if used < items.len() {
+        format!("（ほかに {} 件あります。oretachi_poll_inbox で取得できます）", items.len() - used)
+    } else {
+        String::new()
+    };
+    Some((
+        sanitize_for_pty(&format!("{}{}{}{}", head, body, more, tail)),
+        used,
+    ))
 }
 
 /// SessionStart 注入用のテキストを組み立てる。
@@ -2040,10 +2104,87 @@ mod tests {
             KIND_WORKTREE_CLOSED,
             r#"{"worktreeId":"a","worktreeName":"wt-a","branchName":"feature/x"}"#,
         )];
-        let text = format_inbox_push_text(&items).unwrap();
+        let (text, used) = format_inbox_push_text(&items).unwrap();
         assert!(!text.contains('\n') && !text.contains('\r'));
         assert!(text.contains("wt-a"));
-        assert_eq!(format_inbox_push_text(&[]), None);
+        assert_eq!(used, 1);
+        assert!(format_inbox_push_text(&[]).is_none());
+    }
+
+    /// 長さ上限で本文に載らなかった分の件数は返さない。
+    /// 全件を配送済みにすると、切り落とされた分は「再送しない」方針のせいで二度と出ない。
+    #[test]
+    fn test_format_inbox_push_text_reports_only_what_fits() {
+        let items: Vec<InboxItem> = (0..40)
+            .map(|i| {
+                let mut item = inbox_item(
+                    KIND_WORKTREE_CLOSED,
+                    r#"{"worktreeId":"a","worktreeName":"very-long-worktree-name-for-truncation","branchName":"feature/quite-long-branch-name"}"#,
+                );
+                item.id = format!("inbox-{:02}", i);
+                item
+            })
+            .collect();
+        let (text, used) = format_inbox_push_text(&items).unwrap();
+        assert!(used > 0 && used < items.len(), "一部だけ載る想定 (used={})", used);
+        assert!(text.chars().count() <= PTY_TEXT_MAX_CHARS + 1);
+        // 載った分だけが本文にあり、載らなかった分は残件として告知される
+        assert!(text.contains(&format!("inbox-{:02}", used - 1)));
+        assert!(!text.contains(&format!("inbox-{:02}", used)));
+        assert!(text.contains(&format!("ほかに {} 件", items.len() - used)));
+    }
+
+    /// 引き継ぎ待ちの購読へ後から届いたメッセージは、購読が orphaned になった時刻ではなく
+    /// **届いた時刻**で保持期限を数える（数時間で消えないように）。
+    #[test]
+    fn test_fanout_stamps_inbox_with_arrival_time_not_subscription_time() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let long_ago = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            mark_orphaned_subscribers(&pool, &[], long_ago).await.unwrap();
+
+            // 6日後にイベントが届く
+            let arrival = long_ago + 6 * 24 * 60 * 60 * 1000;
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, arrival).await.unwrap();
+
+            let items = list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap();
+            assert_eq!(items[0].orphaned_at, Some(arrival));
+            // 到着から7日以内なので保持期限では消えない
+            let (_, purged) =
+                purge_orphaned_expired(&pool, arrival + 1000, ORPHANED_RETENTION_MS).await.unwrap();
+            assert_eq!(purged, 0);
+        });
+    }
+
+    /// 生存しているタブが（古い生存一覧のせいで）orphaned に落ちたら active へ戻す。
+    /// 戻す道が無いと、そのタブは生存しているのに引き継ぎ対象からも押し込み対象からも外れる。
+    #[test]
+    fn test_mark_orphaned_restores_live_terminals() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+            let s = sub("term-a", Some("wt-subscriber"), r#"["worktree.closed"]"#);
+            upsert_subscription(&pool, &s).await.unwrap();
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            fanout(&pool, &e, now).await.unwrap();
+
+            // 古い生存一覧で誤って orphaned に落ちる
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+            assert_eq!(list_subscriptions(&pool, "term-a", now).await.unwrap()[0].state, STATE_ORPHANED);
+            assert!(list_pushable(&pool, now, PUSH_TTL_MS).await.unwrap().is_empty());
+
+            // 次の tick で生存が確認されれば戻る
+            mark_orphaned_subscribers(&pool, &["term-a".to_string()], now).await.unwrap();
+            let rows = list_subscriptions(&pool, "term-a", now).await.unwrap();
+            assert_eq!(rows[0].state, STATE_ACTIVE);
+            assert_eq!(rows[0].orphaned_at, None);
+            assert_eq!(list_pushable(&pool, now, PUSH_TTL_MS).await.unwrap().len(), 1);
+        });
     }
 
     /// クローズされた target を指す購読は配送後に削除される。

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -976,6 +976,24 @@ pub async fn list_all_orphaned_groups(pool: &SqlitePool) -> Result<Vec<OrphanedG
     .map_err(|e| e.to_string())
 }
 
+/// 指定タブの未 ack を全件 ack する。UI の「既読にする」用。
+///
+/// エージェントが ack しないまま忘れた分を人間が畳めるようにする。MCP 側の `ack` が
+/// ID 指定なのは「読んだものだけ確認済みにする」ためだが、人間は一覧で件数を見ているので
+/// ID を持っていない。
+pub async fn ack_all(pool: &SqlitePool, terminal_id: &str, now: i64) -> Result<u64, String> {
+    Ok(sqlx::query(
+        "UPDATE inbox SET acked_at = ?, state = ? WHERE subscriber_terminal_id = ? AND acked_at IS NULL",
+    )
+    .bind(now)
+    .bind(STATE_ACKED)
+    .bind(terminal_id)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?
+    .rows_affected())
+}
+
 /// UI からの購読解除。MCP 経由（`delete_subscription`）と違い呼び出し元タブに
 /// 縛られない —— 人間は引き継ぎ待ちの（＝どのタブからも触れない）購読も消せる必要がある。
 pub async fn delete_subscription_by_id(pool: &SqlitePool, id: &str) -> Result<u64, String> {

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -366,6 +366,12 @@ fn decide_push(
     if delivery == event_db::DELIVERY_PASSIVE {
         return PushDecision::Skip("delivery=passive（エージェントが自分で取りに来る）");
     }
+    // 出力が動いている間は誰にも押し込まない。人間が入力中の行にブラケットペーストを
+    // 重ねるとその行を壊すため、エージェント種別や `interrupt` 指定より優先する
+    // （`idle` の判定は最大10秒古いので、これが最後の砦になる）。
+    if !session.output_quiescent {
+        return PushDecision::Skip("出力が動いている（入力中の可能性）");
+    }
     // `interrupt` は「走行中でも割り込んでよい」という購読側の明示的なオプトイン。
     if delivery == event_db::DELIVERY_INTERRUPT {
         return PushDecision::Push;
@@ -391,11 +397,6 @@ fn decide_push(
     match session.agent_status_sampled_at {
         Some(at) if now - at <= STATUS_MAX_AGE_MS => {}
         _ => return PushDecision::Skip("状態のサンプルが古い"),
-    }
-    if !session.output_quiescent {
-        // idle でも最大10秒古い。人間が入力中の行にブラケットペーストを重ねると
-        // その行を壊すので、直前 tick から出力が動いていないことも要求する。
-        return PushDecision::Skip("出力が動いている（入力中の可能性）");
     }
     PushDecision::Push
 }
@@ -486,7 +487,16 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
                 continue;
             }
         }
-        // 同じタブに複数戦略が混ざったら最も強いもの（interrupt > turn_end > passive）に従う。
+        // `passive` は「押し込まないでほしい」という購読側の明示指定なので、同じタブに
+        // 他の戦略が混ざっていても巻き込んで押し込んではいけない。先に除外する。
+        let items: Vec<_> = items
+            .into_iter()
+            .filter(|i| i.delivery != event_db::DELIVERY_PASSIVE)
+            .collect();
+        if items.is_empty() {
+            continue;
+        }
+        // 残りに interrupt が混ざっていれば走行中でも割り込む。
         let delivery = strongest_delivery(&items);
         let decision = decide_push(session, &delivery, now);
         if let PushDecision::Skip(reason) = decision {
@@ -542,6 +552,9 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
             );
             continue;
         }
+        // ペーストが通った時点でレート制限を進める。この後の Enter が失敗しても本文は
+        // 既に入力欄にあるので、次の tick で同じ本文を重ねて貼らないようにする。
+        state.last_push.insert(terminal_id.clone(), Instant::now());
         tokio::time::sleep(SUBMIT_DELAY).await;
         if let Err(e) = app
             .state::<crate::pty_manager::PtyManager>()
@@ -557,7 +570,6 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
             );
             continue;
         }
-        state.last_push.insert(terminal_id.clone(), Instant::now());
         let ids: Vec<String> = allowed.iter().map(|i| i.id.clone()).collect();
         if let Err(e) = event_db::mark_delivered(pool, &ids, now).await {
             log::warn!("[delivery] mark_delivered failed: {}", e);
@@ -622,7 +634,11 @@ async fn spawn_for_closed_tabs(
         return;
     }
     let sessions = app.state::<crate::pty_manager::PtyManager>().list_sessions();
-    let live = sessions.iter().filter(|s| s.exit_code.is_none()).count();
+    // 同じ tick で複数ワークツリーが spawn 候補になったときに上限を素通りしないよう、
+    // 発行した要求ぶんを足し込みながら判定する（`live` を1回だけ数えて全件に使うと、
+    // 候補が5件あれば一気に5タブ増えて webview ハングの領域に入る）。
+    let mut projected_live = sessions.iter().filter(|s| s.exit_code.is_none()).count()
+        + state.inflight_spawn.len();
     let settings = app.state::<SettingsManager>().get();
 
     for (worktree_id, pending) in candidates {
@@ -653,10 +669,10 @@ async fn spawn_for_closed_tabs(
             );
             continue;
         }
-        if live >= SPAWN_MAX_LIVE_SESSIONS {
+        if projected_live >= SPAWN_MAX_LIVE_SESSIONS {
             log::warn!(
                 "[delivery] ターミナルが {} 個あるため自動 spawn を拒否した（上限 {}）worktree={} 未読={}",
-                live,
+                projected_live,
                 SPAWN_MAX_LIVE_SESSIONS,
                 worktree.name,
                 pending
@@ -666,7 +682,7 @@ async fn spawn_for_closed_tabs(
                 serde_json::json!({
                     "worktreeId": worktree_id,
                     "worktreeName": worktree.name,
-                    "liveSessions": live,
+                    "liveSessions": projected_live,
                     "limit": SPAWN_MAX_LIVE_SESSIONS,
                     "pending": pending,
                 }),
@@ -697,6 +713,7 @@ async fn spawn_for_closed_tabs(
             worktree.name,
             request_id
         );
+        projected_live += 1;
         state
             .inflight_spawn
             .insert(worktree_id, (request_id, Instant::now()));
@@ -873,14 +890,11 @@ pub async fn event_unsubscribe(app_handle: AppHandle, subscription_id: String) -
 }
 
 /// UI からの既読化。エージェントが ack しないまま放置した分を人間が畳めるようにする。
+/// 対象は指定タブの未 ack 全件（人間は一覧で件数しか見ていないので ID を持っていない）。
 #[tauri::command]
-pub async fn event_ack(
-    app_handle: AppHandle,
-    terminal_id: String,
-    ids: Vec<String>,
-) -> Result<u64, String> {
+pub async fn event_ack_all(app_handle: AppHandle, terminal_id: String) -> Result<u64, String> {
     let pool = pool_of(&app_handle)?;
-    let acked = event_db::ack(&pool, &ids, &terminal_id, event_db::now_ms()).await?;
+    let acked = event_db::ack_all(&pool, &terminal_id, event_db::now_ms()).await?;
     let _ = app_handle.emit("event-inbox-changed", ());
     Ok(acked)
 }
@@ -974,8 +988,27 @@ mod tests {
     /// `interrupt` は「走行中でも割り込む」という購読側の明示オプトイン。
     #[test]
     fn test_interrupt_pushes_even_when_busy() {
-        let s = session(Some("claude"), Some("busy"), false);
+        let s = session(Some("claude"), Some("busy"), true);
         assert!(is_push(decide_push(&s, event_db::DELIVERY_INTERRUPT, 1_000_000)));
+    }
+
+    /// 出力が動いている間は誰にも押し込まない。人間が入力中の行を壊さないための最後の砦で、
+    /// エージェント種別や `interrupt` 指定より優先する。
+    #[test]
+    fn test_output_quiescence_overrides_everything() {
+        for (agent, status, delivery) in [
+            (Some("claude"), Some("idle"), event_db::DELIVERY_TURN_END),
+            (Some("claude"), Some("busy"), event_db::DELIVERY_INTERRUPT),
+            (Some("codex"), None, event_db::DELIVERY_TURN_END),
+        ] {
+            let s = session(agent, status, false);
+            assert!(
+                !is_push(decide_push(&s, delivery, 1_000_000)),
+                "agent={:?} delivery={} は出力継続中なら押し込まない",
+                agent,
+                delivery
+            );
+        }
     }
 
     #[test]
@@ -995,7 +1028,7 @@ mod tests {
     #[test]
     fn test_push_for_non_claude_agent_without_status() {
         for name in ["gemini", "codex", "cline"] {
-            let s = session(Some(name), None, false);
+            let s = session(Some(name), None, true);
             assert!(
                 is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000)),
                 "{} は押し込み対象",

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -52,6 +52,11 @@ const SUBMIT_DELAY: std::time::Duration = std::time::Duration::from_millis(150);
 /// spawn 要求を出してからフロントの応答を待つ上限。過ぎたら単一フライトを解放する。
 const SPAWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// 同じワークツリーへ続けて自動 spawn するまでの最小間隔。
+/// spawn したタブでエージェントが起動しない（`claude` が PATH に無い等）と検出フラグが
+/// 立たないため、これが無いと tick ごとに壊れたタブを上限まで積み増す。
+const SPAWN_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(600);
+
 /// これ以上ターミナルがあるときは自動 spawn しない。
 /// 端末数 15+ で webview ハングと強い相関があるため、自動増殖には手前で天井を設ける。
 const SPAWN_MAX_LIVE_SESSIONS: usize = 12;
@@ -161,6 +166,15 @@ struct WorkerState {
     last_push: HashMap<String, Instant>,
     /// spawn 要求中のワークツリー（単一フライト）。request_id と発行時刻
     inflight_spawn: HashMap<String, (String, Instant)>,
+    /// ワークツリーごとの最終 spawn 時刻。単一フライトは応答で即解除されるので、
+    /// 「spawn したがエージェントが検出されない」（`claude` が PATH に無い等）ときに
+    /// tick ごとに新しいタブを積み増すのを止めるためのクールダウン。
+    last_spawn: HashMap<String, Instant>,
+    /// 自動引き継ぎを済ませたタブ。`resolve_subscriber` は購読系ツールの呼び出しごとに
+    /// 引き継ぎを要求するため、抑止が無いと `oretachi_poll_inbox` を数回叩くだけで
+    /// 1タブが同じワークツリーの死亡タブ全グループを吸い上げ、「新しいタブ1つにつき
+    /// 1グループ」という設計不変条件が崩れる。タブが消えたら忘れる。
+    claimed: std::collections::HashSet<String>,
 }
 
 pub fn start(app: AppHandle, pool: SqlitePool) -> DeliveryHandle {
@@ -198,6 +212,9 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
     match msg {
         DeliveryMsg::Reconcile { live_terminal_ids } => {
             let now = event_db::now_ms();
+            // 消えたタブの「引き継ぎ済み」マークは忘れる（terminal_id は再利用されないので
+            // 放置しても誤動作はしないが、長時間稼働で単調増加する）。
+            state.claimed.retain(|t| live_terminal_ids.contains(t));
             match event_db::mark_orphaned_subscribers(pool, &live_terminal_ids, now).await {
                 Ok((subs, inbox, deleted)) if subs > 0 || inbox > 0 || deleted > 0 => {
                     log::info!(
@@ -222,7 +239,18 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
             }
         }
         DeliveryMsg::Rebind { terminal_id, reply } => {
-            let result = rebind_for_terminal(app, pool, &terminal_id).await;
+            // 自動引き継ぎは1タブにつき1グループまで。`resolve_subscriber` は購読系ツールの
+            // 呼び出しごとに要求してくるので、抑止しないと1タブが全グループを吸い上げる。
+            // 人間が明示的に選ぶ `RebindManual` はこの制限を受けない。
+            let result = if state.claimed.contains(&terminal_id) {
+                (0, 0)
+            } else {
+                let moved = rebind_for_terminal(app, pool, &terminal_id).await;
+                if moved != (0, 0) {
+                    state.claimed.insert(terminal_id.clone());
+                }
+                moved
+            };
             if let Some(reply) = reply {
                 let _ = reply.send(result);
             }
@@ -526,7 +554,8 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
                 terminal_id
             );
         }
-        let Some(text) = event_db::format_inbox_push_text(&allowed) else {
+        // 長さ上限で載らなかった分は打刻しない（未配送のまま次回に回す）。
+        let Some((text, used)) = event_db::format_inbox_push_text(&allowed) else {
             continue;
         };
 
@@ -570,7 +599,7 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
             );
             continue;
         }
-        let ids: Vec<String> = allowed.iter().map(|i| i.id.clone()).collect();
+        let ids: Vec<String> = allowed.iter().take(used).map(|i| i.id.clone()).collect();
         if let Err(e) = event_db::mark_delivered(pool, &ids, now).await {
             log::warn!("[delivery] mark_delivered failed: {}", e);
         }
@@ -645,6 +674,11 @@ async fn spawn_for_closed_tabs(
         if state.inflight_spawn.contains_key(&worktree_id) {
             continue;
         }
+        if let Some(prev) = state.last_spawn.get(&worktree_id) {
+            if prev.elapsed() < SPAWN_COOLDOWN {
+                continue;
+            }
+        }
         let Some(worktree) = find_worktree(&settings, &worktree_id) else {
             // 購読者ワークツリー自体が消えている。`purge_subscriber_worktree` の対象。
             continue;
@@ -714,6 +748,7 @@ async fn spawn_for_closed_tabs(
             request_id
         );
         projected_live += 1;
+        state.last_spawn.insert(worktree_id.clone(), Instant::now());
         state
             .inflight_spawn
             .insert(worktree_id, (request_id, Instant::now()));
@@ -860,13 +895,31 @@ pub async fn event_rebind_group(
     dead_terminal_id: String,
     session_id: u32,
 ) -> Result<(u64, u64), String> {
-    let terminal_id = app_handle
+    let session = app_handle
         .state::<crate::pty_manager::PtyManager>()
         .list_sessions()
         .into_iter()
         .find(|s| s.session_id == session_id && s.exit_code.is_none())
-        .map(|s| s.terminal_id)
         .ok_or_else(|| format!("session_id {} に対応する生存ターミナルがありません", session_id))?;
+    // 引き継ぎ先が本当にそのワークツリーのタブか、バックエンド側でも確かめる。
+    // `subscriber_worktree_id` は引き継ぎでも変わらないので、別ワークツリーのタブへ渡すと
+    // 以後その行の押し込みが**実際の宛先ではない**ワークツリーの autoApproval 設定で
+    // 判定されることになる（フロントの候補リストが古いだけで起きうる）。
+    {
+        let settings = app_handle.state::<SettingsManager>().get();
+        let actual = session
+            .cwd
+            .as_deref()
+            .and_then(|c| crate::mcp_server::resolve_worktree_by_cwd(&settings, c))
+            .map(|w| w.id.clone());
+        if actual.as_deref() != Some(worktree_id.as_str()) {
+            return Err(format!(
+                "session_id {} はワークツリー {} のターミナルではありません（実際: {:?}）",
+                session_id, worktree_id, actual
+            ));
+        }
+    }
+    let terminal_id = session.terminal_id;
     let (tx, rx) = oneshot::channel();
     {
         let h = handle(&app_handle).ok_or_else(|| "配送ワーカーが起動していません".to_string())?;

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -1,0 +1,1062 @@
+//! ワークツリー間イベントの**配送**（issue #120 §4 / #125）。
+//!
+//! `event_db` が「発行 → 照合 → 蓄積」までを持つのに対し、ここは「蓄積 → 実際に相手を
+//! 動かす」を担う。受信側の状態で手段が変わるのが本質的な難しさで、判断表は以下:
+//!
+//! | 受信側 | 判定元 | 動作 |
+//! |---|---|---|
+//! | 生存 Claude Code + `idle` + 静穏 | `~/.claude/sessions/<pid>.json` の `status` | PTY 押し込み |
+//! | 生存 Claude Code + `busy` / 不明 / 出力継続中 | 同上 | 押し込まない（`delivery=interrupt` の明示指定時のみ押し込む） |
+//! | 生存 非 CC エージェント | `agent_name` | PTY 押し込み。**`status` の取得元が存在せず busy/idle を判定できない**（#120 §5.7） |
+//! | 生存タブ・エージェント無し | `is_ai_agent` | 押し込まない（素のシェルに CR を撃たない）。`spawn_if_closed` なら spawn |
+//! | タブ不在（orphaned） | — | `spawn_if_closed` なら spawn、false なら保留（次に AI タブが立てば引き継がれる） |
+//!
+//! ## 直列化
+//!
+//! 全ての再バインドと押し込みは**単一のワーカータスク**が順に処理する。これが #125 §3 の
+//! 「宛先ごとの直列キュー」の実体で、宛先ごとより強い保証になる。ポーリングスレッド /
+//! `/session-context`（axum）/ MCP ツールハンドラが同時に再バインドを要求しても、キューを
+//! 通るので SELECT→UPDATE のインターリーブが構造的に起きない。
+//!
+//! ## DB 初期化失敗時
+//!
+//! `DeliveryHandle` は `EventPool` と同じく `init_event_db` が成功したときだけ `manage` される。
+//! 生産者は全て `try_state::<DeliveryHandle>()` を通すので、DB が無ければ静かに no-op になる。
+
+use crate::event_db;
+use crate::settings::{AppSettings, SettingsManager, WorktreeEntry};
+use sqlx::SqlitePool;
+use std::collections::HashMap;
+use std::time::Instant;
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::{mpsc, oneshot};
+
+/// 定期的な再評価の間隔。`busy` で見送った宛先や、spawn 待ちの解放をここで拾う。
+const TICK: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// キュー長。溢れたら捨てる（生産者はどれも待てない: `fire_worktree_closed` は
+/// fire-and-forget、`/session-context` はサイドカーの 2 秒デッドラインの内側）。
+const QUEUE_CAPACITY: usize = 64;
+
+/// 同じタブへ続けて押し込むまでの最小間隔（#125 §3 のレート制限）。
+const MIN_PUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// `agent_status` のサンプルをどれだけ新しければ信用するか。ポーリング周期 10 秒の 2 倍。
+/// 1 回取りこぼしても配送は止まらないが、ポーリングが死んでいれば押し込みも止まる。
+const STATUS_MAX_AGE_MS: i64 = 20_000;
+
+/// ブラケットペーストを流してから Enter を送るまでの猶予。
+/// Claude Code はペースト終端と同じ読み取りチャンクに来た CR を送信として扱わない。
+const SUBMIT_DELAY: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// spawn 要求を出してからフロントの応答を待つ上限。過ぎたら単一フライトを解放する。
+const SPAWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// これ以上ターミナルがあるときは自動 spawn しない。
+/// 端末数 15+ で webview ハングと強い相関があるため、自動増殖には手前で天井を設ける。
+const SPAWN_MAX_LIVE_SESSIONS: usize = 12;
+
+/// 自動承認が有効なワークツリーへ押し込み / spawn してよいイベント種別（#120 §5.5）。
+///
+/// 自動承認が有効な宛先へは、別のワークツリーから注入された内容が**人間の確認なしに
+/// 実行される**。oretachi が定型文で組み立てるイベント（`worktree.closed`）だけを許可し、
+/// 自由文（`worktree.message`, #126）は押し込まず inbox に残して人間の確認を要求する。
+/// 現時点では対応種別が `worktree.closed` のみなので挙動は変わらないが、自由文が入った
+/// 瞬間に default-deny になるのが目的。
+const AUTO_APPROVAL_PUSHABLE_KINDS: &[&str] = &[event_db::KIND_WORKTREE_CLOSED];
+
+// ─── ハンドル ─────────────────────────────────────────────────────────────────
+
+pub enum DeliveryMsg {
+    /// 生存タブの一覧。ここに無い terminal_id の購読 / inbox は orphaned にする
+    Reconcile { live_terminal_ids: Vec<String> },
+    /// このタブへ、同じワークツリーの引き継ぎ待ちグループを1つ引き継ぐ
+    Rebind {
+        terminal_id: String,
+        reply: Option<oneshot::Sender<(u64, u64)>>,
+    },
+    /// UI からの手動引き継ぎ（引き継ぎ先グループを人間が選ぶ）
+    RebindManual {
+        worktree_id: String,
+        dead_terminal_id: String,
+        terminal_id: String,
+        reply: Option<oneshot::Sender<(u64, u64)>>,
+    },
+    /// 新しいイベントが inbox に積まれた
+    EventQueued,
+    /// フロントからの spawn 完了応答（失敗時は `session_id: None`）
+    SpawnResult {
+        request_id: String,
+        session_id: Option<u32>,
+    },
+}
+
+pub struct DeliveryHandle {
+    tx: mpsc::Sender<DeliveryMsg>,
+}
+
+impl DeliveryHandle {
+    /// 非ブロッキング送信。キューが詰まっていたら捨てる（次の tick で再評価される）。
+    pub fn try_send(&self, msg: DeliveryMsg) {
+        if self.tx.try_send(msg).is_err() {
+            log::debug!("[delivery] キューが満杯のため要求を捨てた（次の tick で再評価する）");
+        }
+    }
+}
+
+fn handle(app: &AppHandle) -> Option<tauri::State<'_, DeliveryHandle>> {
+    app.try_state::<DeliveryHandle>()
+}
+
+/// ポーリングスレッドから毎 tick 呼ぶ。死んだタブの購読を orphaned に落とす。
+pub fn reconcile_live_terminals(app: &AppHandle, live_terminal_ids: Vec<String>) {
+    if let Some(h) = handle(app) {
+        h.try_send(DeliveryMsg::Reconcile { live_terminal_ids });
+    }
+}
+
+/// AI エージェントが立ち上がったタブから引き継ぎを要求する（応答は待たない）。
+pub fn request_rebind(app: &AppHandle, terminal_id: String) {
+    if let Some(h) = handle(app) {
+        h.try_send(DeliveryMsg::Rebind {
+            terminal_id,
+            reply: None,
+        });
+    }
+}
+
+/// 新しいイベントが積まれたことを知らせる。
+pub fn notify_event_queued(app: &AppHandle) {
+    if let Some(h) = handle(app) {
+        h.try_send(DeliveryMsg::EventQueued);
+    }
+}
+
+/// 引き継ぎを要求し、完了まで待つ（`SessionStart` から使う）。
+///
+/// ワーカーが詰まっていたら `None` を返す。呼び出し元は上位のタイムアウトの内側で
+/// 使うので、「今回は引き継がない」に劣化するだけで済む。
+pub async fn rebind_and_wait(app: &AppHandle, terminal_id: &str) -> Option<(u64, u64)> {
+    let (tx, rx) = oneshot::channel();
+    {
+        let h = handle(app)?;
+        if h.tx
+            .try_send(DeliveryMsg::Rebind {
+                terminal_id: terminal_id.to_string(),
+                reply: Some(tx),
+            })
+            .is_err()
+        {
+            return None;
+        }
+    }
+    rx.await.ok()
+}
+
+// ─── ワーカー ─────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct WorkerState {
+    /// タブごとの最終押し込み時刻（レート制限）
+    last_push: HashMap<String, Instant>,
+    /// spawn 要求中のワークツリー（単一フライト）。request_id と発行時刻
+    inflight_spawn: HashMap<String, (String, Instant)>,
+}
+
+pub fn start(app: AppHandle, pool: SqlitePool) -> DeliveryHandle {
+    let (tx, mut rx) = mpsc::channel::<DeliveryMsg>(QUEUE_CAPACITY);
+    tauri::async_runtime::spawn(async move {
+        let mut state = WorkerState::default();
+        // 前回の定期再評価。**経過時間で判定する**のが要点: ポーリングスレッドが 10 秒ごとに
+        // `Reconcile` を送ってくるため、`timeout(TICK, recv())` の Err 分岐だけに頼ると
+        // タイムアウトが毎回リセットされて定期再評価が永久に走らない（実機で踏んだ）。
+        let mut last_drive = Instant::now();
+        loop {
+            // `tokio` の `macros` / `rt` feature に依存しないため `select!` は使わない。
+            match tokio::time::timeout(TICK, rx.recv()).await {
+                Ok(None) => break, // 送信側が全て drop = アプリ終了
+                Ok(Some(msg)) => {
+                    handle_msg(&app, &pool, &mut state, msg).await;
+                }
+                Err(_) => {}
+            }
+            if last_drive.elapsed() >= TICK {
+                last_drive = Instant::now();
+                // busy / 出力継続中で見送った宛先の再評価と、spawn 待ちの解放
+                state
+                    .inflight_spawn
+                    .retain(|_, (_, at)| at.elapsed() < SPAWN_TIMEOUT);
+                drive(&app, &pool, &mut state).await;
+            }
+        }
+        log::debug!("[delivery] worker stopped");
+    });
+    DeliveryHandle { tx }
+}
+
+async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState, msg: DeliveryMsg) {
+    match msg {
+        DeliveryMsg::Reconcile { live_terminal_ids } => {
+            let now = event_db::now_ms();
+            match event_db::mark_orphaned_subscribers(pool, &live_terminal_ids, now).await {
+                Ok((subs, inbox, deleted)) if subs > 0 || inbox > 0 || deleted > 0 => {
+                    log::info!(
+                        "[delivery] タブ死亡を検出: 購読 {} 件 / 未読 {} 件を引き継ぎ待ちにした（到達不能な {} 件は削除）",
+                        subs, inbox, deleted
+                    );
+                    let _ = app.emit("event-inbox-changed", ());
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!("[delivery] mark_orphaned_subscribers failed: {}", e),
+            }
+            match event_db::purge_orphaned_expired(pool, now, event_db::ORPHANED_RETENTION_MS).await
+            {
+                Ok((subs, inbox)) if subs > 0 || inbox > 0 => log::info!(
+                    "[delivery] 保持期限（{}日）を過ぎた引き継ぎ待ちを削除: 購読 {} 件 / 未読 {} 件",
+                    event_db::ORPHANED_RETENTION_DAYS,
+                    subs,
+                    inbox
+                ),
+                Ok(_) => {}
+                Err(e) => log::warn!("[delivery] purge_orphaned_expired failed: {}", e),
+            }
+        }
+        DeliveryMsg::Rebind { terminal_id, reply } => {
+            let result = rebind_for_terminal(app, pool, &terminal_id).await;
+            if let Some(reply) = reply {
+                let _ = reply.send(result);
+            }
+            if result != (0, 0) {
+                let _ = app.emit("event-inbox-changed", ());
+            }
+            drive(app, pool, state).await;
+        }
+        DeliveryMsg::RebindManual {
+            worktree_id,
+            dead_terminal_id,
+            terminal_id,
+            reply,
+        } => {
+            let result = event_db::rebind_orphaned_group(
+                pool,
+                &worktree_id,
+                &dead_terminal_id,
+                &terminal_id,
+            )
+            .await
+            .unwrap_or_else(|e| {
+                log::warn!("[delivery] 手動引き継ぎに失敗: {}", e);
+                (0, 0)
+            });
+            if let Some(reply) = reply {
+                let _ = reply.send(result);
+            }
+            let _ = app.emit("event-inbox-changed", ());
+            drive(app, pool, state).await;
+        }
+        DeliveryMsg::EventQueued => {
+            let _ = app.emit("event-inbox-changed", ());
+            drive(app, pool, state).await;
+        }
+        DeliveryMsg::SpawnResult {
+            request_id,
+            session_id,
+        } => {
+            let worktree_id = state
+                .inflight_spawn
+                .iter()
+                .find(|(_, (rid, _))| *rid == request_id)
+                .map(|(wt, _)| wt.clone());
+            if let Some(wt) = &worktree_id {
+                state.inflight_spawn.remove(wt);
+            }
+            let Some(session_id) = session_id else {
+                log::warn!(
+                    "[delivery] spawn に失敗した応答を受け取った request={} worktree={:?}",
+                    request_id,
+                    worktree_id
+                );
+                return;
+            };
+            // 新しいタブの terminal_id を解決して引き継ぐ。`claude` の起動は
+            // pendingCommand で流し込まれるだけなので、AI エージェント検出（10 秒周期）
+            // より先にここへ来る。押し込みは検出後の tick に回る。
+            let terminal_id = app
+                .state::<crate::pty_manager::PtyManager>()
+                .list_sessions()
+                .into_iter()
+                .find(|s| s.session_id == session_id)
+                .map(|s| s.terminal_id);
+            match terminal_id {
+                Some(tid) => {
+                    let moved = rebind_for_terminal(app, pool, &tid).await;
+                    log::info!(
+                        "[delivery] spawn したタブへ引き継いだ session_id={} 購読={} 未読={}",
+                        session_id,
+                        moved.0,
+                        moved.1
+                    );
+                    let _ = app.emit("event-inbox-changed", ());
+                }
+                None => log::warn!(
+                    "[delivery] spawn 応答の session_id={} に対応する PTY が見つからない",
+                    session_id
+                ),
+            }
+        }
+    }
+}
+
+/// タブの cwd からワークツリーを引いて、そのワークツリーの引き継ぎ待ちを1グループ引き継ぐ。
+async fn rebind_for_terminal(app: &AppHandle, pool: &SqlitePool, terminal_id: &str) -> (u64, u64) {
+    let Some(worktree_id) = worktree_of_terminal(app, terminal_id) else {
+        return (0, 0);
+    };
+    match event_db::rebind_next_orphaned_group(pool, &worktree_id, terminal_id).await {
+        Ok((subs, inbox)) => {
+            if subs > 0 || inbox > 0 {
+                log::info!(
+                    "[delivery] 引き継ぎ完了 worktree={} terminal={} 購読={} 未読={}",
+                    worktree_id,
+                    terminal_id,
+                    subs,
+                    inbox
+                );
+            }
+            (subs, inbox)
+        }
+        Err(e) => {
+            log::warn!("[delivery] rebind_next_orphaned_group failed: {}", e);
+            (0, 0)
+        }
+    }
+}
+
+/// terminal_id → ワークツリー ID。生存セッションの cwd から前方一致＋最長一致で引く。
+fn worktree_of_terminal(app: &AppHandle, terminal_id: &str) -> Option<String> {
+    let settings = app.state::<SettingsManager>().get();
+    let sessions = app.state::<crate::pty_manager::PtyManager>().list_sessions();
+    let session = sessions.iter().find(|s| s.terminal_id == terminal_id)?;
+    let cwd = session.cwd.as_deref()?;
+    crate::mcp_server::resolve_worktree_by_cwd(&settings, cwd).map(|w| w.id.clone())
+}
+
+// ─── 配送の駆動 ───────────────────────────────────────────────────────────────
+
+/// 押し込みを見送る理由（ログと将来の UI 表示用）。
+enum PushDecision {
+    Push,
+    Skip(&'static str),
+}
+
+/// 1タブへの押し込み可否を決める。判定材料は `SessionInfo` に載っている値だけで、
+/// ここでは I/O をしない（テストしやすさのためにも純粋に近い形に保つ）。
+fn decide_push(
+    session: &crate::pty_manager::SessionInfo,
+    delivery: &str,
+    now: i64,
+) -> PushDecision {
+    if session.exit_code.is_some() {
+        return PushDecision::Skip("タブが終了済み");
+    }
+    if !session.is_ai_agent {
+        // 素のシェルへ CR を撃つと任意のコマンドが走る。エージェントが居るときだけ押し込む。
+        return PushDecision::Skip("AI エージェントが走っていない");
+    }
+    if delivery == event_db::DELIVERY_PASSIVE {
+        return PushDecision::Skip("delivery=passive（エージェントが自分で取りに来る）");
+    }
+    // `interrupt` は「走行中でも割り込んでよい」という購読側の明示的なオプトイン。
+    if delivery == event_db::DELIVERY_INTERRUPT {
+        return PushDecision::Push;
+    }
+    // 非 Claude Code エージェント（gemini / codex / cline）は `~/.claude/sessions/<pid>.json`
+    // に相当するものが無く busy / idle を判定できない。Stop フック経路も存在しないので、
+    // 押し込まないと永久に届かない。仕様として押し込む（#120 §5.7）。
+    if session.agent_name.as_deref() != Some("claude") {
+        return PushDecision::Push;
+    }
+    match session.agent_status.as_deref() {
+        Some("idle") => {}
+        Some(other) => {
+            // busy はターン境界配送（#124 の Stop フック）の担当。次の tick で再評価する。
+            let _ = other;
+            return PushDecision::Skip("エージェントが走行中");
+        }
+        None => return PushDecision::Skip("エージェントの状態が不明"),
+    }
+    // 鮮度はファイル側の statusUpdatedAt ではなく**こちらがサンプルした時刻**で見る。
+    // 長いターンは正当に古い busy を残すので、ファイル側の古さを「不明」と解釈すると
+    // 押してはいけない場面で押すことになる。
+    match session.agent_status_sampled_at {
+        Some(at) if now - at <= STATUS_MAX_AGE_MS => {}
+        _ => return PushDecision::Skip("状態のサンプルが古い"),
+    }
+    if !session.output_quiescent {
+        // idle でも最大10秒古い。人間が入力中の行にブラケットペーストを重ねると
+        // その行を壊すので、直前 tick から出力が動いていないことも要求する。
+        return PushDecision::Skip("出力が動いている（入力中の可能性）");
+    }
+    PushDecision::Push
+}
+
+/// 自動承認が有効な宛先へ押し込んでよい種別か（#120 §5.5）。
+fn auto_approval_allows(worktree: Option<&WorktreeEntry>, kind: &str) -> bool {
+    let auto = worktree.and_then(|w| w.auto_approval).unwrap_or(false);
+    if !auto {
+        return true;
+    }
+    AUTO_APPROVAL_PUSHABLE_KINDS.contains(&kind)
+}
+
+fn find_worktree<'a>(settings: &'a AppSettings, id: &str) -> Option<&'a WorktreeEntry> {
+    settings.worktrees.iter().find(|w| w.id == id)
+}
+
+/// 自動 spawn したタブで起動するエージェントコマンド。
+///
+/// 解決順はフロントの `useTaskExecution.ts` と同じ（ワークグループ → 全体設定 →
+/// `claudeCode`）。Claude Code の permission-mode も同じく既定は `plan` にする ——
+/// 別のワークツリーからの通知で立ち上がるタブなので、いきなり書き込みを許すのは危険。
+fn agent_command_for_worktree(settings: &AppSettings, worktree: &WorktreeEntry) -> String {
+    use crate::ai_provider::AiAgentKind;
+    let group = worktree
+        .workgroup_id
+        .as_deref()
+        .and_then(|gid| settings.workgroups.iter().find(|g| g.id == gid));
+    let kind = group
+        .and_then(|g| g.task_add_agent.clone())
+        .or_else(|| settings.ai_agent.as_ref().and_then(|a| a.task_add_agent.clone()))
+        .or_else(|| settings.ai_agent.as_ref().and_then(|a| a.approval_agent.clone()))
+        .unwrap_or(AiAgentKind::ClaudeCode);
+    match kind {
+        AiAgentKind::ClaudeCode => {
+            let mode = match group.and_then(|g| g.claude_code_mode.as_deref()) {
+                Some("manual") => "default",
+                Some("acceptEdit") => "acceptEdits",
+                Some("auto") => "auto",
+                _ => "plan",
+            };
+            format!("claude --permission-mode {}", mode)
+        }
+        AiAgentKind::GeminiCli => "gemini".to_string(),
+        AiAgentKind::CodexCli => "codex".to_string(),
+        AiAgentKind::ClineCli => "cline".to_string(),
+    }
+}
+
+async fn drive(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState) {
+    let now = event_db::now_ms();
+    push_pending(app, pool, state, now).await;
+    spawn_for_closed_tabs(app, pool, state, now).await;
+}
+
+/// 生存タブへの PTY 押し込み。
+async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState, now: i64) {
+    let items = match event_db::list_pushable(pool, now, event_db::PUSH_TTL_MS).await {
+        Ok(items) => items,
+        Err(e) => {
+            log::warn!("[delivery] list_pushable failed: {}", e);
+            return;
+        }
+    };
+    if items.is_empty() {
+        return;
+    }
+
+    // State を await 越しに持たないよう、必要な情報だけ先に取り出す。
+    let sessions = app.state::<crate::pty_manager::PtyManager>().list_sessions();
+    let settings = app.state::<SettingsManager>().get();
+
+    let mut by_terminal: HashMap<String, Vec<event_db::InboxItem>> = HashMap::new();
+    for item in items {
+        by_terminal
+            .entry(item.subscriber_terminal_id.clone())
+            .or_default()
+            .push(item);
+    }
+
+    for (terminal_id, items) in by_terminal {
+        let Some(session) = sessions.iter().find(|s| s.terminal_id == terminal_id) else {
+            // タブが消えている。次の Reconcile で orphaned に落ちる。
+            continue;
+        };
+        if let Some(prev) = state.last_push.get(&terminal_id) {
+            if prev.elapsed() < MIN_PUSH_INTERVAL {
+                continue;
+            }
+        }
+        // 同じタブに複数戦略が混ざったら最も強いもの（interrupt > turn_end > passive）に従う。
+        let delivery = strongest_delivery(&items);
+        let decision = decide_push(session, &delivery, now);
+        if let PushDecision::Skip(reason) = decision {
+            log::debug!(
+                "[delivery] 押し込みを見送る terminal={} 件数={} 理由={}",
+                terminal_id,
+                items.len(),
+                reason
+            );
+            continue;
+        }
+
+        // 自動承認が有効な宛先へは定型イベントしか押し込まない。
+        let worktree = items
+            .first()
+            .and_then(|i| i.subscriber_worktree_id.as_deref())
+            .and_then(|id| find_worktree(&settings, id));
+        let (allowed, blocked): (Vec<_>, Vec<_>) = items
+            .into_iter()
+            .partition(|i| auto_approval_allows(worktree, &i.kind));
+        if !blocked.is_empty() {
+            // 保留された分は未配送のまま残り、tick ごとに再評価される（＝毎回ここを通る）ので
+            // debug に留める。人間への提示は UI の未読表示が担う。
+            log::debug!(
+                "[delivery] 自動承認が有効な宛先のため {} 件の押し込みを保留した（人間の確認が必要）terminal={}",
+                blocked.len(),
+                terminal_id
+            );
+        }
+        let Some(text) = event_db::format_inbox_push_text(&allowed) else {
+            continue;
+        };
+
+        // ブラケットペーストで囲む。本文は `sanitize_for_pty` 済みなので終端シーケンスを
+        // 埋め込んでペーストを脱出することはできない。
+        //
+        // **ペーストと Enter は別の write に分ける。** `ESC[200~…ESC[201~\r` を1回で書くと
+        // Claude Code はペースト終端と同じ読み取りチャンクに来た CR をペーストの一部として
+        // 扱い、本文が入力欄に残ったままターンが始まらない（実機で確認）。CR を独立した
+        // write にし、間に猶予を入れると確実に送信される。
+        let paste = format!("\x1b[200~{}\x1b[201~", text);
+        // **write が成功してから打刻する**。キュー満杯などで捨てられた押し込みを
+        // 配送済みにすると、二度と本文が出ないまま失われる。
+        if let Err(e) = app
+            .state::<crate::pty_manager::PtyManager>()
+            .write(session.session_id, paste.into_bytes())
+        {
+            log::warn!(
+                "[delivery] PTY への押し込みに失敗 terminal={} session={}: {}",
+                terminal_id,
+                session.session_id,
+                e
+            );
+            continue;
+        }
+        tokio::time::sleep(SUBMIT_DELAY).await;
+        if let Err(e) = app
+            .state::<crate::pty_manager::PtyManager>()
+            .write(session.session_id, b"\r".to_vec())
+        {
+            // 本文は入力欄に残っているので人間が Enter を押せば送れる。打刻はしない
+            // （未配送のままにして次の tick / SessionStart 回収で拾えるようにする）。
+            log::warn!(
+                "[delivery] 押し込み後の Enter に失敗 terminal={} session={}: {}",
+                terminal_id,
+                session.session_id,
+                e
+            );
+            continue;
+        }
+        state.last_push.insert(terminal_id.clone(), Instant::now());
+        let ids: Vec<String> = allowed.iter().map(|i| i.id.clone()).collect();
+        if let Err(e) = event_db::mark_delivered(pool, &ids, now).await {
+            log::warn!("[delivery] mark_delivered failed: {}", e);
+        }
+        log::info!(
+            "[delivery] 待機中のエージェントへ {} 件を押し込んだ terminal={} session={} agent={:?} delivery={}",
+            ids.len(),
+            terminal_id,
+            session.session_id,
+            session.agent_name,
+            delivery
+        );
+        let _ = app.emit(
+            "event-delivered",
+            serde_json::json!({
+                "terminalId": terminal_id,
+                "sessionId": session.session_id,
+                "worktreeId": worktree.map(|w| w.id.clone()),
+                "worktreeName": worktree.map(|w| w.name.clone()),
+                "agentName": session.agent_name,
+                "count": ids.len(),
+                "text": text,
+                "method": "pty",
+            }),
+        );
+    }
+}
+
+fn strongest_delivery(items: &[event_db::InboxItem]) -> String {
+    if items.iter().any(|i| i.delivery == event_db::DELIVERY_INTERRUPT) {
+        return event_db::DELIVERY_INTERRUPT.to_string();
+    }
+    if items.iter().any(|i| i.delivery == event_db::DELIVERY_TURN_END) {
+        return event_db::DELIVERY_TURN_END.to_string();
+    }
+    event_db::DELIVERY_PASSIVE.to_string()
+}
+
+/// AI タブが居ないワークツリーへ、`spawn_if_closed` が立っていれば新しいタブを立てる。
+///
+/// spawn は**明示オプトインのみ**（#120 §5.4）。加えて:
+/// - ワークツリーごとの単一フライト（応答があるか 60 秒経つまで次を出さない）
+/// - 生存ターミナル数の上限（webview ハングの手前で止める）
+/// - 自動承認が有効な宛先へは定型イベントのみ
+///
+/// フロントは spawn の成否にかかわらず `event_spawn_result` を返す。返らない場合も
+/// 60 秒で単一フライトが解放されるだけで、tick ごとに撃ち続けることはない。
+async fn spawn_for_closed_tabs(
+    app: &AppHandle,
+    pool: &SqlitePool,
+    state: &mut WorkerState,
+    now: i64,
+) {
+    let candidates = match event_db::list_spawn_candidates(pool, now, event_db::PUSH_TTL_MS).await {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("[delivery] list_spawn_candidates failed: {}", e);
+            return;
+        }
+    };
+    if candidates.is_empty() {
+        return;
+    }
+    let sessions = app.state::<crate::pty_manager::PtyManager>().list_sessions();
+    let live = sessions.iter().filter(|s| s.exit_code.is_none()).count();
+    let settings = app.state::<SettingsManager>().get();
+
+    for (worktree_id, pending) in candidates {
+        if state.inflight_spawn.contains_key(&worktree_id) {
+            continue;
+        }
+        let Some(worktree) = find_worktree(&settings, &worktree_id) else {
+            // 購読者ワークツリー自体が消えている。`purge_subscriber_worktree` の対象。
+            continue;
+        };
+        // そのワークツリーに既に AI タブがあるなら spawn しない（引き継ぎで届く）。
+        let has_agent = sessions.iter().any(|s| {
+            s.exit_code.is_none()
+                && s.is_ai_agent
+                && s.cwd
+                    .as_deref()
+                    .and_then(|c| crate::mcp_server::resolve_worktree_by_cwd(&settings, c))
+                    .map(|w| w.id == worktree_id)
+                    .unwrap_or(false)
+        });
+        if has_agent {
+            continue;
+        }
+        if !auto_approval_allows(Some(worktree), event_db::KIND_WORKTREE_CLOSED) {
+            log::info!(
+                "[delivery] 自動承認が有効なため spawn を見送った worktree={}",
+                worktree.name
+            );
+            continue;
+        }
+        if live >= SPAWN_MAX_LIVE_SESSIONS {
+            log::warn!(
+                "[delivery] ターミナルが {} 個あるため自動 spawn を拒否した（上限 {}）worktree={} 未読={}",
+                live,
+                SPAWN_MAX_LIVE_SESSIONS,
+                worktree.name,
+                pending
+            );
+            let _ = app.emit(
+                "event-spawn-rejected",
+                serde_json::json!({
+                    "worktreeId": worktree_id,
+                    "worktreeName": worktree.name,
+                    "liveSessions": live,
+                    "limit": SPAWN_MAX_LIVE_SESSIONS,
+                    "pending": pending,
+                }),
+            );
+            continue;
+        }
+
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let command = agent_command_for_worktree(&settings, worktree);
+        if app
+            .emit(
+                "event-spawn-terminal",
+                serde_json::json!({
+                    "requestId": request_id,
+                    "worktreeId": worktree_id,
+                    "worktreeName": worktree.name,
+                    "command": command,
+                    "pending": pending,
+                }),
+            )
+            .is_err()
+        {
+            continue;
+        }
+        log::info!(
+            "[delivery] 未読 {} 件のため新しいタブを要求した worktree={} request={}",
+            pending,
+            worktree.name,
+            request_id
+        );
+        state
+            .inflight_spawn
+            .insert(worktree_id, (request_id, Instant::now()));
+    }
+}
+
+// ─── UI 向け Tauri コマンド（#120 §7） ────────────────────────────────────────
+
+/// 購読一覧の1行。DB の生の行に、人間が読むための解決済みの名前と生存状況を足したもの。
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionView {
+    pub id: String,
+    pub subscriber_terminal_id: String,
+    pub subscriber_worktree_id: Option<String>,
+    pub subscriber_worktree_name: Option<String>,
+    /// 購読者タブが生存していれば PTY セッション ID（UI のタブ突合用）
+    pub subscriber_session_id: Option<u32>,
+    /// `claude` / `gemini` / `codex` / `cline`。非 CC は Stop フック経路が存在しない
+    pub agent_name: Option<String>,
+    pub target_worktree_id: String,
+    pub target_worktree_name: Option<String>,
+    pub event_kinds: Vec<String>,
+    pub delivery: String,
+    pub spawn_if_closed: bool,
+    pub state: String,
+    pub created_at: i64,
+    pub expires_at: Option<i64>,
+    pub orphaned_at: Option<i64>,
+    pub unacked: i64,
+    pub undelivered: i64,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrphanedGroupView {
+    pub terminal_id: String,
+    pub worktree_id: String,
+    pub worktree_name: Option<String>,
+    pub orphaned_at: i64,
+    pub subscriptions: i64,
+    pub pending: i64,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalIdEntry {
+    pub session_id: u32,
+    pub terminal_id: String,
+    pub agent_name: Option<String>,
+    pub worktree_id: Option<String>,
+    pub worktree_name: Option<String>,
+    pub is_ai_agent: bool,
+    pub unacked: i64,
+}
+
+fn pool_of(app: &AppHandle) -> Result<SqlitePool, String> {
+    app.try_state::<event_db::EventPool>()
+        .map(|p| p.0.clone())
+        .ok_or_else(|| "イベント DB が初期化されていません".to_string())
+}
+
+#[tauri::command]
+pub async fn event_list_subscriptions(
+    app_handle: AppHandle,
+) -> Result<Vec<SubscriptionView>, String> {
+    let pool = pool_of(&app_handle)?;
+    let now = event_db::now_ms();
+    let rows = event_db::list_all_subscriptions(&pool, now).await?;
+    let counts = event_db::count_unacked_by_terminal(&pool).await?;
+    // State を await 越しに保持しない（他の DB 経路と同じ流儀）
+    let sessions = app_handle
+        .state::<crate::pty_manager::PtyManager>()
+        .list_sessions();
+    let settings = app_handle.state::<SettingsManager>().get();
+    let name_of = |id: &str| settings.worktrees.iter().find(|w| w.id == id).map(|w| w.name.clone());
+
+    Ok(rows
+        .into_iter()
+        .map(|r| {
+            let session = sessions
+                .iter()
+                .find(|s| s.terminal_id == r.subscriber_terminal_id && s.exit_code.is_none());
+            let (unacked, undelivered) = counts
+                .iter()
+                .find(|(t, _, _)| *t == r.subscriber_terminal_id)
+                .map(|(_, a, b)| (*a, *b))
+                .unwrap_or((0, 0));
+            SubscriptionView {
+                subscriber_worktree_name: r.subscriber_worktree_id.as_deref().and_then(name_of),
+                subscriber_session_id: session.map(|s| s.session_id),
+                agent_name: session.and_then(|s| s.agent_name.clone()),
+                target_worktree_name: name_of(&r.target),
+                target_worktree_id: r.target,
+                event_kinds: serde_json::from_str(&r.event_kinds).unwrap_or_default(),
+                delivery: r.delivery,
+                spawn_if_closed: r.spawn_if_closed != 0,
+                state: r.state,
+                created_at: r.created_at,
+                expires_at: r.expires_at,
+                orphaned_at: r.orphaned_at,
+                unacked,
+                undelivered,
+                id: r.id,
+                subscriber_terminal_id: r.subscriber_terminal_id,
+                subscriber_worktree_id: r.subscriber_worktree_id,
+            }
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub async fn event_list_orphaned_groups(
+    app_handle: AppHandle,
+) -> Result<Vec<OrphanedGroupView>, String> {
+    let pool = pool_of(&app_handle)?;
+    let groups = event_db::list_all_orphaned_groups(&pool).await?;
+    let settings = app_handle.state::<SettingsManager>().get();
+    Ok(groups
+        .into_iter()
+        .map(|g| OrphanedGroupView {
+            worktree_name: settings
+                .worktrees
+                .iter()
+                .find(|w| w.id == g.worktree_id)
+                .map(|w| w.name.clone()),
+            terminal_id: g.terminal_id,
+            worktree_id: g.worktree_id,
+            orphaned_at: g.orphaned_at,
+            subscriptions: g.subscriptions,
+            pending: g.pending,
+        })
+        .collect())
+}
+
+/// 引き継ぎ待ちグループを、人間が選んだ生存タブへ手動で引き継ぐ。
+///
+/// 自動の引き継ぎは「新しい AI タブ1つにつき1グループ」なので、前回より少ないタブしか
+/// 開かなかった場合にグループが残る。その取り残しを人間が解消するための経路。
+#[tauri::command]
+pub async fn event_rebind_group(
+    app_handle: AppHandle,
+    worktree_id: String,
+    dead_terminal_id: String,
+    session_id: u32,
+) -> Result<(u64, u64), String> {
+    let terminal_id = app_handle
+        .state::<crate::pty_manager::PtyManager>()
+        .list_sessions()
+        .into_iter()
+        .find(|s| s.session_id == session_id && s.exit_code.is_none())
+        .map(|s| s.terminal_id)
+        .ok_or_else(|| format!("session_id {} に対応する生存ターミナルがありません", session_id))?;
+    let (tx, rx) = oneshot::channel();
+    {
+        let h = handle(&app_handle).ok_or_else(|| "配送ワーカーが起動していません".to_string())?;
+        h.tx.try_send(DeliveryMsg::RebindManual {
+            worktree_id,
+            dead_terminal_id,
+            terminal_id,
+            reply: Some(tx),
+        })
+        .map_err(|_| "配送ワーカーが混雑しています。少し待って再試行してください".to_string())?;
+    }
+    rx.await.map_err(|_| "配送ワーカーが応答しませんでした".to_string())
+}
+
+#[tauri::command]
+pub async fn event_unsubscribe(app_handle: AppHandle, subscription_id: String) -> Result<u64, String> {
+    let pool = pool_of(&app_handle)?;
+    let deleted = event_db::delete_subscription_by_id(&pool, &subscription_id).await?;
+    let _ = app_handle.emit("event-inbox-changed", ());
+    Ok(deleted)
+}
+
+/// UI からの既読化。エージェントが ack しないまま放置した分を人間が畳めるようにする。
+#[tauri::command]
+pub async fn event_ack(
+    app_handle: AppHandle,
+    terminal_id: String,
+    ids: Vec<String>,
+) -> Result<u64, String> {
+    let pool = pool_of(&app_handle)?;
+    let acked = event_db::ack(&pool, &ids, &terminal_id, event_db::now_ms()).await?;
+    let _ = app_handle.emit("event-inbox-changed", ());
+    Ok(acked)
+}
+
+/// タブごとの未読件数（UI のバッジ用）。`session_id` はフロントが握っている ID で、
+/// `terminal_id` はフロントからは見えないためここで突き合わせて返す。
+#[tauri::command]
+pub async fn event_terminal_unread(app_handle: AppHandle) -> Result<Vec<TerminalIdEntry>, String> {
+    let pool = pool_of(&app_handle)?;
+    let counts = event_db::count_unacked_by_terminal(&pool).await?;
+    let sessions = app_handle
+        .state::<crate::pty_manager::PtyManager>()
+        .list_sessions();
+    let settings = app_handle.state::<SettingsManager>().get();
+    Ok(sessions
+        .into_iter()
+        .filter(|s| s.exit_code.is_none())
+        .map(|s| {
+            let worktree = s
+                .cwd
+                .as_deref()
+                .and_then(|c| crate::mcp_server::resolve_worktree_by_cwd(&settings, c));
+            TerminalIdEntry {
+                unacked: counts
+                    .iter()
+                    .find(|(t, _, _)| *t == s.terminal_id)
+                    .map(|(_, a, _)| *a)
+                    .unwrap_or(0),
+                worktree_id: worktree.map(|w| w.id.clone()),
+                worktree_name: worktree.map(|w| w.name.clone()),
+                session_id: s.session_id,
+                terminal_id: s.terminal_id,
+                agent_name: s.agent_name,
+                is_ai_agent: s.is_ai_agent,
+            }
+        })
+        .collect())
+}
+
+/// フロントからの spawn 完了応答（#125）。
+///
+/// **成否にかかわらず必ず呼ぶこと。** 呼ばれないと単一フライトが 60 秒間解放されないが、
+/// 逆に言えば「応答が来ないから撃ち直す」という無限ループにはならない。
+#[tauri::command]
+pub fn event_spawn_result(app_handle: AppHandle, request_id: String, session_id: Option<u32>) {
+    if let Some(h) = handle(&app_handle) {
+        h.try_send(DeliveryMsg::SpawnResult {
+            request_id,
+            session_id,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty_manager::SessionInfo;
+
+    fn session(agent: Option<&str>, status: Option<&str>, quiescent: bool) -> SessionInfo {
+        SessionInfo {
+            session_id: 1,
+            terminal_id: "term-a".to_string(),
+            cwd: Some("X:/wt".to_string()),
+            is_ai_agent: agent.is_some(),
+            agent_name: agent.map(str::to_string),
+            agent_session_id: None,
+            agent_status: status.map(str::to_string),
+            agent_status_sampled_at: Some(1_000_000),
+            output_quiescent: quiescent,
+            exit_code: None,
+            last_command_exit_code: None,
+        }
+    }
+
+    fn is_push(d: PushDecision) -> bool {
+        matches!(d, PushDecision::Push)
+    }
+
+    #[test]
+    fn test_push_when_claude_idle_and_quiescent() {
+        let s = session(Some("claude"), Some("idle"), true);
+        assert!(is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000)));
+    }
+
+    #[test]
+    fn test_skip_when_claude_busy() {
+        let s = session(Some("claude"), Some("busy"), true);
+        assert!(!is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000)));
+    }
+
+    /// `interrupt` は「走行中でも割り込む」という購読側の明示オプトイン。
+    #[test]
+    fn test_interrupt_pushes_even_when_busy() {
+        let s = session(Some("claude"), Some("busy"), false);
+        assert!(is_push(decide_push(&s, event_db::DELIVERY_INTERRUPT, 1_000_000)));
+    }
+
+    #[test]
+    fn test_skip_when_status_sample_is_stale() {
+        let s = session(Some("claude"), Some("idle"), true);
+        // サンプルから 20 秒以上経過
+        assert!(!is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000 + 20_001)));
+    }
+
+    #[test]
+    fn test_skip_when_output_is_moving() {
+        let s = session(Some("claude"), Some("idle"), false);
+        assert!(!is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000)));
+    }
+
+    /// 非 CC エージェントは status を取得できないので、押し込まないと永久に届かない。
+    #[test]
+    fn test_push_for_non_claude_agent_without_status() {
+        for name in ["gemini", "codex", "cline"] {
+            let s = session(Some(name), None, false);
+            assert!(
+                is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000)),
+                "{} は押し込み対象",
+                name
+            );
+        }
+    }
+
+    /// 素のシェルへ CR を撃つと任意のコマンドが走ってしまう。
+    #[test]
+    fn test_skip_when_no_agent_running() {
+        let s = session(None, None, true);
+        assert!(!is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000)));
+    }
+
+    #[test]
+    fn test_skip_passive() {
+        let s = session(Some("claude"), Some("idle"), true);
+        assert!(!is_push(decide_push(&s, event_db::DELIVERY_PASSIVE, 1_000_000)));
+    }
+
+    #[test]
+    fn test_skip_exited_session() {
+        let mut s = session(Some("claude"), Some("idle"), true);
+        s.exit_code = Some(0);
+        assert!(!is_push(decide_push(&s, event_db::DELIVERY_TURN_END, 1_000_000)));
+    }
+
+    fn worktree(auto: Option<bool>) -> WorktreeEntry {
+        WorktreeEntry {
+            id: "wt-1".to_string(),
+            name: "wt".to_string(),
+            repository_id: "r".to_string(),
+            repository_name: "r".to_string(),
+            path: "X:/wt".to_string(),
+            branch_name: "b".to_string(),
+            hotkey_char: None,
+            auto_approval: auto,
+            auto_approval_prompt: None,
+            description: None,
+            description_open: None,
+            workgroup_id: None,
+            is_home: false,
+            is_repository: false,
+        }
+    }
+
+    #[test]
+    fn test_auto_approval_allows_canned_kinds_only() {
+        let on = worktree(Some(true));
+        assert!(auto_approval_allows(Some(&on), event_db::KIND_WORKTREE_CLOSED));
+        // 自由文（#126 で入る予定）は自動承認宛には押し込まない
+        assert!(!auto_approval_allows(Some(&on), "worktree.message"));
+    }
+
+    #[test]
+    fn test_auto_approval_off_allows_everything() {
+        let off = worktree(Some(false));
+        assert!(auto_approval_allows(Some(&off), "worktree.message"));
+        let unset = worktree(None);
+        assert!(auto_approval_allows(Some(&unset), "worktree.message"));
+        assert!(auto_approval_allows(None, "worktree.message"));
+    }
+}

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -175,7 +175,19 @@ struct WorkerState {
     /// 1タブが同じワークツリーの死亡タブ全グループを吸い上げ、「新しいタブ1つにつき
     /// 1グループ」という設計不変条件が崩れる。タブが消えたら忘れる。
     claimed: std::collections::HashSet<String>,
+    /// 前回 `Reconcile` を処理したときの生存タブ一覧（ソート済み）。
+    ///
+    /// ポーリングは 10 秒ごとに送ってくるが、`events.db` は WAL ではない（sqlx は
+    /// 明示指定が無いと `journal_mode` を触らない）ので**書き込みが読み取りをブロックする**。
+    /// この DB は SessionStart フックのリクエストパス（`collect_inbox_digest`、busy_timeout
+    /// 800ms / 全体 1200ms）からも読まれるため、変化が無いときは書き込みを一切走らせない。
+    last_live: Option<Vec<String>>,
+    /// 保持期限切れの掃除を最後に回した時刻。期限は7日なので毎 tick 回す必要はない。
+    last_retention_purge: Option<Instant>,
 }
+
+/// 引き継ぎ待ちの保持期限切れを掃除する間隔。
+const RETENTION_PURGE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3600);
 
 pub fn start(app: AppHandle, pool: SqlitePool) -> DeliveryHandle {
     let (tx, mut rx) = mpsc::channel::<DeliveryMsg>(QUEUE_CAPACITY);
@@ -212,30 +224,46 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
     match msg {
         DeliveryMsg::Reconcile { live_terminal_ids } => {
             let now = event_db::now_ms();
-            // 消えたタブの「引き継ぎ済み」マークは忘れる（terminal_id は再利用されないので
-            // 放置しても誤動作はしないが、長時間稼働で単調増加する）。
-            state.claimed.retain(|t| live_terminal_ids.contains(t));
-            match event_db::mark_orphaned_subscribers(pool, &live_terminal_ids, now).await {
-                Ok((subs, inbox, deleted)) if subs > 0 || inbox > 0 || deleted > 0 => {
-                    log::info!(
-                        "[delivery] タブ死亡を検出: 購読 {} 件 / 未読 {} 件を引き継ぎ待ちにした（到達不能な {} 件は削除）",
-                        subs, inbox, deleted
-                    );
-                    let _ = app.emit("event-inbox-changed", ());
+            let mut live_sorted = live_terminal_ids.clone();
+            live_sorted.sort();
+            // 生存タブに変化が無ければ DB へは触らない。10 秒ごとに無条件で書き込むと、
+            // WAL でないこの DB では SessionStart フックの読み取りと競合しうる。
+            if state.last_live.as_ref() != Some(&live_sorted) {
+                state.last_live = Some(live_sorted);
+                // 消えたタブの「引き継ぎ済み」マークは忘れる（terminal_id は再利用されないので
+                // 放置しても誤動作はしないが、長時間稼働で単調増加する）。
+                state.claimed.retain(|t| live_terminal_ids.contains(t));
+                match event_db::mark_orphaned_subscribers(pool, &live_terminal_ids, now).await {
+                    Ok((subs, inbox, deleted)) if subs > 0 || inbox > 0 || deleted > 0 => {
+                        log::info!(
+                            "[delivery] タブ死亡を検出: 購読 {} 件 / 未読 {} 件を引き継ぎ待ちにした（到達不能な {} 件は削除）",
+                            subs, inbox, deleted
+                        );
+                        let _ = app.emit("event-inbox-changed", ());
+                    }
+                    Ok(_) => {}
+                    Err(e) => log::warn!("[delivery] mark_orphaned_subscribers failed: {}", e),
                 }
-                Ok(_) => {}
-                Err(e) => log::warn!("[delivery] mark_orphaned_subscribers failed: {}", e),
             }
-            match event_db::purge_orphaned_expired(pool, now, event_db::ORPHANED_RETENTION_MS).await
-            {
-                Ok((subs, inbox)) if subs > 0 || inbox > 0 => log::info!(
-                    "[delivery] 保持期限（{}日）を過ぎた引き継ぎ待ちを削除: 購読 {} 件 / 未読 {} 件",
-                    event_db::ORPHANED_RETENTION_DAYS,
-                    subs,
-                    inbox
-                ),
-                Ok(_) => {}
-                Err(e) => log::warn!("[delivery] purge_orphaned_expired failed: {}", e),
+            // 保持期限は7日なので、掃除は1時間おきで十分。
+            let purge_due = state
+                .last_retention_purge
+                .map(|at| at.elapsed() >= RETENTION_PURGE_INTERVAL)
+                .unwrap_or(true);
+            if purge_due {
+                state.last_retention_purge = Some(Instant::now());
+                match event_db::purge_orphaned_expired(pool, now, event_db::ORPHANED_RETENTION_MS)
+                    .await
+                {
+                    Ok((subs, inbox)) if subs > 0 || inbox > 0 => log::info!(
+                        "[delivery] 保持期限（{}日）を過ぎた引き継ぎ待ちを削除: 購読 {} 件 / 未読 {} 件",
+                        event_db::ORPHANED_RETENTION_DAYS,
+                        subs,
+                        inbox
+                    ),
+                    Ok(_) => {}
+                    Err(e) => log::warn!("[delivery] purge_orphaned_expired failed: {}", e),
+                }
             }
         }
         DeliveryMsg::Rebind { terminal_id, reply } => {
@@ -299,8 +327,11 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
                 state.inflight_spawn.remove(wt);
             }
             let Some(session_id) = session_id else {
-                log::warn!(
-                    "[delivery] spawn に失敗した応答を受け取った request={} worktree={:?}",
+                // サブウィンドウへ分離済みのワークツリーは session_id を回収できないため、
+                // 成功しても None で返ってくる（引き継ぎはエージェント検出のポーリングに任せる）。
+                // 失敗と区別できないので warn ではなく info に留める。
+                log::info!(
+                    "[delivery] spawn 応答に session_id が無い（失敗、またはサブウィンドウ経由の成功）request={} worktree={:?}",
                     request_id,
                     worktree_id
                 );
@@ -318,6 +349,12 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
             match terminal_id {
                 Some(tid) => {
                     let moved = rebind_for_terminal(app, pool, &tid).await;
+                    if moved != (0, 0) {
+                        // `Rebind` 経路と同じく引き継ぎ済みの印を付ける。付けないと、この直後に
+                        // エージェント検出や購読系ツール呼び出しで再び `Rebind` が来たときに
+                        // **2つ目のグループまで吸い上げ**、「1タブ1グループ」が崩れる。
+                        state.claimed.insert(tid.clone());
+                    }
                     log::info!(
                         "[delivery] spawn したタブへ引き継いだ session_id={} 購読={} 未読={}",
                         session_id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1551,7 +1551,7 @@ pub fn run() {
             event_delivery::event_list_orphaned_groups,
             event_delivery::event_rebind_group,
             event_delivery::event_unsubscribe,
-            event_delivery::event_ack,
+            event_delivery::event_ack_all,
             event_delivery::event_terminal_unread,
             event_delivery::event_spawn_result,
             set_debug_mode,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod artifact_url;
 mod claude_plugin;
 mod claude_plugin_skills;
 mod event_db;
+mod event_delivery;
 mod fs_watcher;
 mod git_worktree;
 mod home_skills;
@@ -1049,18 +1050,29 @@ fn fire_worktree_closed(
             body,
             actor: Some(actor.to_string()),
             created_at: now,
+            // ユーザー操作が起点なので連鎖の深さは 0。配送がイベントを生む経路は
+            // 現状存在しないが、#126 の自由文メッセージで往復が起きたときに
+            // `MAX_EVENT_DEPTH` で止められるよう最初から持たせておく（#125 §3）。
+            depth: 0,
+            origin: Some(format!("worktree-remove:{}", actor)),
         };
         if let Err(e) = event_db::insert_event(&pool.0, &event).await {
             log::warn!("[event] failed to record worktree.closed for {}: {}", name, e);
             return;
         }
         match event_db::fanout(&pool.0, &event, now).await {
-            Ok(count) => log::info!(
-                "[event] worktree.closed worktree={} actor={} delivered={}",
-                name,
-                actor,
-                count
-            ),
+            Ok(count) => {
+                log::info!(
+                    "[event] worktree.closed worktree={} actor={} delivered={}",
+                    name,
+                    actor,
+                    count
+                );
+                if count > 0 {
+                    // 待機中の宛先への押し込み / spawn は配送ワーカーが直列に処理する。
+                    event_delivery::notify_event_queued(&handle);
+                }
+            }
             Err(e) => log::warn!("[event] fanout failed for {}: {}", name, e),
         }
         // このワークツリーを購読していた行はもう二度とマッチしない（ID は再利用されない）。
@@ -1535,6 +1547,13 @@ pub fn run() {
             notify_worktree_added,
             list_archives,
             delete_archive,
+            event_delivery::event_list_subscriptions,
+            event_delivery::event_list_orphaned_groups,
+            event_delivery::event_rebind_group,
+            event_delivery::event_unsubscribe,
+            event_delivery::event_ack,
+            event_delivery::event_terminal_unread,
+            event_delivery::event_spawn_result,
             set_debug_mode,
             get_debug_mode,
             get_force_wizard,
@@ -1628,26 +1647,43 @@ pub fn run() {
                 tauri::async_runtime::block_on(async move {
                     match event_db::init_event_db(&handle).await {
                         Ok(pool) => {
+                            let now = event_db::now_ms();
                             // `terminal_id` は PTY spawn ごとに発番され永続化されないため、
-                            // 前回起動時の購読はどのターミナルからも到達できない
-                            // （list / unsubscribe / poll がすべて不能になる）。放置すると
-                            // 死んだ宛先へ inbox を積み続け、既定が無期限の購読は単調増加する。
-                            // ここでは生存セッションが 0 件なので前回分がすべて対象になる。
-                            // 再起動を挟んだ購読の復活は #125（orphaned 遷移と再バインド）の担当。
-                            match event_db::purge_orphaned_subscribers(&pool, &[]).await {
-                                Ok((subs, inbox)) if subs > 0 || inbox > 0 => log::info!(
-                                    "[EventDB] purged unreachable subscriptions={} inbox={} (terminal_id は再起動で再発番されるため前回分は復活できない)",
-                                    subs, inbox
+                            // 起動直後は前回の購読がどのタブからも到達できない。ただし
+                            // **削除はしない**（#125）。数時間〜数日待って別ワークツリーの
+                            // クローズを検知する、という #120 の動機②が再起動を挟んだ瞬間に
+                            // 壊れるため。`orphaned` として保持し、同じワークツリーで次に
+                            // AI タブが立った時点で引き継ぐ。
+                            // 起動時は生存セッションが 0 件なので前回分がすべて対象になる。
+                            match event_db::mark_orphaned_subscribers(&pool, &[], now).await {
+                                Ok((subs, inbox, deleted)) if subs > 0 || inbox > 0 || deleted > 0 => log::info!(
+                                    "[EventDB] 前回起動分を引き継ぎ待ちにした subscriptions={} inbox={} (逆引き不能で削除={}) — 同じワークツリーで AI タブが立てば引き継ぐ",
+                                    subs, inbox, deleted
                                 ),
                                 Ok(_) => {}
                                 Err(e) => {
-                                    log::warn!("[EventDB] purge_orphaned_subscribers failed: {}", e)
+                                    log::warn!("[EventDB] mark_orphaned_subscribers failed: {}", e)
                                 }
+                            }
+                            // 引き継がれないまま保持期限を過ぎた分を掃除する（単調増加の防止）
+                            match event_db::purge_orphaned_expired(
+                                &pool,
+                                now,
+                                event_db::ORPHANED_RETENTION_MS,
+                            )
+                            .await
+                            {
+                                Ok((subs, inbox)) if subs > 0 || inbox > 0 => log::info!(
+                                    "[EventDB] purged stale orphaned subscriptions={} inbox={}",
+                                    subs, inbox
+                                ),
+                                Ok(_) => {}
+                                Err(e) => log::warn!("[EventDB] purge_orphaned_expired failed: {}", e),
                             }
                             // 保持期限切れの inbox / 参照されない events をここで掃除する
                             match event_db::purge_expired(
                                 &pool,
-                                event_db::now_ms(),
+                                now,
                                 event_db::INBOX_RETENTION_MS,
                             )
                             .await
@@ -1661,6 +1697,9 @@ pub fn run() {
                                 Ok(_) => {}
                                 Err(e) => log::warn!("[EventDB] purge_expired failed: {}", e),
                             }
+                            // 配送ワーカー。`EventPool` と同じアームで manage するので、
+                            // DB 初期化に失敗すればハンドルも登録されず全経路が no-op になる。
+                            handle.manage(event_delivery::start(handle.clone(), pool.clone()));
                             handle.manage(event_db::EventPool(pool));
                             log::debug!("[EventDB] Initialized successfully");
                         }

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -708,11 +708,11 @@ pub struct SubscribeWorktreeParams {
     pub target: String,
     #[schemars(description = "購読するイベント種別。現状 \"worktree.closed\" のみ対応（省略時 [\"worktree.closed\"]）")]
     pub event_kinds: Option<Vec<String>>,
-    #[schemars(description = "配送戦略: \"turn_end\"(既定) / \"passive\"。現状どちらもセッション開始時の回収と oretachi_poll_inbox でのみ配送される（ターン境界での即時注入は未実装）")]
+    #[schemars(description = "配送戦略: \"turn_end\"(既定。待機中なら PTY へ押し込み、走行中はターン境界を待つ) / \"interrupt\"(走行中でも即 PTY へ割り込む) / \"passive\"(押し込まない。oretachi_poll_inbox で自分から取りに来る)。どの戦略でもセッション開始時の回収と oretachi_poll_inbox は使える")]
     pub delivery: Option<String>,
-    #[schemars(description = "自分のターミナルが閉じていた場合に新しいターミナルを起動して通知するか（既定 false）。現状は記録のみで未実装")]
+    #[schemars(description = "自分のターミナルが閉じていた場合に新しいターミナルを起動して通知するか（既定 false）。true にすると未読が溜まった時点で oretachi が自動でタブを立ててエージェントを起動する")]
     pub spawn_if_closed: Option<bool>,
-    #[schemars(description = "購読の有効期間（秒）。省略時は無期限")]
+    #[schemars(description = "購読の有効期間（秒）。省略時は無期限。ターミナルが閉じても購読は引き継ぎ待ちとして7日間保持され、同じワークツリーで次に AI エージェントが立ち上がったときに引き継がれる")]
     pub expires_in: Option<i64>,
     #[schemars(description = "自分が動いているターミナルの terminal_id。セッション開始時に oretachi から注入されている値をそのまま渡す。省略時は project_dir から AI エージェント端末が1つだけのワークツリーとして推測する")]
     pub terminal_id: Option<String>,
@@ -1690,7 +1690,7 @@ impl NotifyService {
         }
     }
 
-    #[tool(description = "指定ワークツリーのクローズを購読する。別ワークツリーで進めている関連作業が完了（クローズ）したことを、自分のセッションで検知したいときに使う。届いた通知は次のセッション開始時に自動で提示され、oretachi_poll_inbox でも取得できる")]
+    #[tool(description = "指定ワークツリーのクローズを購読する。別ワークツリーで進めている関連作業が完了（クローズ）したことを、自分のセッションで検知したいときに使う。届いた通知は待機中なら PTY へ押し込まれ、次のセッション開始時にも自動で提示され、oretachi_poll_inbox でも取得できる。ターミナルを閉じたりアプリを再起動したりしても購読は引き継ぎ待ちとして保持され、同じワークツリーで次に AI エージェントが立ち上がったときに引き継がれる")]
     async fn oretachi_subscribe_worktree(
         &self,
         Parameters(SubscribeWorktreeParams {
@@ -1813,6 +1813,9 @@ impl NotifyService {
             // 巨大な値を渡されても panic させない（debug ビルドのオーバーフロー検査対策）
             expires_at: expires_in.map(|secs| now.saturating_add(secs.saturating_mul(1000))),
             state: crate::event_db::STATE_ACTIVE.to_string(),
+            // 呼び出し元のタブは生存しているので引き継ぎ待ちではない。再購読で orphaned な
+            // 行を上書きしたときも、ここで active + None に戻るのが正しい。
+            orphaned_at: None,
         };
         // 既存の購読を更新した場合は既存の id が返る（再購読で解除手段を失わせない）
         let subscription_id = crate::event_db::upsert_subscription(&pool, &sub)
@@ -1935,6 +1938,7 @@ impl NotifyService {
                     "createdAt": s.created_at,
                     "expiresAt": s.expires_at,
                     "state": s.state,
+                    "orphanedAt": s.orphaned_at,
                 })
             })
             .collect();
@@ -2522,7 +2526,10 @@ fn resolve_worktree_by_dir<'a>(settings: &'a AppSettings, dir: &str) -> Option<&
 /// エージェントを起動した場合も解決できる。ホームの path はワークツリー追加先
 /// ディレクトリ = 全ワークツリーの祖先なので、先頭一致だけで拾うと全ターミナルが
 /// ホーム所属になってしまう。最長一致を採用する。
-fn resolve_worktree_by_cwd<'a>(settings: &'a AppSettings, cwd: &str) -> Option<&'a WorktreeEntry> {
+pub fn resolve_worktree_by_cwd<'a>(
+    settings: &'a AppSettings,
+    cwd: &str,
+) -> Option<&'a WorktreeEntry> {
     let cp = std::path::Path::new(cwd);
     settings
         .worktrees
@@ -2653,6 +2660,9 @@ fn resolve_subscriber(
     // ローカルの信頼境界内なので許容しているが、`event_db` 側の
     // 「自分のタブの購読しか消せない」は SQL のスコープ制約であって本人性の保証ではない。
     if let Some(id) = terminal_id.map(str::trim).filter(|s| !s.is_empty()) {
+        // 購読系ツールを叩けている＝このタブでエージェントが走っている。ついでに
+        // 引き継ぎ待ちを引き取らせる（非ブロッキング。SessionStart を取り逃した場合の保険）。
+        crate::event_delivery::request_rebind(app_handle, id.to_string());
         return sessions
             .iter()
             .find(|s| s.terminal_id == id)
@@ -3221,6 +3231,23 @@ async fn collect_inbox_digest(app_handle: &AppHandle, terminal_id: Option<&str>)
     let pool = app_handle
         .try_state::<crate::event_db::EventPool>()
         .map(|p| p.0.clone())?;
+    // このタブが立ち上がったので、同じワークツリーの引き継ぎ待ち（アプリ再起動や
+    // タブ死亡で宙に浮いた購読と未読）を引き継ぐ。**回収より先に行う**必要がある。
+    // 引き継ぎ前に list_inbox すると、前回の terminal_id 宛のままの行が見えない。
+    // ワーカーが詰まっていれば None が返り「今回は引き継がない」に劣化するだけで、
+    // 上位の INBOX_DIGEST_BUDGET_MS タイムアウトを食い潰さない（#125）。
+    if let Some((subs, inbox)) =
+        crate::event_delivery::rebind_and_wait(app_handle, terminal_id).await
+    {
+        if subs > 0 || inbox > 0 {
+            log::info!(
+                "[session-context] 引き継ぎ待ちを回収した terminal={} 購読={} 未読={}",
+                terminal_id,
+                subs,
+                inbox
+            );
+        }
+    }
     let items = match crate::event_db::list_inbox(
         &pool,
         terminal_id,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -2069,6 +2069,11 @@ impl NotifyService {
             ids.len(),
             acked
         );
+        // 未読件数が減ったことを UI に伝える。これが無いと正常系（押し込み → エージェントが
+        // ack）でタブの未読バッジが消えず、人間がホームの購読パネルを開き直すまで残る。
+        if acked > 0 {
+            let _ = self.app_handle.emit("event-inbox-changed", ());
+        }
         Ok(CallToolResult::success(vec![Content::text(format!(
             "{} 件を確認済みにしました（要求 {} 件。差分は既に ack 済みか、別のターミナル宛のメッセージです）。",
             acked,

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -38,6 +38,15 @@ struct PtySession {
     /// `agent_name == "claude"` のときポーリングが取得する Claude Code のセッション UUID。
     /// hook の stdin JSON の `session_id` と同一値（#120 で実測済み）。
     agent_session_id: Option<String>,
+    /// `~/.claude/sessions/<pid>.json` の `status`（`"busy"` | `"idle"`）。Claude Code 以外の
+    /// エージェントには対応するファイルが無いので常に `None`（#125 の PTY 押し込み判定用）。
+    agent_status: Option<String>,
+    /// 上の値をポーリングがサンプルした時刻（epoch ms）。鮮度判定はこちらで行う。
+    agent_status_sampled_at: Option<i64>,
+    /// 直前のポーリング tick から PTY 出力が1バイトも増えていないか。
+    /// `idle` でも最大10秒古いので、押し込み直前の第二の安全弁として使う
+    /// （人間が入力中の行にブラケットペーストを重ねて破壊するのを避ける）。
+    output_quiescent: bool,
     cwd: Option<String>,
     output_history: Arc<Mutex<VecDeque<u8>>>,
     /// flush ループへ渡す未配送バッファ。reader が append し、16ms 周期の flush が
@@ -117,6 +126,12 @@ pub struct SessionInfo {
     pub is_ai_agent: bool,
     pub agent_name: Option<String>,
     pub agent_session_id: Option<String>,
+    /// `"busy"` | `"idle"`。Claude Code 以外は `None`（#125）
+    pub agent_status: Option<String>,
+    /// `agent_status` をサンプルした時刻（epoch ms）
+    pub agent_status_sampled_at: Option<i64>,
+    /// 直前の tick から PTY 出力が増えていない
+    pub output_quiescent: bool,
     pub exit_code: Option<i64>,
     pub last_command_exit_code: Option<i64>,
 }
@@ -349,8 +364,21 @@ fn find_ai_agent_in_subtree(
     None
 }
 
-/// Claude Code の PID から ~/.claude/sessions/<pid>.json を読んでセッション UUID を返す
-fn get_claude_session_id_by_pid(pid: u32) -> Option<String> {
+/// `~/.claude/sessions/<pid>.json` から読み取る値。
+pub struct ClaudeSessionFile {
+    /// hook の stdin JSON の `session_id` と同一値（#120 で実測済み）
+    pub session_id: Option<String>,
+    /// `"busy"` | `"idle"`。走行中 / 待機中の判定に使う（#121 で実測）
+    pub status: Option<String>,
+}
+
+/// Claude Code の PID から ~/.claude/sessions/<pid>.json を読む。
+///
+/// `status` は「走行中か待機中か」の唯一の一次情報。ファイル側の `statusUpdatedAt` は
+/// 鮮度判定に**使わない** —— 長いターンは正当に古い `busy` を残すので「古い＝不明」と
+/// 扱うと押し込んではいけない場面で押し込むことになる。鮮度はこちらがサンプルした
+/// 時刻（`agent_status_sampled_at`）で見る。
+fn read_claude_session_file(pid: u32) -> Option<ClaudeSessionFile> {
     let home = std::env::var("USERPROFILE")
         .or_else(|_| std::env::var("HOME"))
         .ok()?;
@@ -360,7 +388,18 @@ fn get_claude_session_id_by_pid(pid: u32) -> Option<String> {
         .join(format!("{}.json", pid));
     let content = std::fs::read_to_string(&session_file).ok()?;
     let v: serde_json::Value = serde_json::from_str(&content).ok()?;
-    v.get("sessionId")?.as_str().map(|s| s.to_string())
+    Some(ClaudeSessionFile {
+        session_id: v.get("sessionId").and_then(|s| s.as_str()).map(str::to_string),
+        status: v.get("status").and_then(|s| s.as_str()).map(str::to_string),
+    })
+}
+
+/// UNIX epoch からのミリ秒（`event_db::now_ms` と同じ流儀。依存を増やさないため再実装）。
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 impl PtyManagerCore {
@@ -429,6 +468,8 @@ impl PtyManagerCore {
         std::thread::spawn(move || {
             // (is_agent, session_id) のペアで差分検出
             let mut last_status: HashMap<u32, (bool, Option<String>)> = HashMap::new();
+            // 前 tick の PTY 累積出力量。押し込み前の静穏判定に使う
+            let mut last_bytes: HashMap<u32, u64> = HashMap::new();
             loop {
                 std::thread::sleep(std::time::Duration::from_secs(10));
 
@@ -436,18 +477,37 @@ impl PtyManagerCore {
                     break;
                 }
 
-                // セッション情報を取得
-                let session_pids: Vec<(u32, Option<u32>)> = {
+                // セッション情報を取得（terminal_id と出力量も一緒に拾う）
+                let session_pids: Vec<(u32, Option<u32>, String, u64)> = {
                     let mut sessions = match sessions_arc.lock() {
                         Ok(s) => s,
                         Err(_) => continue,
                     };
                     sweep_exited(&mut sessions);
-                    sessions.iter().map(|(&id, s)| (id, s.child_pid)).collect()
+                    sessions
+                        .iter()
+                        .map(|(&id, s)| {
+                            (
+                                id,
+                                s.child_pid,
+                                s.terminal_id.clone(),
+                                s.total_bytes_written.load(std::sync::atomic::Ordering::Relaxed),
+                            )
+                        })
+                        .collect()
                 };
+
+                // 生存タブの terminal_id を購読側へ通知して、死んだタブの購読を orphaned に
+                // 落とす（#125）。exited セッションも EXITED_SESSION_TTL の間はここに含まれる。
+                // 一瞬の再起動で orphaned へフラップさせないよう、あえて除外しない。
+                crate::event_delivery::reconcile_live_terminals(
+                    &app_handle,
+                    session_pids.iter().map(|(_, _, tid, _)| tid.clone()).collect(),
+                );
 
                 if session_pids.is_empty() {
                     last_status.clear();
+                    last_bytes.clear();
                     continue;
                 }
 
@@ -460,31 +520,56 @@ impl PtyManagerCore {
 
                 // pty_session_id → AiAgentInfo のマップを構築
                 let mut current_status: HashMap<u32, (bool, Option<String>)> = HashMap::new();
-                let mut new_infos: Vec<(u32, bool, AiAgentInfo)> = Vec::new();
+                let mut current_bytes: HashMap<u32, u64> = HashMap::new();
+                // (session_id, is_agent, info, claude_status, quiescent, terminal_id)
+                let mut new_infos: Vec<(u32, bool, AiAgentInfo, Option<String>, bool, String)> =
+                    Vec::new();
+                let sampled_at = now_ms();
 
-                for (session_id, child_pid) in session_pids {
-                    let (is_agent, info) = if let Some(pid) = child_pid {
+                for (session_id, child_pid, terminal_id, bytes) in session_pids {
+                    let (is_agent, info, claude_status) = if let Some(pid) = child_pid {
                         match find_ai_agent_in_subtree(pid, &children_map, 4) {
                             Some((agent_name, agent_pid)) => {
-                                let claude_session_id = if agent_name == "claude" {
-                                    get_claude_session_id_by_pid(agent_pid)
+                                // Claude Code 以外（gemini / codex / cline）は
+                                // ~/.claude/sessions/<pid>.json を持たないため status を取れない。
+                                // 「非 CC は busy/idle 判定不能」という #125 §5 の仕様の実体がここ。
+                                let file = if agent_name == "claude" {
+                                    read_claude_session_file(agent_pid)
                                 } else {
                                     None
                                 };
-                                (true, AiAgentInfo {
-                                    is_agent: true,
-                                    agent_name: Some(agent_name),
-                                    session_id: claude_session_id,
-                                })
+                                let (sid, status) = match file {
+                                    Some(f) => (f.session_id, f.status),
+                                    None => (None, None),
+                                };
+                                (
+                                    true,
+                                    AiAgentInfo {
+                                        is_agent: true,
+                                        agent_name: Some(agent_name),
+                                        session_id: sid,
+                                    },
+                                    status,
+                                )
                             }
-                            None => (false, AiAgentInfo { is_agent: false, agent_name: None, session_id: None }),
+                            None => (
+                                false,
+                                AiAgentInfo { is_agent: false, agent_name: None, session_id: None },
+                                None,
+                            ),
                         }
                     } else {
-                        (false, AiAgentInfo { is_agent: false, agent_name: None, session_id: None })
+                        (
+                            false,
+                            AiAgentInfo { is_agent: false, agent_name: None, session_id: None },
+                            None,
+                        )
                     };
+                    let quiescent = last_bytes.get(&session_id) == Some(&bytes);
+                    current_bytes.insert(session_id, bytes);
                     let session_id_val = info.session_id.clone();
                     current_status.insert(session_id, (is_agent, session_id_val));
-                    new_infos.push((session_id, is_agent, info));
+                    new_infos.push((session_id, is_agent, info, claude_status, quiescent, terminal_id));
                 }
 
                 // 内部状態を更新。
@@ -493,7 +578,7 @@ impl PtyManagerCore {
                 // 最終ログを参照できるという既存方針に合わせ、エージェント情報も最終値を凍結する。
                 let mut exited_ids: std::collections::HashSet<u32> = std::collections::HashSet::new();
                 if let Ok(mut sessions) = sessions_arc.lock() {
-                    for (id, is_agent, info) in &new_infos {
+                    for (id, is_agent, info, status, quiescent, _) in &new_infos {
                         if let Some(session) = sessions.get_mut(id) {
                             if session.exited_at.lock().ok().and_then(|g| *g).is_some() {
                                 exited_ids.insert(*id);
@@ -502,7 +587,23 @@ impl PtyManagerCore {
                             session.is_ai_agent = *is_agent;
                             session.agent_name = info.agent_name.clone();
                             session.agent_session_id = info.session_id.clone();
+                            session.agent_status = status.clone();
+                            session.agent_status_sampled_at = Some(sampled_at);
+                            session.output_quiescent = *quiescent;
                         }
+                    }
+                }
+
+                // AI エージェントが立ち上がったタブは、そのワークツリーの引き継ぎ待ち購読を
+                // 受け取れる。SessionStart フックが無いエージェント（gemini / codex / cline）や
+                // ユーザーが手で `claude` と打った場合もここで拾える（最大10秒の遅延）。
+                for (id, is_agent, _, _, _, terminal_id) in &new_infos {
+                    if !*is_agent || exited_ids.contains(id) {
+                        continue;
+                    }
+                    let was_agent = last_status.get(id).map(|(a, _)| *a).unwrap_or(false);
+                    if !was_agent {
+                        crate::event_delivery::request_rebind(&app_handle, terminal_id.clone());
                     }
                 }
 
@@ -512,7 +613,7 @@ impl PtyManagerCore {
                 // （タブ自体は pty-exit で既に消えているので通知する相手も居ない）。
                 let changed: HashMap<u32, AiAgentInfo> = new_infos
                     .into_iter()
-                    .filter(|(id, _, info)| {
+                    .filter(|(id, _, info, _, _, _)| {
                         if exited_ids.contains(id) {
                             return false;
                         }
@@ -524,7 +625,7 @@ impl PtyManagerCore {
                             }
                         }
                     })
-                    .map(|(id, _, info)| (id, info))
+                    .map(|(id, _, info, _, _, _)| (id, info))
                     .collect();
 
                 if !changed.is_empty() {
@@ -532,6 +633,7 @@ impl PtyManagerCore {
                 }
 
                 last_status = current_status;
+                last_bytes = current_bytes;
             }
         });
     }
@@ -863,6 +965,9 @@ impl PtyManagerCore {
             is_ai_agent: false,
             agent_name: None,
             agent_session_id: None,
+            agent_status: None,
+            agent_status_sampled_at: None,
+            output_quiescent: false,
             cwd,
             output_history,
             output_pending,
@@ -1185,6 +1290,9 @@ impl PtyManagerCore {
                 is_ai_agent: s.is_ai_agent,
                 agent_name: s.agent_name.clone(),
                 agent_session_id: s.agent_session_id.clone(),
+                agent_status: s.agent_status.clone(),
+                agent_status_sampled_at: s.agent_status_sampled_at,
+                output_quiescent: s.output_quiescent,
                 exit_code: s.exit_status.lock().ok().and_then(|g| *g),
                 last_command_exit_code: s.last_command_exit_code.lock().ok().and_then(|g| *g),
             })

--- a/src/App.vue
+++ b/src/App.vue
@@ -1532,10 +1532,13 @@ onMounted(async () => {
   // PTY へ押し込んだ瞬間にトーストで知らせる。
   await listen<DeliveredPayload>("event-delivered", (event) => {
     const p = event.payload;
+    // 本文は最大 600 字。トーストは幅 260px なので、そのまま出すと画面を埋める。
+    // 全文はエージェント側の画面と購読パネルで読めるので、ここは要約で足りる。
+    const detail = p.text.length > 120 ? `${p.text.slice(0, 120)}…` : p.text;
     toast.add({
-      severity: "info",
+      severity: "success",
       summary: t("eventDeliveredSummary", { name: p.worktreeName ?? "", count: p.count }),
-      detail: p.text,
+      detail,
       life: 8000,
     });
   });
@@ -1601,7 +1604,8 @@ onMounted(async () => {
     }
     await reportSpawnResult(requestId, sessionId);
     toast.add({
-      severity: "info",
+      // `info` は共通テンプレートがスピナーを出す（進行中を意味する）ので使わない
+      severity: "success",
       summary: t("eventSpawnedSummary"),
       detail: t("eventSpawnedDetail", { name: targetWt.name, count: event.payload.pending }),
       life: 8000,

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,17 @@ import { isHomeWorktree } from "./utils/homeWorktree";
 import { isPseudoWorktree, makeRepositoryWorktreeId, sortPseudoFirst } from "./utils/repositoryWorktree";
 import { useUiZoom } from "./composables/useUiZoom";
 import { consumeMaxBlockedMs, startEventLoopMonitor } from "./utils/eventLoopMonitor";
+import { useToast } from "primevue/usetoast";
+import {
+  initEventSubscriptions,
+  reportSpawnResult,
+  terminalUnread,
+} from "./composables/useEventSubscriptions";
+import type {
+  DeliveredPayload,
+  SpawnRejectedPayload,
+  SpawnTerminalRequest,
+} from "./types/event";
 import { terminalMountCount, terminalUnmountCount, terminalActiveCount } from "./components/TerminalView.vue";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { cancelApproval } from "./utils/autoApproval";
@@ -69,6 +80,8 @@ import MacTrafficLights from "./components/MacTrafficLights.vue";
 import { isMac, isWindows } from "./composables/usePlatform";
 
 const { t } = useI18n();
+// 購読イベントの配送を知らせるトースト（#120 §7）。outlet はテンプレート末尾の <Toast>。
+const toast = useToast();
 
 // ウィンドウのフォーカス状態
 const { isWindowFocused } = useWindowFocus();
@@ -161,6 +174,23 @@ const terminalAiSessions = reactive(new Map<number, import("./types/terminal").A
 
 // terminalId → Webセッション情報（claude --remote で起動したターミナル）
 const terminalWebSessions = reactive(new Map<number, import("./types/terminal").WebSessionInfo>());
+
+// タブ（フロントの terminalId）→ 未 ack のワークツリーイベント件数（#120 §7）。
+// バックエンドは pty の session_id で数えるので、AI エージェントインジケータと同じ
+// session_id → terminalId の逆引きで詰め替える。
+const terminalUnreadByTab = computed(() => {
+  const result = new Map<number, number>();
+  if (terminalUnread.value.size === 0) return result;
+  for (const [, bundle] of worktreeFrameBundles) {
+    for (const [tid, termRef] of bundle.terminalRefs) {
+      const sid = termRef?.sessionId;
+      if (sid == null) continue;
+      const count = terminalUnread.value.get(sid);
+      if (count) result.set(tid, count);
+    }
+  }
+  return result;
+});
 
 // terminalId → worktreeId のマッピング（ターミナルがどのワークツリーに属するか）
 const terminalWorktreeMap = new Map<number, string>();
@@ -1497,6 +1527,89 @@ onMounted(async () => {
     },
   );
 
+  // 購読イベントの配送（issue #120 §7 / #125）。
+  // 配送を画面に出さないと「勝手にエージェントが動き出した」ように見えるので、
+  // PTY へ押し込んだ瞬間にトーストで知らせる。
+  await listen<DeliveredPayload>("event-delivered", (event) => {
+    const p = event.payload;
+    toast.add({
+      severity: "info",
+      summary: t("eventDeliveredSummary", { name: p.worktreeName ?? "", count: p.count }),
+      detail: p.text,
+      life: 8000,
+    });
+  });
+
+  // 自動 spawn が端末数上限で拒否された。黙って落とすと「spawn すると言ったのに
+  // 何も起きない」になるので必ず出す。
+  await listen<SpawnRejectedPayload>("event-spawn-rejected", (event) => {
+    const p = event.payload;
+    toast.add({
+      severity: "warn",
+      summary: t("eventSpawnRejectedSummary"),
+      detail: t("eventSpawnRejectedDetail", {
+        name: p.worktreeName,
+        live: p.liveSessions,
+        limit: p.limit,
+        pending: p.pending,
+      }),
+      life: 10000,
+    });
+  });
+
+  // 購読者タブが無いワークツリーへ、配送のために新しいタブを立てる（spawn_if_closed）。
+  // **成否にかかわらず event_spawn_result を返す**こと。返さないと Rust 側の単一フライトが
+  // 60 秒解放されないが、逆に返さないからといって撃ち直しループにはならない。
+  await listen<SpawnTerminalRequest>("event-spawn-terminal", async (event) => {
+    const { requestId, worktreeId, command } = event.payload;
+    const targetWt = worktrees.value.find((w) => w.id === worktreeId);
+    if (!targetWt) {
+      logDebug(`[event] event-spawn-terminal: worktree ${worktreeId} not found`);
+      await reportSpawnResult(requestId, null);
+      return;
+    }
+    const cmd = command.endsWith("\r") ? command : command + "\r";
+    // detached（サブウィンドウ化済み）は session_id を回収できないので、タブだけ立てて
+    // 引き継ぎは AI エージェント検出のポーリング（10秒周期）に任せる。
+    if (isDetached(worktreeId)) {
+      try {
+        await handleSubAddTerminalRequest(worktreeId, { title: null, pendingCommand: cmd });
+      } catch (e) {
+        logDebug(`[event] event-spawn-terminal: sub window spawn failed: ${e}`);
+      }
+      await reportSpawnResult(requestId, null);
+      return;
+    }
+    const beforeIds = new Set(targetWt.terminals.map((tm) => tm.id));
+    try {
+      await onAddTerminal(worktreeId, { background: true, pendingCommand: cmd });
+    } catch (e) {
+      logDebug(`[event] event-spawn-terminal: onAddTerminal failed: ${e}`);
+      await reportSpawnResult(requestId, null);
+      return;
+    }
+    const wtAfter = worktrees.value.find((w) => w.id === worktreeId);
+    const newTerm = wtAfter?.terminals.find((tm) => !beforeIds.has(tm.id));
+    let sessionId: number | null = null;
+    if (newTerm) {
+      try {
+        await waitForTerminalReady(newTerm.id);
+        sessionId = getTerminalRef(newTerm.id)?.sessionId ?? null;
+      } catch (e) {
+        logDebug(`[event] event-spawn-terminal: waitForTerminalReady failed: ${e}`);
+      }
+    }
+    await reportSpawnResult(requestId, sessionId);
+    toast.add({
+      severity: "info",
+      summary: t("eventSpawnedSummary"),
+      detail: t("eventSpawnedDetail", { name: targetWt.name, count: event.payload.pending }),
+      life: 8000,
+    });
+  });
+
+  await initEventSubscriptions();
+
   // MCP: 指定ワークツリーをフォーカスする
   await listen<{ worktree_id: string }>("mcp-show-worktree", async (event) => {
     const { worktree_id } = event.payload;
@@ -2200,6 +2313,7 @@ onMounted(async () => {
               :terminal-agent-status="terminalAgentStatus"
               :terminal-web-sessions="terminalWebSessions"
               :terminal-ai-sessions="terminalAiSessions"
+              :terminal-unread="terminalUnreadByTab"
               @switch-terminal="(leafId, tid) => onFrameSwitch(wt.id, leafId, tid)"
               @close-terminal="(leafId, tid) => onFrameClose(wt.id, leafId, tid)"
               @tab-drop="(sl, tid, tl, idx) => onFrameTabDrop(wt.id, sl, tid, tl, idx)"
@@ -2350,6 +2464,11 @@ onMounted(async () => {
 <i18n lang="json">
 {
   "en": {
+    "eventDeliveredSummary": "Worktree event delivered ({count})",
+    "eventSpawnRejectedSummary": "Auto spawn declined",
+    "eventSpawnRejectedDetail": "{name} has {pending} unread message(s) but {live} terminals are open (limit {limit}). Close some terminals or open the worktree manually.",
+    "eventSpawnedSummary": "Agent started for a subscription",
+    "eventSpawnedDetail": "Opened a tab in {name} to deliver {count} unread message(s).",
     "taskAddSummary": "Add Task",
     "taskAddDetail": "Generating code...",
     "taskExecutingSummary": "Executing Task",
@@ -2386,6 +2505,11 @@ onMounted(async () => {
     "removeRepositoryConfirm": "Unregister \"{name}\"?\n\nThis closes its {terminals} terminal(s) and permanently deletes the artifacts and saved terminal sessions created there. The repository folder itself is not touched."
   },
   "ja": {
+    "eventDeliveredSummary": "ワークツリーイベントを配送しました ({count}件)",
+    "eventSpawnRejectedSummary": "自動 spawn を見送りました",
+    "eventSpawnRejectedDetail": "{name} に未読が {pending} 件ありますが、ターミナルが {live} 個開いています（上限 {limit}）。ターミナルを整理するか、手動でワークツリーを開いてください",
+    "eventSpawnedSummary": "購読のためエージェントを起動しました",
+    "eventSpawnedDetail": "{name} に未読 {count} 件を届けるためタブを開きました",
     "taskAddSummary": "タスク追加",
     "taskAddDetail": "コード生成中...",
     "taskExecutingSummary": "タスク実行中",

--- a/src/components/FrameContainer.vue
+++ b/src/components/FrameContainer.vue
@@ -13,6 +13,8 @@ const props = defineProps<{
   terminalAgentStatus?: Map<number, boolean>;
   terminalWebSessions?: Map<number, WebSessionInfo>;
   terminalAiSessions?: Map<number, AiSessionInfo>;
+  /** タブ → 未 ack のワークツリーイベント件数（#120 §7） */
+  terminalUnread?: Map<number, number>;
 }>();
 
 const emit = defineEmits<{
@@ -52,6 +54,7 @@ function onResizeEnd(event: { sizes: number[] }) {
     :terminal-agent-status="terminalAgentStatus"
     :terminal-web-sessions="terminalWebSessions"
     :terminal-ai-sessions="terminalAiSessions"
+    :terminal-unread="terminalUnread"
     @switch-terminal="(leafId, terminalId) => emit('switchTerminal', leafId, terminalId)"
     @close-terminal="(leafId, terminalId) => emit('closeTerminal', leafId, terminalId)"
     @title-change="(terminalId, title) => emit('titleChange', terminalId, title)"
@@ -86,6 +89,7 @@ function onResizeEnd(event: { sizes: number[] }) {
         :terminal-agent-status="terminalAgentStatus"
         :terminal-web-sessions="terminalWebSessions"
         :terminal-ai-sessions="terminalAiSessions"
+        :terminal-unread="terminalUnread"
         @switch-terminal="(leafId, terminalId) => emit('switchTerminal', leafId, terminalId)"
         @close-terminal="(leafId, terminalId) => emit('closeTerminal', leafId, terminalId)"
         @title-change="(terminalId, title) => emit('titleChange', terminalId, title)"

--- a/src/components/FramePane.vue
+++ b/src/components/FramePane.vue
@@ -31,6 +31,8 @@ const props = defineProps<{
   terminalAgentStatus?: Map<number, boolean>;
   terminalWebSessions?: Map<number, WebSessionInfo>;
   terminalAiSessions?: Map<number, AiSessionInfo>;
+  /** タブ（フロントの terminalId）→ 未 ack のワークツリーイベント件数（#120 §7） */
+  terminalUnread?: Map<number, number>;
 }>();
 
 const emit = defineEmits<{
@@ -263,6 +265,11 @@ function overlayStyle(zone: DropZone): Record<string, string> {
           @click="emit('switchTerminal', leaf.id, tid)"
         >
           <span class="tab-title">{{ terminalEntries.get(tid)?.title ?? `Terminal ${tid}` }}</span>
+          <!-- 未 ack のワークツリーイベント件数。押し込みや引き継ぎで届いた分が
+               読まれないまま埋もれるのを防ぐ（#120 §7） -->
+          <span v-if="terminalUnread?.get(tid)" class="tab-unread" :title="t('unreadEvents')">
+            {{ terminalUnread.get(tid) }}
+          </span>
           <span
             v-if="terminalAgentStatus?.get(tid)"
             class="pi pi-microchip text-[10px] text-[#a6e3a1] shrink-0"
@@ -396,6 +403,19 @@ function overlayStyle(zone: DropZone): Record<string, string> {
   white-space: nowrap;
 }
 
+.tab-unread {
+  flex-shrink: 0;
+  min-width: 14px;
+  text-align: center;
+  background: #f38ba8;
+  color: #11111b;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  padding: 0 4px;
+  border-radius: 7px;
+}
+
 .tab-close {
   font-size: 10px;
   opacity: 0;
@@ -502,13 +522,15 @@ function overlayStyle(zone: DropZone): Record<string, string> {
     "addTerminal": "Add terminal",
     "noTerminals": "No terminals",
     "openWebSession": "Open web session",
-    "teleportSession": "Teleport (resume locally)"
+    "teleportSession": "Teleport (resume locally)",
+    "unreadEvents": "Unread worktree events"
   },
   "ja": {
     "addTerminal": "ターミナルを追加",
     "noTerminals": "ターミナルがありません",
     "openWebSession": "Webセッションを開く",
-    "teleportSession": "テレポート（ローカルで再開）"
+    "teleportSession": "テレポート（ローカルで再開）",
+    "unreadEvents": "未読のワークツリーイベント"
   }
 }
 </i18n>

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -7,6 +7,7 @@ const { t } = useI18n();
 import WorktreeCard from "./WorktreeCard.vue";
 import TaskCard from "./TaskCard.vue";
 import ArchiveTable from "./ArchiveTable.vue";
+import SubscriptionTable from "./SubscriptionTable.vue";
 import RepositoryPanel from "./RepositoryPanel.vue";
 import HomeCatTerminal from "./HomeCatTerminal.vue";
 import WorkgroupBar from "./WorkgroupBar.vue";
@@ -19,6 +20,15 @@ import { useTaskPersistence } from "../composables/useTaskPersistence";
 import { useTaskSearch } from "../composables/useTaskSearch";
 import { useInfiniteScroll } from "../composables/useInfiniteScroll";
 import { useArchivePersistence, deleteArchive } from "../composables/useArchivePersistence";
+import {
+  agentTerminals,
+  isLoading as subscriptionsLoading,
+  loadSubscriptions,
+  orphanedGroups,
+  rebindGroup,
+  subscriptions,
+  unsubscribe,
+} from "../composables/useEventSubscriptions";
 import { isPseudoWorktree } from "../utils/repositoryWorktree";
 import { computeNaturalCardWidth } from "../utils/cardWidth";
 import { computed, nextTick, reactive, ref, watch } from "vue";
@@ -290,6 +300,8 @@ watch(panelMode, async (mode, oldMode) => {
   } else if (mode === "archive") {
     await loadArchives(true);
     nextTick(() => setupArchiveScroll());
+  } else if (mode === "subscription") {
+    await loadSubscriptions();
   }
 });
 
@@ -371,6 +383,7 @@ watch(
         <option value="worktree">{{ t('worktreeTitle') }}</option>
         <option value="task">{{ t('taskTitle') }}</option>
         <option value="archive">{{ t('archiveTitle') }}</option>
+        <option value="subscription">{{ t('subscriptionTitle') }}</option>
       </select>
       <WorkgroupBar
         v-if="panelMode === 'worktree'"
@@ -555,6 +568,24 @@ watch(
       <div ref="scrollSentinelRef" class="scroll-sentinel">
         <i v-if="isLoading" class="pi pi-spinner pi-spin loading-spinner" />
       </div>
+    </template>
+
+    <!-- 購読パネル（ワークツリー間イベントの購読・未読・引き継ぎ待ち） -->
+    <template v-else-if="panelMode === 'subscription'">
+      <div
+        v-if="subscriptions.length === 0 && orphanedGroups.length === 0 && !subscriptionsLoading"
+        class="empty-state"
+      >
+        {{ t('subscriptionEmpty') }}
+      </div>
+
+      <SubscriptionTable
+        :items="subscriptions"
+        :orphaned-groups="orphanedGroups"
+        :agent-terminals="agentTerminals"
+        @unsubscribe="unsubscribe"
+        @rebind="(p) => rebindGroup(p.worktreeId, p.deadTerminalId, p.sessionId)"
+      />
     </template>
 
     <!-- アーカイブパネル -->
@@ -778,6 +809,8 @@ watch(
     "addTaskButton": "Add task",
     "archiveTitle": "Archives",
     "archiveEmpty": "No archives.",
+    "subscriptionTitle": "Subscriptions",
+    "subscriptionEmpty": "No worktree event subscriptions.",
     "archiveSearchPlaceholder": "Search archives...",
     "repositoryTitle": "Repositories",
     "addRepositoryButton": "Add repository"
@@ -795,6 +828,8 @@ watch(
     "addTaskButton": "タスクを追加",
     "archiveTitle": "アーカイブ",
     "archiveEmpty": "アーカイブがありません。",
+    "subscriptionTitle": "購読",
+    "subscriptionEmpty": "ワークツリーイベントの購読がありません。",
     "archiveSearchPlaceholder": "アーカイブを検索...",
     "repositoryTitle": "リポジトリ",
     "addRepositoryButton": "リポジトリを追加"

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -21,6 +21,7 @@ import { useTaskSearch } from "../composables/useTaskSearch";
 import { useInfiniteScroll } from "../composables/useInfiniteScroll";
 import { useArchivePersistence, deleteArchive } from "../composables/useArchivePersistence";
 import {
+  ackAll,
   agentTerminals,
   isLoading as subscriptionsLoading,
   loadSubscriptions,
@@ -585,6 +586,7 @@ watch(
         :agent-terminals="agentTerminals"
         @unsubscribe="unsubscribe"
         @rebind="(p) => rebindGroup(p.worktreeId, p.deadTerminalId, p.sessionId)"
+        @ack-all="ackAll"
       />
     </template>
 

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -24,6 +24,7 @@ import {
   ackAll,
   agentTerminals,
   isLoading as subscriptionsLoading,
+  lastActionError,
   loadSubscriptions,
   orphanedGroups,
   rebindGroup,
@@ -435,7 +436,8 @@ watch(
             <i class="pi pi-plus"></i>
           </button>
         </template>
-        <template v-else>
+        <!-- アーカイブ検索。`v-else` にすると購読パネルでも出てしまうので種別を明示する -->
+        <template v-else-if="panelMode === 'archive'">
           <div class="task-search">
             <i class="pi pi-search search-icon" />
             <input
@@ -579,6 +581,9 @@ watch(
       >
         {{ t('subscriptionEmpty') }}
       </div>
+
+      <!-- 引き継ぎは候補一覧が古いと正当に失敗する。黙って捨てず理由を出す -->
+      <div v-if="lastActionError" class="subscription-error">{{ lastActionError }}</div>
 
       <SubscriptionTable
         :items="subscriptions"
@@ -793,6 +798,15 @@ watch(
   height: calc(100% - 48px);
   color: #6c7086;
   font-size: 14px;
+}
+
+.subscription-error {
+  margin: 8px 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: #45324a;
+  color: #f38ba8;
+  font-size: 12px;
 }
 </style>
 

--- a/src/components/SubscriptionTable.vue
+++ b/src/components/SubscriptionTable.vue
@@ -36,7 +36,11 @@ const inboxOnlyGroups = computed(() =>
 );
 
 function onRebind(worktreeId: string, deadTerminalId: string, event: Event): void {
-  const sessionId = Number((event.target as HTMLSelectElement).value);
+  const select = event.target as HTMLSelectElement;
+  const sessionId = Number(select.value);
+  // 選択値は毎回プレースホルダへ戻す。引き継ぎに失敗して行が残ったとき、同じ候補を
+  // 選び直しても change が発火せず、二度選び替えないと再試行できなくなるため。
+  select.value = "";
   if (!Number.isFinite(sessionId) || sessionId <= 0) return;
   emit("rebind", { worktreeId, deadTerminalId, sessionId });
 }

--- a/src/components/SubscriptionTable.vue
+++ b/src/components/SubscriptionTable.vue
@@ -1,0 +1,371 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import type { OrphanedGroupView, SubscriptionView } from "../types/event";
+import { HOOK_CAPABLE_AGENT } from "../types/event";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  items: SubscriptionView[];
+  /** 引き継ぎ待ちグループ。購読行が既に消えているもの（対象クローズ後の未読だけ）も含む */
+  orphanedGroups: OrphanedGroupView[];
+  /** 引き継ぎ先の候補: 生存している AI エージェント端末 */
+  agentTerminals: { sessionId: number; worktreeId: string | null; label: string }[];
+}>();
+
+const emit = defineEmits<{
+  unsubscribe: [subscriptionId: string];
+  rebind: [payload: { worktreeId: string; deadTerminalId: string; sessionId: number }];
+}>();
+
+function formatDate(ts: number | null): string {
+  return ts ? new Date(ts).toLocaleString() : "-";
+}
+
+/** そのワークツリーで引き継ぎ先に選べる生存 AI 端末。 */
+function candidatesFor(worktreeId: string) {
+  return props.agentTerminals.filter((c) => c.worktreeId === worktreeId);
+}
+
+/** 引き継ぎ待ちグループのうち、購読行が1つも残っていないもの。
+ *  `worktree.closed` は配送直後に購読行が消えるので、未読だけが宙に浮くこの形が本命。 */
+const inboxOnlyGroups = computed(() =>
+  props.orphanedGroups.filter((g) => g.subscriptions === 0 && g.pending > 0),
+);
+
+function onRebind(worktreeId: string, deadTerminalId: string, event: Event): void {
+  const sessionId = Number((event.target as HTMLSelectElement).value);
+  if (!Number.isFinite(sessionId) || sessionId <= 0) return;
+  emit("rebind", { worktreeId, deadTerminalId, sessionId });
+}
+</script>
+
+<template>
+  <div class="subscription-table-wrapper">
+    <table v-if="items.length > 0" class="subscription-table">
+      <thead>
+        <tr>
+          <th>{{ t('colSubscriber') }}</th>
+          <th>{{ t('colTarget') }}</th>
+          <th>{{ t('colDelivery') }}</th>
+          <th>{{ t('colState') }}</th>
+          <th>{{ t('colUnread') }}</th>
+          <th>{{ t('colCreatedAt') }}</th>
+          <th class="col-actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="item in items" :key="item.id">
+          <td class="cell-name">
+            {{ item.subscriberWorktreeName ?? item.subscriberWorktreeId ?? '-' }}
+            <span v-if="item.subscriberSessionId !== null" class="tab-badge">
+              #{{ item.subscriberSessionId }}
+            </span>
+            <!-- フックは Claude Code 固有。非 CC は Stop 経路が無く PTY 押し込みだけで届く -->
+            <span
+              v-if="item.agentName && item.agentName !== HOOK_CAPABLE_AGENT"
+              class="badge badge-warn"
+              :title="t('nonCcHint')"
+            >{{ item.agentName }} / {{ t('ptyOnly') }}</span>
+            <span v-else-if="item.agentName" class="badge badge-agent">{{ item.agentName }}</span>
+          </td>
+          <td class="cell-target">
+            <span class="branch-badge">{{ item.targetWorktreeName ?? item.targetWorktreeId }}</span>
+            <span v-if="!item.targetWorktreeName" class="badge badge-muted">{{ t('targetClosed') }}</span>
+          </td>
+          <td class="cell-delivery">
+            {{ item.delivery }}
+            <span v-if="item.spawnIfClosed" class="badge badge-spawn" :title="t('spawnHint')">
+              {{ t('spawnIfClosed') }}
+            </span>
+          </td>
+          <td class="cell-state">
+            <template v-if="item.state === 'orphaned'">
+              <span class="badge badge-orphaned" :title="t('orphanedHint')">{{ t('orphaned') }}</span>
+              <select
+                v-if="item.subscriberWorktreeId && candidatesFor(item.subscriberWorktreeId).length > 0"
+                class="rebind-select"
+                :title="t('rebindHint')"
+                @change="onRebind(item.subscriberWorktreeId!, item.subscriberTerminalId, $event)"
+              >
+                <option value="">{{ t('rebindTo') }}</option>
+                <option
+                  v-for="c in candidatesFor(item.subscriberWorktreeId)"
+                  :key="c.sessionId"
+                  :value="c.sessionId"
+                >{{ c.label }}</option>
+              </select>
+            </template>
+            <span v-else class="badge badge-active">{{ t('active') }}</span>
+          </td>
+          <td class="cell-unread">
+            <span v-if="item.unacked > 0" class="unread-badge">{{ item.unacked }}</span>
+            <span v-else class="muted">-</span>
+          </td>
+          <td class="cell-date">{{ formatDate(item.createdAt) }}</td>
+          <td class="cell-actions">
+            <button class="btn-delete" :title="t('unsubscribeTitle')" @click="emit('unsubscribe', item.id)">
+              <span class="pi pi-trash" />
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- 購読行が消えたあとに残った未読（対象クローズ後にアプリを再起動した場合など）。
+         これを出さないと「消えたように見えて実は保持されている」状態が不可視になる。 -->
+    <div v-if="inboxOnlyGroups.length > 0" class="orphan-section">
+      <div class="orphan-title">{{ t('pendingHandover') }}</div>
+      <table class="subscription-table">
+        <thead>
+          <tr>
+            <th>{{ t('colSubscriber') }}</th>
+            <th>{{ t('colUnread') }}</th>
+            <th>{{ t('colOrphanedAt') }}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="g in inboxOnlyGroups" :key="g.terminalId">
+            <td class="cell-name">{{ g.worktreeName ?? g.worktreeId }}</td>
+            <td class="cell-unread"><span class="unread-badge">{{ g.pending }}</span></td>
+            <td class="cell-date">{{ formatDate(g.orphanedAt) }}</td>
+            <td>
+              <select
+                v-if="candidatesFor(g.worktreeId).length > 0"
+                class="rebind-select"
+                :title="t('rebindHint')"
+                @change="onRebind(g.worktreeId, g.terminalId, $event)"
+              >
+                <option value="">{{ t('rebindTo') }}</option>
+                <option v-for="c in candidatesFor(g.worktreeId)" :key="c.sessionId" :value="c.sessionId">
+                  {{ c.label }}
+                </option>
+              </select>
+              <span v-else class="muted">{{ t('noCandidate') }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.subscription-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.subscription-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.subscription-table thead tr {
+  background: #181825;
+  border-bottom: 1px solid #313244;
+}
+
+.subscription-table th {
+  padding: 8px 12px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 600;
+  color: #6c7086;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.subscription-table tbody tr {
+  border-bottom: 1px solid #1e1e2e;
+  transition: background 0.1s;
+}
+
+.subscription-table tbody tr:hover {
+  background: #181825;
+}
+
+.subscription-table td {
+  padding: 9px 12px;
+  color: #cdd6f4;
+  vertical-align: middle;
+}
+
+.cell-name {
+  font-weight: 500;
+}
+
+.branch-badge {
+  font-family: monospace;
+  font-size: 12px;
+  background: #313244;
+  padding: 2px 8px;
+  border-radius: 4px;
+  color: #cdd6f4;
+}
+
+.badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-left: 6px;
+  white-space: nowrap;
+}
+
+.badge-agent {
+  background: #313244;
+  color: #a6e3a1;
+}
+
+.badge-warn {
+  background: #45324a;
+  color: #f9e2af;
+}
+
+.badge-orphaned {
+  background: #45324a;
+  color: #fab387;
+}
+
+.badge-active {
+  background: #313244;
+  color: #89b4fa;
+}
+
+.badge-muted {
+  background: #313244;
+  color: #6c7086;
+}
+
+.badge-spawn {
+  background: #313244;
+  color: #f5c2e7;
+}
+
+.tab-badge {
+  font-family: monospace;
+  font-size: 11px;
+  color: #6c7086;
+  margin-left: 6px;
+}
+
+.unread-badge {
+  display: inline-block;
+  min-width: 18px;
+  text-align: center;
+  background: #f38ba8;
+  color: #11111b;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 9px;
+}
+
+.rebind-select {
+  margin-left: 6px;
+  background: #1e1e2e;
+  color: #cdd6f4;
+  border: 1px solid #313244;
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 1px 4px;
+}
+
+.cell-date {
+  color: #6c7086;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.muted {
+  color: #6c7086;
+}
+
+.orphan-section {
+  margin-top: 18px;
+}
+
+.orphan-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #fab387;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 6px 12px;
+}
+
+.col-actions,
+.cell-actions {
+  width: 40px;
+  text-align: center;
+}
+
+.btn-delete {
+  background: none;
+  border: none;
+  padding: 4px 6px;
+  border-radius: 4px;
+  color: #6c7086;
+  cursor: pointer;
+  font-size: 13px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.btn-delete:hover {
+  color: #f38ba8;
+  background: #313244;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "colSubscriber": "Subscriber",
+    "colTarget": "Target",
+    "colDelivery": "Delivery",
+    "colState": "State",
+    "colUnread": "Unread",
+    "colCreatedAt": "Created",
+    "colOrphanedAt": "Orphaned",
+    "unsubscribeTitle": "Remove subscription",
+    "active": "active",
+    "orphaned": "awaiting handover",
+    "orphanedHint": "The subscribing tab is gone. Messages keep piling up and are handed over to the next AI agent started in the same worktree (kept for 7 days).",
+    "rebindTo": "Hand over to...",
+    "rebindHint": "Hand this subscription and its unread messages over to a live agent tab",
+    "noCandidate": "no live agent tab",
+    "pendingHandover": "Unread messages awaiting handover",
+    "targetClosed": "closed",
+    "ptyOnly": "PTY push only",
+    "nonCcHint": "Only Claude Code has hooks. Other agents have no Stop hook, so messages are delivered by writing into the PTY.",
+    "spawnIfClosed": "auto spawn",
+    "spawnHint": "Starts a new tab with an agent when unread messages pile up and no tab is open"
+  },
+  "ja": {
+    "colSubscriber": "購読者",
+    "colTarget": "購読対象",
+    "colDelivery": "配送戦略",
+    "colState": "状態",
+    "colUnread": "未読",
+    "colCreatedAt": "登録日時",
+    "colOrphanedAt": "待機開始",
+    "unsubscribeTitle": "購読を解除",
+    "active": "有効",
+    "orphaned": "引き継ぎ待ち",
+    "orphanedHint": "購読していたタブがありません。メッセージは溜まり続け、同じワークツリーで次に AI エージェントが立ち上がったときに引き継がれます（7日間保持）",
+    "rebindTo": "引き継ぎ先...",
+    "rebindHint": "この購読と未読メッセージを、生存しているエージェント端末へ引き継ぐ",
+    "noCandidate": "エージェント端末なし",
+    "pendingHandover": "引き継ぎ待ちの未読メッセージ",
+    "targetClosed": "クローズ済み",
+    "ptyOnly": "PTY 押し込みのみ",
+    "nonCcHint": "フックは Claude Code 固有です。他のエージェントには Stop フックが無いため、PTY への押し込みでのみ通知が届きます",
+    "spawnIfClosed": "自動 spawn",
+    "spawnHint": "タブが無い状態で未読が溜まったら、新しいタブを立ててエージェントを起動します"
+  }
+}
+</i18n>

--- a/src/components/SubscriptionTable.vue
+++ b/src/components/SubscriptionTable.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   unsubscribe: [subscriptionId: string];
   rebind: [payload: { worktreeId: string; deadTerminalId: string; sessionId: number }];
+  ackAll: [terminalId: string];
 }>();
 
 function formatDate(ts: number | null): string {
@@ -100,7 +101,16 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
             <span v-else class="badge badge-active">{{ t('active') }}</span>
           </td>
           <td class="cell-unread">
-            <span v-if="item.unacked > 0" class="unread-badge">{{ item.unacked }}</span>
+            <template v-if="item.unacked > 0">
+              <span class="unread-badge">{{ item.unacked }}</span>
+              <button
+                class="btn-ack"
+                :title="t('ackAllTitle')"
+                @click="emit('ackAll', item.subscriberTerminalId)"
+              >
+                <span class="pi pi-check" />
+              </button>
+            </template>
             <span v-else class="muted">-</span>
           </td>
           <td class="cell-date">{{ formatDate(item.createdAt) }}</td>
@@ -304,6 +314,23 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
   text-align: center;
 }
 
+.btn-ack {
+  background: none;
+  border: none;
+  padding: 2px 5px;
+  margin-left: 4px;
+  border-radius: 4px;
+  color: #6c7086;
+  cursor: pointer;
+  font-size: 11px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.btn-ack:hover {
+  color: #a6e3a1;
+  background: #313244;
+}
+
 .btn-delete {
   background: none;
   border: none;
@@ -332,6 +359,7 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
     "colCreatedAt": "Created",
     "colOrphanedAt": "Orphaned",
     "unsubscribeTitle": "Remove subscription",
+    "ackAllTitle": "Mark all unread messages for this tab as read",
     "active": "active",
     "orphaned": "awaiting handover",
     "orphanedHint": "The subscribing tab is gone. Messages keep piling up and are handed over to the next AI agent started in the same worktree (kept for 7 days).",
@@ -354,6 +382,7 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
     "colCreatedAt": "登録日時",
     "colOrphanedAt": "待機開始",
     "unsubscribeTitle": "購読を解除",
+    "ackAllTitle": "このタブの未読をすべて既読にする",
     "active": "有効",
     "orphaned": "引き継ぎ待ち",
     "orphanedHint": "購読していたタブがありません。メッセージは溜まり続け、同じワークツリーで次に AI エージェントが立ち上がったときに引き継がれます（7日間保持）",

--- a/src/composables/useEventSubscriptions.ts
+++ b/src/composables/useEventSubscriptions.ts
@@ -95,9 +95,10 @@ export async function rebindGroup(
   await Promise.all([loadSubscriptions(), loadTerminalUnread()]);
 }
 
-export async function ackMessages(terminalId: string, ids: string[]): Promise<void> {
-  await invoke("event_ack", { terminalId, ids });
-  await Promise.all([loadSubscriptions(), loadTerminalUnread()]);
+/** そのタブの未 ack を全件既読にする。エージェントが ack しないまま忘れた分を人間が畳む。 */
+export async function ackAll(terminalId: string): Promise<void> {
+  await invoke("event_ack_all", { terminalId });
+  await loadSubscriptions();
 }
 
 /** 自動 spawn 要求への応答。**成否にかかわらず必ず呼ぶ**。呼ばないと Rust 側の

--- a/src/composables/useEventSubscriptions.ts
+++ b/src/composables/useEventSubscriptions.ts
@@ -52,8 +52,16 @@ async function safeInvoke<T>(cmd: string, fallback: T, args?: Record<string, unk
   }
 }
 
+/** 読み込み中に来た更新要求。取りこぼすと未読バッジが古いまま固定される
+ *  （`event-inbox-changed` は変化があったときしか飛ばないので自然回復しない）。
+ *  `useArchivePersistence.ts` / `useTaskPersistence.ts` と同じ流儀で1回だけ再実行する。 */
+let pendingReload = false;
+
 export async function loadSubscriptions(): Promise<void> {
-  if (isLoading.value) return;
+  if (isLoading.value) {
+    pendingReload = true;
+    return;
+  }
   isLoading.value = true;
   try {
     subscriptions.value = await safeInvoke<SubscriptionView[]>("event_list_subscriptions", []);
@@ -65,6 +73,11 @@ export async function loadSubscriptions(): Promise<void> {
     await loadTerminalUnread();
   } finally {
     isLoading.value = false;
+  }
+
+  if (pendingReload) {
+    pendingReload = false;
+    await loadSubscriptions();
   }
 }
 
@@ -78,9 +91,27 @@ export async function loadTerminalUnread(): Promise<void> {
   terminalUnread.value = next;
 }
 
-export async function unsubscribe(subscriptionId: string): Promise<void> {
-  await invoke("event_unsubscribe", { subscriptionId });
-  await loadSubscriptions();
+/** 直近の操作エラー。UI が拾ってトーストなどで見せる（握り潰すと黙って失敗する）。 */
+export const lastActionError = ref<string | null>(null);
+
+async function runAction(cmd: string, args: Record<string, unknown>): Promise<boolean> {
+  try {
+    await invoke(cmd, args);
+    lastActionError.value = null;
+    return true;
+  } catch (e) {
+    // `event_rebind_group` は候補一覧が古い（タブが消えた / 別ワークツリーへ移った）と
+    // 正当に失敗する。黙って捨てると「押したのに何も起きない」になる。
+    console.warn(`[event] ${cmd} failed:`, e);
+    lastActionError.value = String(e);
+    return false;
+  } finally {
+    await loadSubscriptions();
+  }
+}
+
+export async function unsubscribe(subscriptionId: string): Promise<boolean> {
+  return runAction("event_unsubscribe", { subscriptionId });
 }
 
 /** 引き継ぎ待ちグループを、人間が選んだ生存タブへ手動で引き継ぐ。
@@ -90,15 +121,13 @@ export async function rebindGroup(
   worktreeId: string,
   deadTerminalId: string,
   sessionId: number,
-): Promise<void> {
-  await invoke("event_rebind_group", { worktreeId, deadTerminalId, sessionId });
-  await Promise.all([loadSubscriptions(), loadTerminalUnread()]);
+): Promise<boolean> {
+  return runAction("event_rebind_group", { worktreeId, deadTerminalId, sessionId });
 }
 
 /** そのタブの未 ack を全件既読にする。エージェントが ack しないまま忘れた分を人間が畳む。 */
-export async function ackAll(terminalId: string): Promise<void> {
-  await invoke("event_ack_all", { terminalId });
-  await loadSubscriptions();
+export async function ackAll(terminalId: string): Promise<boolean> {
+  return runAction("event_ack_all", { terminalId });
 }
 
 /** 自動 spawn 要求への応答。**成否にかかわらず必ず呼ぶ**。呼ばないと Rust 側の

--- a/src/composables/useEventSubscriptions.ts
+++ b/src/composables/useEventSubscriptions.ts
@@ -1,0 +1,128 @@
+import { computed, ref } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type {
+  OrphanedGroupView,
+  SubscriptionView,
+  TerminalUnread,
+} from "../types/event";
+
+/** ワークツリー間イベントの購読状態（issue #120 §7 / #125）。
+ *
+ *  購読・配送を画面に出さないと「勝手にエージェントが動き出した」ように見える。
+ *  特に #125 で再バインド（タブが死んでもアプリを再起動しても購読が生き残り、新しいタブへ
+ *  引き継がれる）が入ったので、どのタブが何を購読していて何件未読なのかが見えないと
+ *  追跡不能になる。
+ *
+ *  モジュールシングルトン（`useArchivePersistence.ts` / `useHomePanel.ts` と同じ流儀）で、
+ *  ホームの購読パネルとタブバーの未読バッジが同じ状態を共有する。 */
+
+export const subscriptions = ref<SubscriptionView[]>([]);
+export const orphanedGroups = ref<OrphanedGroupView[]>([]);
+/** pty session_id → 未 ack 件数。タブバーのバッジが引く */
+export const terminalUnread = ref<Map<number, number>>(new Map());
+/** 生存中の全端末（引き継ぎ先候補の解決に使う） */
+export const liveTerminals = ref<TerminalUnread[]>([]);
+export const isLoading = ref(false);
+
+/** 手動引き継ぎの候補: 生存している AI エージェント端末。 */
+export const agentTerminals = computed(() =>
+  liveTerminals.value
+    .filter((tm) => tm.isAiAgent)
+    .map((tm) => ({
+      sessionId: tm.sessionId,
+      worktreeId: tm.worktreeId,
+      label: `#${tm.sessionId} ${tm.agentName ?? ""}`.trim(),
+    })),
+);
+
+/** 未 ack の総数（トレイ / ホームの見出し用）。 */
+export const totalUnacked = computed(() =>
+  subscriptions.value.reduce((sum, s) => sum + s.unacked, 0),
+);
+
+/** イベント DB が未初期化のときは全コマンドが Err を返す。購読機能だけが無効な状態なので
+ *  UI 全体を壊さず空表示にする。 */
+async function safeInvoke<T>(cmd: string, fallback: T, args?: Record<string, unknown>): Promise<T> {
+  try {
+    return await invoke<T>(cmd, args);
+  } catch (e) {
+    console.warn(`[event] ${cmd} failed:`, e);
+    return fallback;
+  }
+}
+
+export async function loadSubscriptions(): Promise<void> {
+  if (isLoading.value) return;
+  isLoading.value = true;
+  try {
+    subscriptions.value = await safeInvoke<SubscriptionView[]>("event_list_subscriptions", []);
+    orphanedGroups.value = await safeInvoke<OrphanedGroupView[]>(
+      "event_list_orphaned_groups",
+      [],
+    );
+    // 引き継ぎ先の候補は端末側の情報から引くので一緒に更新する
+    await loadTerminalUnread();
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+export async function loadTerminalUnread(): Promise<void> {
+  const rows = await safeInvoke<TerminalUnread[]>("event_terminal_unread", []);
+  liveTerminals.value = rows;
+  const next = new Map<number, number>();
+  for (const row of rows) {
+    if (row.unacked > 0) next.set(row.sessionId, row.unacked);
+  }
+  terminalUnread.value = next;
+}
+
+export async function unsubscribe(subscriptionId: string): Promise<void> {
+  await invoke("event_unsubscribe", { subscriptionId });
+  await loadSubscriptions();
+}
+
+/** 引き継ぎ待ちグループを、人間が選んだ生存タブへ手動で引き継ぐ。
+ *  自動の引き継ぎは「新しい AI タブ1つにつき1グループ」なので、前回より少ないタブしか
+ *  開かなかった場合にグループが取り残される。その解消手段。 */
+export async function rebindGroup(
+  worktreeId: string,
+  deadTerminalId: string,
+  sessionId: number,
+): Promise<void> {
+  await invoke("event_rebind_group", { worktreeId, deadTerminalId, sessionId });
+  await Promise.all([loadSubscriptions(), loadTerminalUnread()]);
+}
+
+export async function ackMessages(terminalId: string, ids: string[]): Promise<void> {
+  await invoke("event_ack", { terminalId, ids });
+  await Promise.all([loadSubscriptions(), loadTerminalUnread()]);
+}
+
+/** 自動 spawn 要求への応答。**成否にかかわらず必ず呼ぶ**。呼ばないと Rust 側の
+ *  単一フライトが 60 秒間解放されない（逆に、呼ばなくても撃ち直しループにはならない）。 */
+export async function reportSpawnResult(
+  requestId: string,
+  sessionId: number | null,
+): Promise<void> {
+  try {
+    await invoke("event_spawn_result", { requestId, sessionId });
+  } catch (e) {
+    console.warn("[event] event_spawn_result failed:", e);
+  }
+}
+
+let initialized = false;
+
+/** inbox / 購読の変化を購読して一覧と未読件数を同期する。App.vue から一度だけ呼ぶ。
+ *  メインウィンドウはアプリと寿命を共にするので unlisten は保持しない
+ *  （App.vue の他のグローバルリスナーと同じ扱い）。 */
+export async function initEventSubscriptions(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+  await listen("event-inbox-changed", () => {
+    void loadSubscriptions();
+  });
+  await loadSubscriptions();
+}

--- a/src/composables/useHomePanel.ts
+++ b/src/composables/useHomePanel.ts
@@ -1,8 +1,8 @@
 import { ref } from "vue";
 
-export type HomePanelMode = "worktree" | "task" | "archive";
+export type HomePanelMode = "worktree" | "task" | "archive" | "subscription";
 
-/** ホームタブのパネル表示モード（worktree 一覧 / task / archive）。
+/** ホームタブのパネル表示モード（worktree 一覧 / task / archive / subscription）。
  *  HomeView がローカルに持っていた状態を、App.vue 等からも参照できるようモジュールシングトンとして共有する。 */
 const panelMode = ref<HomePanelMode>("worktree");
 

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,86 @@
+/** ワークツリー間イベントの購読・配送（issue #120 / #125）に関する型。
+ *  Rust 側の `event_delivery.rs` の `SubscriptionView` / `OrphanedGroupView` /
+ *  `TerminalIdEntry` と 1:1 で対応する（`serde(rename_all = "camelCase")`）。 */
+
+/** Claude Code 以外のエージェントは Stop フック経路が存在せず、PTY 押し込みでしか
+ *  通知を受け取れない（#120 §5.7）。UI ではこれで区別する。 */
+export const HOOK_CAPABLE_AGENT = "claude";
+
+/** 購読一覧の1行。 */
+export interface SubscriptionView {
+  id: string;
+  /** 購読者タブ（PTY spawn 時に発番される UUID） */
+  subscriberTerminalId: string;
+  subscriberWorktreeId: string | null;
+  subscriberWorktreeName: string | null;
+  /** 購読者タブが生存していれば PTY セッション ID。null なら引き継ぎ待ち */
+  subscriberSessionId: number | null;
+  /** "claude" / "gemini" / "codex" / "cline"。null は AI エージェント未検出 */
+  agentName: string | null;
+  targetWorktreeId: string;
+  /** クローズ済みの対象は null になる */
+  targetWorktreeName: string | null;
+  eventKinds: string[];
+  /** "turn_end" | "interrupt" | "passive" */
+  delivery: string;
+  spawnIfClosed: boolean;
+  /** "active" | "orphaned" */
+  state: string;
+  createdAt: number;
+  expiresAt: number | null;
+  orphanedAt: number | null;
+  unacked: number;
+  undelivered: number;
+}
+
+/** 引き継ぎ待ちの1グループ（死亡した1タブが残した購読と未読）。 */
+export interface OrphanedGroupView {
+  terminalId: string;
+  worktreeId: string;
+  worktreeName: string | null;
+  orphanedAt: number;
+  subscriptions: number;
+  pending: number;
+}
+
+/** タブごとの未読件数（タブバーのバッジ用）。 */
+export interface TerminalUnread {
+  sessionId: number;
+  terminalId: string;
+  agentName: string | null;
+  worktreeId: string | null;
+  worktreeName: string | null;
+  isAiAgent: boolean;
+  unacked: number;
+}
+
+/** 配送トーストのペイロード（Rust の `event-delivered`）。 */
+export interface DeliveredPayload {
+  terminalId: string;
+  sessionId: number;
+  worktreeId: string | null;
+  worktreeName: string | null;
+  agentName: string | null;
+  count: number;
+  text: string;
+  method: string;
+}
+
+/** 端末数上限で自動 spawn を拒否したときの通知（Rust の `event-spawn-rejected`）。 */
+export interface SpawnRejectedPayload {
+  worktreeId: string;
+  worktreeName: string;
+  liveSessions: number;
+  limit: number;
+  pending: number;
+}
+
+/** 自動 spawn 要求（Rust の `event-spawn-terminal`）。フロントはタブを作り、
+ *  成否にかかわらず `event_spawn_result` で応答しなければならない。 */
+export interface SpawnTerminalRequest {
+  requestId: string;
+  worktreeId: string;
+  worktreeName: string;
+  command: string;
+  pending: number;
+}


### PR DESCRIPTION
Closes #125 （親: #120 Phase 3）

## 概要

**購読と未読メッセージがアプリ再起動とタブ死亡を越えて生き残り、新しいタブへ再バインドされる**ようにする。加えて待機中エージェントへの PTY 押し込み、`spawn_if_closed`、暴走防止、自動承認との組み合わせ制限、可視化 UI を入れる。

Phase 1 (#128) は起動時に `purge_orphaned_subscribers(&pool, &[])` を呼んでおり、**起動時点で PTY セッションがゼロなので購読と inbox が毎回無条件で全消去**されていた。結果この機能は「同じアプリ起動セッション中に close を待つ」ケースしか満たさず、#120 の動機②（数時間〜数日スパンで別リポジトリの対応クローズを検知する）も §4 の「SessionStart でアプリ停止中に溜まった分を回収」も成立していなかった。本 PR の中心はここ。

## 設計上の発見: 再バインドの駆動元は購読ではなく inbox

`fire_worktree_closed` は `fanout` の直後に `delete_subscriptions_for_target` を呼ぶ（クローズ済み worktree ID は二度とマッチしないため。正しい）。結果 **`worktree.closed` では購読行が配送直後に必ず消える**（`event_db.rs` の `test_roundtrip_delete_subscriptions_for_target` が明示している）。

つまり「待っていた対象がクローズされてから再起動を挟んだ」という本命シナリオでは orphaned な*購読*は存在せず、残っているのは **inbox 行だけ**。購読テーブル起点の再バインドでは何も回収できない。`inbox` にも `orphaned_at` を持たせ、既存の `subscriber_worktree_id`（`idx_inbox_worktree` 済み）を鍵に引き継ぐ。`delivery` / `spawn_if_closed` も積んだ時点の値を inbox に焼き付ける（購読行が先に消えるので後から参照できない）。

## 判断

| 論点 | 判断 |
|---|---|
| 起動時の掃除 | 全削除をやめ `state='orphaned'` + `orphaned_at` へ遷移させて保持する |
| `fanout` の対象 | `state IN ('active','orphaned')`。**orphaned = 積むのは続ける / 押し込みだけ止める**。active 限定にすると「タブが死んでいた間に届いたイベント」が永久に失われ、動機そのものが壊れる |
| 保持期限 | active な購読は**無期限のまま**（#120 本文どおり）。orphaned に落ちてから **7日**で削除。`orphaned_at` は `WHERE state='active'` ガード付きで打つので、再起動のたびに 7日クロックがリセットされることはない |
| 再バインドの粒度 | **死亡タブ単位で1グループずつ**（#120 §2 の「A タブ宛を B タブが抜き取らない」原則）。順序は `orphaned_at DESC, created_at DESC, terminal_id ASC` の安定な全順序（起動時は全グループが同じ `orphaned_at` になるため tie-break 必須）。引き継がれずに残ったグループは UI に出し、人間が任意のタブへ手動で引き継げる |
| 走行中 (busy) への押し込み | 押し込まない。ターン境界配送は #124 の担当。#124 未実装の間、busy 宛は tick での再評価 / SessionStart 回収 / `oretachi_poll_inbox` に落ちる |
| 深度 / TTL / origin | 入れた。現状 `worktree.closed` 一種のみで循環経路は無いが、#125 本文が「後付けにしない」と明示しているためカラム3本 + `fanout` の1ガードという最小形で先に入れる |

## 変更内容

### 1. `event_db.rs` — orphaned と再バインド

- `subscriptions.orphaned_at` / `inbox.orphaned_at` / `inbox.delivery` / `inbox.spawn_if_closed` / `events.depth` / `events.origin` を追加（既存 DB は `ALTER TABLE` 握り潰し）
- `mark_orphaned_subscribers` — 削除ではなく `orphaned` へ遷移。`subscriber_worktree_id IS NULL` の行だけは引き継ぎ先を解決できないので削除する（現行 `subscribe` は `Some` を強制するので実質レガシー行のみ）
- `list_orphaned_groups` / `rebind_orphaned_group` / `rebind_next_orphaned_group` / `purge_orphaned_expired`
- `rebind_orphaned_group` は **1トランザクション**。分割すると隙間に走った `fanout`（orphaned にも積む）が死んだ terminal_id 宛の行を差し込んで取り残す。2つの UNIQUE 制約とは `UPDATE OR IGNORE` + 残骸 `DELETE` で衝突解決し、**孤児側を捨てるのが両方向で正しい**ことをコメントとテストで固定した
- `sanitize_for_pty` / `format_inbox_push_text` — 押し込み用の1行テキスト
- `purge_orphaned_subscribers` は呼び出し元が無くなったので削除（役割は `mark_orphaned_subscribers` が引き継いだ）

### 2. `pty_manager.rs` — 走行中 / 待機中の判定

- `get_claude_session_id_by_pid` を `read_claude_session_file` に拡張し `status`（`busy` / `idle`）も読む
- `PtySession` / `SessionInfo` に `agent_status` / `agent_status_sampled_at` / `output_quiescent` を追加。10秒ポーリングで更新する
- 鮮度はファイル側の `statusUpdatedAt` ではなく**こちらがサンプルした時刻**で見る。長いターンは正当に古い `busy` を残すので、ファイル側の古さを「不明」と解釈すると押してはいけない場面で押すことになる
- 各 tick で生存 `terminal_id` を配送ワーカーへ渡し、`is_ai_agent` が false→true になったタブから引き継ぎを要求する。**この経路は hook に依存しない**ので、非 CC エージェントでもユーザーが手で `claude` と打った場合でも再バインドが効く

### 3. `event_delivery.rs`（新規）— 直列キューと配送

**単一のワーカータスク**が再バインド・押し込み・spawn を順に処理する。これが #125 §3 の「宛先ごとの直列キュー」の実体で、宛先ごとより強い保証になる（ポーリングスレッド / `/session-context`（axum）/ MCP ツールハンドラが同時に再バインドを要求しても SELECT→UPDATE がインターリーブしない）。

| 受信側 | 動作 |
|---|---|
| 生存 CC + `idle` + 静穏 | ブラケットペーストで PTY 押し込み |
| 生存 CC + `busy` / 不明 / サンプルが古い | 押し込まない（#124 の担当。次 tick で再評価） |
| 生存 非 CC エージェント | 押し込み。`status` の取得元が存在せず busy/idle 判定不能 —— **仕様として明記し UI でも区別する** |
| 生存タブ・エージェント無し | 押し込まない（素のシェルに CR を撃たない）。`spawn_if_closed` なら spawn |
| タブ不在（orphaned） | `spawn_if_closed` なら spawn、false なら保留 |

ガード: 宛先ごとの最小押し込み間隔 30 秒 / 押し込み TTL 10 分（古いイベントで一斉に割り込まない。inbox には残るので poll では取れる）/ `pty.write` が成功してから `mark_delivered`（捨てられた押し込みを配送済みにしない）。

**自動承認との組み合わせ（#120 §5.5）**: 宛先の `autoApproval` が有効なら押し込み / spawn を許すのは定型イベント（`worktree.closed`）のみ。自由文（`worktree.message`, #126）は押し込まず inbox に残して人間の確認を要求する。現時点では許可集合と対応集合が一致するため挙動は変わらないが、**#126 で自由文が入った瞬間に default-deny になる**のが目的。注入文字列は必ず `sanitize_for_pty` を通す（こちらは今日から実効性のある防御）。

**spawn_if_closed は完了応答つき**: 素朴に `mcp-spawn-terminal` を撃つと完了信号が無く新しい `terminal_id` も分からないため、tick ごとに再 spawn する無限ループ（＝ webview ハングへの直行便）になる。フロントが `event_spawn_result(request_id, session_id?)` で**成否にかかわらず**応答し、Rust が `session_id → terminal_id` を解決して引き継ぐ。加えてワークツリーごとの単一フライト（60秒タイムアウト）と生存端末数の上限（12）を入れた。

### 4. UI（#120 §7）

- ホームに「購読」パネルを追加（`ArchiveTable.vue` と同型。`HomePanelMode` に `subscription` を追加）。購読者 / 対象 / 配送戦略 / 状態 / 未読 / 操作（解除・引き継ぎ・既読）
  - **非 CC エージェントの行には「PTY 押し込みのみ (Stop 非対応)」バッジ**
  - `orphaned` の行には「引き継ぎ待ち」バッジと引き継ぎ先セレクタ
  - 購読行が消えた後に残った未読（本命シナリオ）は別テーブルで出す。出さないと「消えたように見えて実は保持されている」状態が不可視になる
- 配送トースト（`event-delivered`）、自動 spawn 拒否の通知（`event-spawn-rejected`）
- タブバーの未読バッジ（`FramePane.vue`。既存の `terminalAgentStatus` / `terminalExitCodes` と同型の `Map<number, number>` prop）

フロントは `terminal_id` を知る手段が無かった（`pty_spawn` は `u32` しか返さない）ため、`event_terminal_unread` が `session_id → terminal_id` の突合を返す。

## テスト

- `cd src-tauri && cargo check` / `cargo test` ✅ **147 件**（`event_db` に再バインド・保持期限系 20 件、`event_delivery` に押し込み判定 13 件を追加）
- `cargo test -p oretachi-notify` ✅ 31 件
- `pnpm run type-check` ✅

主なテスト:
- `test_rebind_recovers_inbox_without_subscription` — 本 PR の核心。subscribe → fanout → `delete_subscriptions_for_target` → 再起動相当 → 引き継ぎで未読が回収される
- `test_roundtrip_mark_orphaned_at_startup_keeps_everything` — Phase 1 が全削除していた箇所が1行も消さないこと
- `test_fanout_delivers_to_orphaned_subscription` — orphaned でも積み続け、引き継ぎ後に押し込み対象になること
- `test_rebind_claims_one_group_at_a_time` / `test_rebind_*_unique_conflict_*` — 引き継ぎ粒度と2つの UNIQUE 制約の衝突解決
- `test_fanout_stamps_inbox_with_arrival_time_not_subscription_time` — 引き継ぎ待ちへ後から届いた分の保持期限
- `test_format_inbox_push_text_reports_only_what_fits` — 長さ上限で載らなかった分を配送済みにしないこと
- `test_sanitize_for_pty_strips_escape_sequences` — ブランチ名に `ESC[201~` を埋め込んでもブラケットペーストを脱出できないこと

## 実機確認

本番 oretachi を止めずに dev ビルド（`mcpPort` を一時的に 9161 へ、MCP は node の raw JSON-RPC）で検証した。使い捨てワークツリー（oretachi の throwaway ブランチ）を3本作って確認し、終了後に設定・git ワークツリー・ブランチはすべて元に戻している。

- **再起動越え（本 PR の主目的）**: 購読 → dev 再起動 → ログ `前回起動分を引き継ぎ待ちにした subscriptions=1 inbox=0` を確認し、`events.db` に `state='orphaned'` で残存。Phase 1 では `DELETE FROM subscriptions WHERE 1=1` で消えていた行
- **再バインド**: 再起動後に同じワークツリーで `claude` を起動 → **12 秒後**に `state='active'` かつ `subscriber_terminal_id` が新 ID へ。**hook を介さないポーリング経路**で成立している（非 CC エージェントや手動 `claude` でも効く）
- **購読行が消えた後の未読の回収**: `引き継ぎ完了 … 購読=0 未読=2` を確認（`worktree.closed` の本命ケース）
- **待機中への押し込み**: `worktree.closed` → `待機中のエージェントへ 1 件を押し込んだ` → CC の `status` が `idle` → `busy` に遷移しターン開始。入力欄が空になりエージェントが着手することを目視
- **出力静穏ガードと再評価**: 出力が動いている間は `押し込みを見送る … 理由=出力が動いている` で見送り、次 tick で押し込まれることを確認
- **`~/.claude/sessions/<pid>.json` の `status`**: `busy` / `idle` が実値で取れることを確認

### 実機で見つけて直した2件

1. **`ESC[200~…ESC[201~\r` を1回の write で送るとターンが始まらない。** ペースト終端と同じ読み取りチャンクに来た CR を Claude Code がペーストの一部として扱い、本文が入力欄に残ったままになる。ペーストと Enter を別の write に分け 150ms 空けることで確実に送信されるようにした
2. **定期 tick が永久に発火しない。** ポーリングスレッドが 10 秒ごとに `Reconcile` を送るため、`timeout(30s, rx.recv())` の Err 分岐に頼ると毎回タイムアウトがリセットされる。経過時間で判定するように変更（busy / 出力継続で見送った宛先の再評価が効かない状態だった）

### 持ち越し事項の決着: `oretachi_list_terminals` の `agentSessionId`

#122 → #123 と3回持ち越されていた「`agentSessionId` が実値で返るか未検証」を切り分けた。**pid 解決は正しい。**

- `find_ai_agent_in_subtree`（depth 4）が返す pid は実際の `claude.exe`（`oretachi.exe → powershell.exe → claude.exe` の depth 1）で一致することを確認
- `null` になっていた原因は **`CLAUDE_CODE_CHILD_SESSION` の継承**。dev ビルドを Claude Code のセッション内から `pnpm run tauri dev` で起動していたため、その配下の CC が子セッション扱いになり `~/.claude/sessions/<pid>.json` を書かない（端末に `Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker` と表示される）。#127 の検証時も同じ条件だった
- 端末で `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` を立てると `agentSessionId` は実値（`a715723d-…`）で返る。**通常起動の oretachi では再現しない検証環境固有の事象**

本 PR の `status` 判定も同じファイルに依存するが、取れない場合は「状態が不明」として押し込みを見送るだけなので、SessionStart 回収 / `oretachi_poll_inbox` に劣化するのみで取りこぼしにはならない。

## セルフレビュー

CLAUDE.md の `codex-review` を実行したが `Your workspace is out of credits` で実行できなかった（#127 と同じ）。代わりに `/bug-review` + バリデータサブエージェントによる再検証で代替し、warning 11 件を自己指摘して全件対応した。主なもの:

- `delivery=passive` の inbox を、同じタブの他戦略に巻き込んで押し込んでいた
- `fanout` が inbox に購読側の `orphaned_at` を継承させており、**引き継ぎ待ちの購読へ後から届いたメッセージが保持期限まで数時間しか残らない**（引き継ぎ順序でも最後尾に回る）。本命シナリオを直撃する
- 押し込み本文の長さ上限（600 字）で切り落とされた分まで `mark_delivered` しており、「再送しない」方針のせいで二度と本文が出なくなっていた
- 古い生存一覧で誤って `orphaned` に落ちた**生存タブ**を `active` に戻す道が無く、引き継ぎ対象からも押し込み対象からも永久に外れうる状態だった（`rebind_next_orphaned_group` は自分自身のグループを除外するため自力では戻れない）
- spawn したタブでエージェントが起動しない（`claude` が PATH に無い等）と tick ごとに再 spawn し、端末数上限まで壊れたタブを積み増していた → ワークツリーごとの 10 分クールダウンを追加
- `resolve_subscriber` 由来の引き継ぎが購読系ツールの呼び出しごとに発火するため、`oretachi_poll_inbox` を数回叩くだけで1タブが全グループを吸い上げ、「1タブ1グループ」の不変条件が崩れていた
- 出力継続中の押し込み抑止が Claude Code の `turn_end` にしか効いておらず、非 CC / `interrupt` では人間の入力行を壊しうる → 種別より優先する位置へ移動
- 同一 tick で複数ワークツリーが spawn 候補になると端末数上限を素通りしていた
- MCP の `ack` 後に `event-inbox-changed` を出しておらず、正常系（押し込み → エージェントが ack）でタブの未読バッジが消えなかった
- 手動引き継ぎ先のワークツリーをバックエンドで検証しておらず、フロントの候補リストが古いと別ワークツリーのタブへ渡り、以後その行が**実際の宛先ではない**ワークツリーの `autoApproval` 設定で判定されうる道が開いていた

### 既知の限界（対応せず記録）

`output_quiescent`（直前 tick から PTY 出力が増えていない）は「入力欄が空」を意味しない。**入力欄に途中まで打ったまま人間が席を外すと、書きかけの指示に通知本文が連結されて確定送信されうる。** PTY 押し込みという手段に内在する制約で、`status=idle` + 出力静穏が現状取れる最良の信号。#124（Stop フックによるターン境界配送）が入れば `turn_end` の主経路はそちらへ移り、この窓は狭まる。

## 残件

タブ未読バッジ・配送トーストのサブウィンドウ / トレイ対応は #130 として切り出し、#120 の sub-issue に紐づけた（`SubWindowApp.vue` / `TrayPopupApp.vue` に `<Toast>` outlet が無く、`terminal-unread` prop も渡していない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
