### PR TITLE
feat(event): Stop フックによるターン境界配送 + UserPromptSubmit での取りこぼし回収 (#124)

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,13 @@ MCP_SERVER_ENABLED=true
 ORETACHI_DEBUG=false
 ORETACHI_FORCE_WIZARD=false
 ORETACHI_PLUGIN_OVERWRITE=true
+
+# 別ワークツリーで dev ビルドを同時に立ち上げるときのポート退避（#124）。
+# 空 = 既定値を使う（＝未設定と同じ）。値を入れるのは dev の並走時だけでよい。
+#   ORETACHI_MCP_PORT       MCP サーバー。既定は settings.json の mcpPort（本番と共有なので奪い合う）
+#   ORETACHI_TAURI_MCP_PORT tauri-mcp プラグイン。既定 4000。衝突すると起動が panic する（debug のみ）
+#   ORETACHI_DEV_PORT       vite。既定 1420。HMR が +1 を使うので複数立てるときは 2 以上離すこと
+# ※ mcp-server.json を奪わずに並走させるには MCP_PORT_OVERWRITE=false と併用する
+ORETACHI_MCP_PORT=
+ORETACHI_TAURI_MCP_PORT=
+ORETACHI_DEV_PORT=

--- a/src-tauri/notify/src/main.rs
+++ b/src-tauri/notify/src/main.rs
@@ -15,8 +15,11 @@
 //     (SessionStart フック用。/session-context からワークツリー所属グループの systemPrompt を
 //      取得し、SessionStart 用 JSON として stdout に出力する。失敗時は何も出力せず exit 0)
 //   oretachi-notify --prompt-context --project-dir "<dir>"
-//     (UserPromptSubmit フック用。/prompt-context から現在の description を取得し、
+//     (UserPromptSubmit フック用。/prompt-context から現在の description と未読を取得し、
 //      additionalContext JSON を stdout に出力して Claude のコンテキストに注入する)
+//   oretachi-notify --turn-context --project-dir "<dir>"
+//     (Stop フック用。stdin の Stop hook JSON を /turn-context へ転送し、このタブ宛の未読を
+//      additionalContext として stdout に出力する。会話が継続してエージェントが着手する)
 //
 // hook からは userConfig ではなく CC 組み込み変数 ${CLAUDE_PROJECT_DIR} が --project-dir に渡る。
 // 未置換/空の場合はプロセスの current_dir (hook は worktree ディレクトリで実行される) にフォールバック。
@@ -95,6 +98,29 @@ fn main() {
         std::process::exit(0);
     }
 
+    // Stop フック (--turn-context): /turn-context からこのタブ宛の未読を取得し、
+    // additionalContext JSON を stdout に出力する（#124）。Stop の additionalContext は
+    // 会話を継続させるので、未読が無ければ何も出さない（＝そのままターンが終わる）。
+    // --prompt-context と同じく、失敗しても何も出力せず必ず exit 0 する。
+    if has_flag(&args, "--turn-context", "-t") {
+        let dir = resolve_project_dir(&args);
+        let hook_json = read_stdin_if_piped();
+        // 継続ターンの終わりならサーバを起こさずに終わる。サーバ側でも同じ判定をするが、
+        // 無駄な TCP 往復（と 2 秒の読み取り待ち）を hook のクリティカルパスから消す。
+        if !should_request_turn_context(hook_json.as_deref()) {
+            std::process::exit(0);
+        }
+        match send_turn_context(&dir, hook_json.as_deref()) {
+            Ok(Some(output)) => println!("{}", output),
+            Ok(None) => {}
+            Err(_e) => {
+                #[cfg(debug_assertions)]
+                eprintln!("Turn context failed: {}", _e);
+            }
+        }
+        std::process::exit(0);
+    }
+
     // 通知 (--notify): stdin(hook JSON) を body として /notify へ送る。
     // ワークツリー名と kind はサーバー側で project-dir / event から解決する。
     if has_flag(&args, "--notify", "-n") {
@@ -112,7 +138,7 @@ fn main() {
     }
 
     #[cfg(debug_assertions)]
-    eprintln!("Usage: oretachi-notify --notify --project-dir <dir> --event <Event> [--agent <agent>]\n       oretachi-notify --set-description --project-dir <dir>\n       oretachi-notify --session-context --project-dir <dir>\n       oretachi-notify --prompt-context --project-dir <dir>");
+    eprintln!("Usage: oretachi-notify --notify --project-dir <dir> --event <Event> [--agent <agent>]\n       oretachi-notify --set-description --project-dir <dir>\n       oretachi-notify --session-context --project-dir <dir>\n       oretachi-notify --prompt-context --project-dir <dir>\n       oretachi-notify --turn-context --project-dir <dir>");
     std::process::exit(2);
 }
 
@@ -276,6 +302,55 @@ fn send_prompt_context(project_dir: &str) -> Result<Option<String>, String> {
     Ok(build_prompt_context_output(&body))
 }
 
+/// Stop フック用。/turn-context からこのタブ宛の未読を取得し、stdout に出力すべき
+/// additionalContext JSON を返す。未読なしは Ok(None)。
+fn send_turn_context(project_dir: &str, hook_json: Option<&str>) -> Result<Option<String>, String> {
+    let mut payload = serde_json::json!({
+        "projectDir": project_dir,
+    });
+    attach_terminal_id(&mut payload, read_terminal_id().as_deref());
+    if let Some(j) = hook_json {
+        payload["hookJson"] = serde_json::Value::String(j.to_string());
+    }
+    let body = post_json_read_body("/turn-context", &payload)?;
+    Ok(build_turn_context_output(&body))
+}
+
+/// Stop フックの stdin JSON を見て、サーバへ問い合わせるべきか判定する（#124）。
+///
+/// `stop_hook_active` は「この Stop が hook 由来の継続ターンの終わりか」を CC が明示的に
+/// 教えてくれるフィールド（Phase 0 / #121 で CC 2.1.227 の payload に実在することを実測）。
+/// 初回発火は `false`、`additionalContext` による継続後の発火はすべて `true`。
+/// **`true` のときに注入すると会話が永久に回る**ので問い合わせ自体をやめる。
+///
+/// stdin が無い / パースできない / フィールドが無い場合は `true`（問い合わせる）に倒す。
+/// サーバ側でも同じ判定をしており、さらに `prompt_id` 単位の上限と `delivered_at` が
+/// あるので、ここで安全側に倒しても暴走はしない。
+fn should_request_turn_context(hook_json: Option<&str>) -> bool {
+    let Some(v) = hook_json.and_then(|j| serde_json::from_str::<serde_json::Value>(j).ok()) else {
+        return true;
+    };
+    v.get("stop_hook_active").and_then(|b| b.as_bool()) != Some(true)
+}
+
+/// /turn-context のレスポンスボディから Stop 用の additionalContext JSON を組み立てる。
+/// 未読なし・parse 失敗時は None（何も出力しない ＝ そのままターンが終わる）。
+fn build_turn_context_output(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    let inbox = v
+        .get("inbox")
+        .and_then(|i| i.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    let output = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "Stop",
+            "additionalContext": inbox,
+        }
+    });
+    Some(output.to_string())
+}
+
 /// SessionStart 用の additionalContext JSON を組み立てる。
 /// グループの systemPrompt と、自分が属するタブの terminal_id を続けて注入する。
 /// terminal_id を伝えるのは、エージェントが oretachi_list_terminals 等で
@@ -315,26 +390,47 @@ fn build_session_context_output(
 }
 
 /// /prompt-context のレスポンスボディから UserPromptSubmit 用の
-/// additionalContext JSON を組み立てる。skip / parse 失敗時は None。
+/// additionalContext JSON を組み立てる。parse 失敗時と、出すものが何も無ければ None。
+///
+/// `skip` は **description 側だけ**を支配する（#124）。未読の回収は 600 秒スロットルの
+/// 対象外なので、`skip: true` でも `inbox` があれば出力する。`inbox` フィールドを返さない
+/// 旧サーバとの後方互換は「欠落 = None」で担保する。
 fn build_prompt_context_output(body: &str) -> Option<String> {
     let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    let inbox = v
+        .get("inbox")
+        .and_then(|i| i.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
     if v["skip"].as_bool() == Some(true) {
-        return None;
+        // description はスロットル中。未読だけを注入する。
+        let inbox = inbox?;
+        return Some(prompt_context_json(inbox));
     }
-    let context = match v["description"].as_str().map(str::trim).filter(|s| !s.is_empty()) {
+    let description = match v["description"].as_str().map(str::trim).filter(|s| !s.is_empty()) {
         Some(desc) => format!(
             "[oretachi] このワークツリーの現在の description: 「{}」。これは作業全体の目的を表す1行です。今の作業がこの説明の範囲内（同一プランのサブタスク進行・レビュー対応など）なら更新は不要です。全く別の作業に切り替わった場合、または説明が実態と大きくずれている場合のみ oretachi_set_description ツールで更新してください。",
             desc
         ),
         None => "[oretachi] このワークツリーの description は未設定です。作業内容が決まっていれば oretachi_set_description ツールで作業全体の目的を1行でセットしてください。".to_string(),
     };
-    let output = serde_json::json!({
+    // 未読を後ろに置くのは、それが「今このターンで着手すべきこと」であり
+    // 前段の description より新しい指示だから（build_session_context_output と同じ順序）。
+    let context = match inbox {
+        Some(i) => format!("{}\n\n{}", description, i),
+        None => description,
+    };
+    Some(prompt_context_json(&context))
+}
+
+fn prompt_context_json(context: &str) -> String {
+    serde_json::json!({
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
             "additionalContext": context,
         }
-    });
-    Some(output.to_string())
+    })
+    .to_string()
 }
 
 /// post_json と同様に POST し、レスポンスボディまで読んで返す。
@@ -643,6 +739,119 @@ mod tests {
     #[test]
     fn test_build_prompt_context_output_skip() {
         assert_eq!(build_prompt_context_output(r#"{"skip":true}"#), None);
+    }
+
+    /// Phase 0 (#121) で実測した Stop payload そのもの。初回発火は stop_hook_active=false。
+    const STOP_PAYLOAD: &str = r#"{
+        "session_id": "bcbd95af-3066-4bc9-9b6b-98fabdd3ef8b",
+        "transcript_path": "X:/t.jsonl",
+        "cwd": "X:/wt/foo",
+        "prompt_id": "46513e5d-9375-47f3-a6c0-c3a4452eb2fa",
+        "permission_mode": "default",
+        "effort": { "level": "medium" },
+        "hook_event_name": "Stop",
+        "stop_hook_active": false,
+        "last_assistant_message": "2",
+        "background_tasks": [],
+        "session_crons": []
+    }"#;
+
+    #[test]
+    fn test_has_flag_turn_context() {
+        let args = vec![
+            "bin".to_string(),
+            "--turn-context".to_string(),
+            "--project-dir".to_string(),
+            "X:/wt/foo".to_string(),
+        ];
+        assert!(has_flag(&args, "--turn-context", "-t"));
+        // 他モードと取り違えない（main の分岐順に依存しないことを固定する）
+        assert!(!has_flag(&args, "--notify", "-n"));
+        assert!(!has_flag(&args, "--prompt-context", "-c"));
+        assert!(!has_flag(&args, "--session-context", "-s"));
+        assert!(!has_flag(&args, "--set-description", "-d"));
+    }
+
+    #[test]
+    fn test_should_request_turn_context_initial_firing() {
+        // 初回の Stop は問い合わせる
+        assert!(should_request_turn_context(Some(STOP_PAYLOAD)));
+    }
+
+    #[test]
+    fn test_should_request_turn_context_blocks_continuation() {
+        // additionalContext による継続後の発火。ここで注入すると無限に回る
+        let json = STOP_PAYLOAD.replace("\"stop_hook_active\": false", "\"stop_hook_active\": true");
+        assert!(!should_request_turn_context(Some(&json)));
+    }
+
+    #[test]
+    fn test_should_request_turn_context_falls_back_to_asking() {
+        // 判定材料が無いときは安全側ではなく「問い合わせる」に倒す。
+        // 止めるのはサーバ側の stop_hook_active / prompt_id / delivered_at の3枚が担う。
+        assert!(should_request_turn_context(None));
+        assert!(should_request_turn_context(Some("not json")));
+        assert!(should_request_turn_context(Some(r#"{"hook_event_name":"Stop"}"#)));
+        // 文字列 "true" は bool ではないので判定材料にしない
+        assert!(should_request_turn_context(Some(r#"{"stop_hook_active":"true"}"#)));
+    }
+
+    #[test]
+    fn test_build_turn_context_output() {
+        let out = build_turn_context_output(r#"{"inbox":"[oretachi] 1 件届いています"}"#).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "Stop");
+        assert_eq!(
+            v["hookSpecificOutput"]["additionalContext"],
+            "[oretachi] 1 件届いています"
+        );
+    }
+
+    #[test]
+    fn test_build_turn_context_output_nothing_to_inject() {
+        // 未読が無ければ何も出さない ＝ そのままターンが終わる（会話を継続させない）
+        assert_eq!(build_turn_context_output(r#"{"inbox":null}"#), None);
+        assert_eq!(build_turn_context_output(r#"{"inbox":"   "}"#), None);
+        assert_eq!(build_turn_context_output(r#"{}"#), None);
+        assert_eq!(build_turn_context_output("not json"), None);
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_inbox_survives_throttle() {
+        // description は 600 秒スロットル中でも、未読だけは注入される（#120 §5.3）
+        let out =
+            build_prompt_context_output(r#"{"skip":true,"inbox":"[oretachi] 未読 2 件"}"#).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "UserPromptSubmit");
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert_eq!(ctx, "[oretachi] 未読 2 件");
+        assert!(!ctx.contains("oretachi_set_description"));
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_skip_without_inbox_is_none() {
+        assert_eq!(build_prompt_context_output(r#"{"skip":true,"inbox":null}"#), None);
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_description_then_inbox() {
+        let body = r#"{"description":"認証機能のリファクタリング","inbox":"[oretachi] 未読 1 件"}"#;
+        let out = build_prompt_context_output(body).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.starts_with("[oretachi] このワークツリーの現在の description"));
+        assert!(ctx.ends_with("[oretachi] 未読 1 件"));
+        assert!(ctx.find("認証機能").unwrap() < ctx.find("未読 1 件").unwrap());
+    }
+
+    #[test]
+    fn test_build_prompt_context_output_without_inbox_field_is_unchanged() {
+        // inbox を返さない旧サーバとの後方互換
+        let out = build_prompt_context_output(r#"{"description":"x"}"#).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ctx = v["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(ctx.contains("oretachi_set_description"));
+        assert!(!ctx.contains('\n'));
     }
 
     #[test]

--- a/src-tauri/src/claude_plugin.rs
+++ b/src-tauri/src/claude_plugin.rs
@@ -219,6 +219,30 @@ fn build_hooks_json(notifier_path: &str) -> serde_json::Value {
         );
     }
 
+    // Stop フック（2つ目のグループ）: ターン境界で購読イベントの未読を additionalContext として
+    // 注入する（#124）。Stop は「at the end of the turn (conversation continues so Claude can act
+    // on feedback)」なので、注入すればそのまま会話が継続してエージェントが着手する。
+    //
+    // 上の EVENT_CONFIG_KEYS ループが張る `--notify --event Stop` とは**別グループ**にする:
+    //   - `--notify` は6イベント共有で post_json（read 500ms・body を読まない・失敗時 exit 1）。
+    //     body を読むために post_json_read_body（read 2s）へ切り替えると Stop 以外まで遅くなる
+    //   - additionalContext を返す経路は「失敗しても無出力で必ず exit 0」に倒す必要があり
+    //     （claude 側に警告を出させない）、exit 1 しうる --notify とは方針が逆
+    // PermissionRequest に ExitPlanMode グループを追記しているのと同じ構造。
+    let turn_context_group = serde_json::json!({
+        "matcher": "",
+        "hooks": [{
+            "type": "command",
+            "command": notifier_path,
+            "args": ["--turn-context", "--project-dir", "${CLAUDE_PROJECT_DIR}"]
+        }]
+    });
+    if let Some(arr) = hooks.get_mut("Stop").and_then(|v| v.as_array_mut()) {
+        arr.push(turn_context_group);
+    } else {
+        hooks.insert("Stop".to_string(), serde_json::json!([turn_context_group]));
+    }
+
     // ExitPlanMode フック: プラン確定時に通知サイドカー (oretachi-notify) を起動し、
     // プランを AI 要約してワークツリーの description にセットさせる。
     // ExitPlanMode はユーザー操作を伴うツールのため PreToolUse/PostToolUse は発火せず、
@@ -448,5 +472,51 @@ fn migrate_remove_oretachi_hooks(json: &mut serde_json::Value) {
         if let Some(obj) = json.as_object_mut() {
             obj.remove("hooks");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Stop` には通知用 (`--notify`) とターン境界配送用 (`--turn-context`) の
+    /// **2つのグループ**が並ぶ（#124）。片方に統合すると、6イベント共有の `--notify` が
+    /// レスポンス body を読む必要が出て全イベントの hook が遅くなる。
+    #[test]
+    fn build_hooks_json_registers_turn_context_alongside_notify() {
+        let v = build_hooks_json("X:/bin/oretachi-notify.exe");
+        let stop = v["hooks"]["Stop"].as_array().expect("Stop グループ");
+        assert_eq!(stop.len(), 2, "通知とターン境界配送で2グループ");
+
+        let args_of = |i: usize| -> Vec<String> {
+            stop[i]["hooks"][0]["args"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|a| a.as_str().unwrap().to_string())
+                .collect()
+        };
+        assert!(args_of(0).contains(&"--notify".to_string()));
+        assert!(args_of(0).contains(&"Stop".to_string()));
+        let turn = args_of(1);
+        assert_eq!(turn[0], "--turn-context");
+        assert!(turn.contains(&"${CLAUDE_PROJECT_DIR}".to_string()));
+        // --turn-context は event / agent を取らない（--notify とは別系統）
+        assert!(!turn.contains(&"--event".to_string()));
+
+        // 他イベントには生えていない（Stop 限定であること）
+        for ev in ["Notification", "PreToolUse", "PostToolUse", "SubagentStop"] {
+            assert_eq!(v["hooks"][ev].as_array().unwrap().len(), 1, "{} は1グループのまま", ev);
+        }
+    }
+
+    /// SessionStart / UserPromptSubmit / PermissionRequest の既存構成を壊していないこと。
+    #[test]
+    fn build_hooks_json_keeps_existing_groups() {
+        let v = build_hooks_json("X:/bin/oretachi-notify.exe");
+        assert_eq!(v["hooks"]["SessionStart"][0]["hooks"][0]["args"][0], "--session-context");
+        assert_eq!(v["hooks"]["UserPromptSubmit"][0]["hooks"][0]["args"][0], "--prompt-context");
+        // PermissionRequest は通知 + ExitPlanMode の2グループ
+        assert_eq!(v["hooks"]["PermissionRequest"].as_array().unwrap().len(), 2);
     }
 }

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -1593,6 +1593,50 @@ mod tests {
         });
     }
 
+    /// #124 の完了条件「同一ワークツリーに複数タブがある状態で誤配送しない」。
+    ///
+    /// `Stop` フックは発火したタブの `terminal_id` を運んでくるので、配送はその ID で
+    /// 未配送を引いて打刻する。B タブの `Stop` が A タブ宛の未読を抜き取らないこと、
+    /// および同じタブの2回目が空になること（`delivered_at` による二重注入防止）を固定する。
+    #[test]
+    fn test_roundtrip_turn_end_drain_is_scoped_to_one_tab() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            for (id, term) in [("sub-a", "term-a"), ("sub-b", "term-b")] {
+                let mut s = sub(term, Some("wt-subscriber"), r#"["worktree.closed"]"#);
+                s.id = id.to_string();
+                upsert_subscription(&pool, &s).await.unwrap();
+            }
+            let e = event("wt-target", None);
+            insert_event(&pool, &e).await.unwrap();
+            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 2, "両タブに積まれる");
+
+            // B タブで Stop が発火した相当の drain
+            let b = list_inbox(&pool, "term-b", InboxFilter::Undelivered).await.unwrap();
+            assert_eq!(b.len(), 1);
+            let ids: Vec<String> = b.iter().map(|i| i.id.clone()).collect();
+            assert_eq!(mark_delivered(&pool, &ids, now).await.unwrap(), 1);
+
+            // A タブ宛は未配送のまま残っている（抜き取られていない）
+            let a = list_inbox(&pool, "term-a", InboxFilter::Undelivered).await.unwrap();
+            assert_eq!(a.len(), 1, "A タブ宛は B タブの Stop で消えない");
+            assert!(a[0].delivered_at.is_none());
+
+            // B タブの次の Stop では本文が出ない（二重注入防止）
+            assert!(list_inbox(&pool, "term-b", InboxFilter::Undelivered)
+                .await
+                .unwrap()
+                .is_empty());
+            // ただし未 ack としては残るので poll_inbox で取り直せる
+            assert_eq!(
+                list_inbox(&pool, "term-b", InboxFilter::Unacked).await.unwrap().len(),
+                1
+            );
+        });
+    }
+
     #[test]
     fn test_roundtrip_expired_subscription_is_not_delivered_and_purged() {
         with_pool(async {

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -366,8 +366,7 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
             reason,
             reply,
         } => {
-            let digest = collect_digest(app, pool, state, &terminal_id, &reason).await;
-            let _ = reply.send(digest);
+            collect_digest(app, pool, state, &terminal_id, &reason, reply).await;
         }
         DeliveryMsg::EventQueued => {
             let _ = app.emit("event-inbox-changed", ());
@@ -505,13 +504,20 @@ fn filter_for_turn_end(
 /// （#120 §5.2）に反する。ただしそれだけだと、注入が失われたとき（サイドカーの読み取り
 /// タイムアウト等）にエージェントも人間も気づけない。そこで**未 ack の残存件数だけは
 /// 毎回伝える**。件数を見れば `oretachi_poll_inbox` で取り直せる。
+///
+/// **本文を呼び出し元へ渡せたときだけ `delivered_at` を打つ。** 呼び出し元（axum ハンドラ）は
+/// `INBOX_DIGEST_BUDGET_MS` のタイムアウトを持っており、ワーカーが詰まっている間に
+/// 諦めると受信側が消える。先に打刻すると「配送済みだが誰も見ていない」本文が生まれ、
+/// 再送しない方針（#120 §5.2）のせいで二度と出てこない。`push_pending` の
+/// 「`pty.write` が成功してから打刻する」と同じ不変条件。
 async fn collect_digest(
     app: &AppHandle,
     pool: &SqlitePool,
     state: &mut WorkerState,
     terminal_id: &str,
     reason: &DigestReason,
-) -> Option<String> {
+    reply: oneshot::Sender<Option<String>>,
+) {
     if let DigestReason::TurnEnd { prompt_id } = reason {
         if !should_deliver_turn(
             state.last_turn.get(terminal_id).map(String::as_str),
@@ -522,7 +528,8 @@ async fn collect_digest(
                 terminal_id,
                 prompt_id
             );
-            return None;
+            let _ = reply.send(None);
+            return;
         }
     }
     // このタブが名乗り出たので、同じワークツリーの引き継ぎ待ち（アプリ再起動やタブ死亡で
@@ -549,7 +556,8 @@ async fn collect_digest(
         Ok(items) => items,
         Err(e) => {
             log::warn!("[delivery] inbox 取得に失敗: {}", e);
-            return None;
+            let _ = reply.send(None);
+            return;
         }
     };
     let items = if reason.is_turn_end() {
@@ -571,7 +579,8 @@ async fn collect_digest(
         // 未 ack の残件があれば「N 件残っています」を返すが、それを `Stop` で注入すると
         // 毎ターン「残件があります」と言うためだけに会話が継続する。
         if items.is_empty() {
-            return None;
+            let _ = reply.send(None);
+            return;
         }
         items
     } else {
@@ -586,11 +595,26 @@ async fn collect_digest(
             0
         }
     };
-    let digest = event_db::format_inbox_digest(&items, carryover)?;
+    let Some(digest) = event_db::format_inbox_digest(&items, carryover) else {
+        let _ = reply.send(None);
+        return;
+    };
+
+    // **先に渡してから打刻する。** 呼び出し元がタイムアウトで諦めていれば送信は失敗し、
+    // その場合は打刻しない（未配送のまま残るので次の機会に再度出る）。逆順にすると
+    // 「配送済みだが誰も見ていない」本文が生まれ、再送しない方針のせいで永久に失われる。
+    if reply.send(Some(digest.clone())).is_err() {
+        log::warn!(
+            "[delivery] 注入本文の受け取り手が既に居ない（タイムアウト）ため打刻しない terminal={} 経路={}",
+            terminal_id,
+            reason.label()
+        );
+        return;
+    }
 
     let ids: Vec<String> = items.iter().map(|i| i.id.clone()).collect();
     if let Err(e) = event_db::mark_delivered(pool, &ids, event_db::now_ms()).await {
-        // 打刻に失敗しても本文は返す。未配送のまま残るので次の機会に再度出る
+        // 打刻に失敗しても本文は既に渡している。未配送のまま残るので次の機会に再度出る
         // （取りこぼすより一度重複するほうが安全）。
         log::warn!("[delivery] mark_delivered に失敗: {}", e);
     }
@@ -628,7 +652,6 @@ async fn collect_digest(
             }),
         );
     }
-    Some(digest)
 }
 
 // ─── 配送の駆動 ───────────────────────────────────────────────────────────────

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -105,10 +105,13 @@ impl DigestReason {
 
     /// 本文が0件でも「未 ack が N 件残っています」だけを伝えてよい経路か。
     ///
-    /// `SessionStart` だけ `true`。1セッション1回しか発火しないので、Phase 1 の
-    /// 「注入が失われても件数で気づける」（#120 §5.2）がそのまま成立する。
-    /// `Stop` / `UserPromptSubmit` は毎ターン・毎プロンプト発火するため、同じことを
-    /// やると ack するまで永久に催促が付きまとう。
+    /// `SessionStart` だけ `true`。発火は startup / resume / clear / compact に限られ
+    /// （`claude_plugin.rs` の SessionStart フックは matcher なしで登録している）、
+    /// 毎ターン・毎プロンプトの `Stop` / `UserPromptSubmit` とは頻度が桁違いに低い。
+    /// この頻度なら Phase 1 の「注入が失われても件数で気づける」（#120 §5.2）が
+    /// 実用になる。`Stop` / `UserPromptSubmit` で同じことをやると、`Stop` は残件を
+    /// 報告するためだけに会話が継続し、`UserPromptSubmit` は ack するまで
+    /// **ユーザーの全プロンプトの先頭に催促が付きまとう**。
     fn reports_carryover_only(&self) -> bool {
         matches!(self, DigestReason::SessionStart)
     }
@@ -229,6 +232,16 @@ struct WorkerState {
     /// 1タブが同じワークツリーの死亡タブ全グループを吸い上げ、「新しいタブ1つにつき
     /// 1グループ」という設計不変条件が崩れる。タブが消えたら忘れる。
     claimed: std::collections::HashSet<String>,
+    /// 引き継ぎを試したが**対象が1グループも無かった**タブ（#124 のレビュー指摘）。
+    ///
+    /// `claimed` は「1グループ引き継いだ」タブしか入らないので、引き継ぐものが無いタブは
+    /// 永久に `claimed` に入らない。`Stop` / `UserPromptSubmit` は毎ターン・毎プロンプト
+    /// 発火するため、抑止しないと**全 CC タブが毎ターン `list_orphaned_groups` を叩き続ける**
+    /// （events.db は非 WAL なので書き込みと競合しうる）。
+    ///
+    /// 引き継ぎ待ちグループが新しく生まれるのは `mark_orphaned_subscribers`（＝生存タブ一覧が
+    /// 変化した `Reconcile`）だけなので、そこで捨てれば取りこぼさない。
+    rebind_probed: std::collections::HashSet<String>,
     /// タブごとの「最後に Stop 経路で注入したターン」の `prompt_id`（#124）。
     ///
     /// `Stop` の `additionalContext` は会話を継続させるので、継続したターンが終われば
@@ -297,6 +310,9 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
                 // 放置しても誤動作はしないが、長時間稼働で単調増加する）。
                 state.claimed.retain(|t| live_terminal_ids.contains(t));
                 state.last_turn.retain(|t, _| live_terminal_ids.contains(t));
+                // 引き継ぎ待ちグループが増えるのはこの直後の `mark_orphaned_subscribers`
+                // だけなので、「対象が無かった」という記憶はここで捨てれば十分。
+                state.rebind_probed.clear();
                 match event_db::mark_orphaned_subscribers(pool, &live_terminal_ids, now).await {
                     Ok((subs, inbox, deleted)) if subs > 0 || inbox > 0 || deleted > 0 => {
                         log::info!(
@@ -331,18 +347,9 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
             }
         }
         DeliveryMsg::Rebind { terminal_id } => {
-            // 自動引き継ぎは1タブにつき1グループまで。`resolve_subscriber` は購読系ツールの
-            // 呼び出しごとに要求してくるので、抑止しないと1タブが全グループを吸い上げる。
-            // 人間が明示的に選ぶ `RebindManual` はこの制限を受けない。
-            let result = if state.claimed.contains(&terminal_id) {
-                (0, 0)
-            } else {
-                let moved = rebind_for_terminal(app, pool, &terminal_id).await;
-                if moved != (0, 0) {
-                    state.claimed.insert(terminal_id.clone());
-                }
-                moved
-            };
+            // 自動引き継ぎは1タブにつき1グループまで。人間が明示的に選ぶ `RebindManual` は
+            // この制限を受けない。
+            let result = try_rebind_once(app, pool, state, &terminal_id).await;
             if result != (0, 0) {
                 let _ = app.emit("event-inbox-changed", ());
             }
@@ -440,6 +447,31 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
     }
 }
 
+/// 1タブにつき1グループまでの引き継ぎを、無駄打ちを抑えつつ試す。
+///
+/// - 既に1グループ引き継いだタブ（`claimed`）は対象外。`resolve_subscriber` や hook 経路は
+///   呼び出しのたびに要求してくるので、抑止しないと1タブが全グループを吸い上げる
+/// - 前回試して**対象が無かった**タブ（`rebind_probed`）も対象外。`Stop` は毎ターン発火
+///   するため、これが無いと全 CC タブが毎ターン `list_orphaned_groups` を叩き続ける。
+///   新しい引き継ぎ待ちが生まれる `Reconcile`（生存タブ変化時）で忘れる
+async fn try_rebind_once(
+    app: &AppHandle,
+    pool: &SqlitePool,
+    state: &mut WorkerState,
+    terminal_id: &str,
+) -> (u64, u64) {
+    if state.claimed.contains(terminal_id) || state.rebind_probed.contains(terminal_id) {
+        return (0, 0);
+    }
+    let moved = rebind_for_terminal(app, pool, terminal_id).await;
+    if moved != (0, 0) {
+        state.claimed.insert(terminal_id.to_string());
+    } else {
+        state.rebind_probed.insert(terminal_id.to_string());
+    }
+    moved
+}
+
 /// タブの cwd からワークツリーを引いて、そのワークツリーの引き継ぎ待ちを1グループ引き継ぐ。
 async fn rebind_for_terminal(app: &AppHandle, pool: &SqlitePool, terminal_id: &str) -> (u64, u64) {
     let Some(worktree_id) = worktree_of_terminal(app, terminal_id) else {
@@ -496,14 +528,25 @@ fn should_deliver_turn(last: Option<&str>, prompt_id: Option<&str>) -> bool {
 ///   他の戦略が混ざっていても巻き込まない（Phase 3 で踏んだバグと同じ轍を踏まない）
 /// - 自動承認が有効な宛先へは定型イベントのみ（#120 §5.5）。自由文は inbox に残して
 ///   人間の確認を要求する
+///
+/// 自動承認の判定は**行ごとにその行自身の `subscriber_worktree_id` で行う**。1タブが
+/// `cd` して別ワークツリーで再購読すると同じ `terminal_id` に異なるワークツリー宛の行が
+/// 混ざるため、代表1件から解決すると**実際の宛先ではないワークツリーの設定で全件を
+/// 判定してしまう**（#131 が手動引き継ぎで塞いだのと同じ穴）。
 fn filter_for_turn_end(
     items: Vec<event_db::InboxItem>,
-    worktree: Option<&WorktreeEntry>,
+    settings: &AppSettings,
 ) -> Vec<event_db::InboxItem> {
     items
         .into_iter()
         .filter(|i| i.delivery != event_db::DELIVERY_PASSIVE)
-        .filter(|i| auto_approval_allows(worktree, &i.kind))
+        .filter(|i| {
+            let worktree = i
+                .subscriber_worktree_id
+                .as_deref()
+                .and_then(|id| find_worktree(settings, id));
+            auto_approval_allows(worktree, &i.kind)
+        })
         .collect()
 }
 
@@ -545,19 +588,16 @@ async fn collect_digest(
     // このタブが名乗り出たので、同じワークツリーの引き継ぎ待ち（アプリ再起動やタブ死亡で
     // 宙に浮いた購読と未読）を引き継ぐ。**回収より先に行う**必要がある。引き継ぎ前に
     // list_inbox すると、前回の terminal_id 宛のままの行が見えない。
-    if !state.claimed.contains(terminal_id) {
-        let moved = rebind_for_terminal(app, pool, terminal_id).await;
-        if moved != (0, 0) {
-            state.claimed.insert(terminal_id.to_string());
-            log::info!(
-                "[delivery] 引き継ぎ待ちを回収した terminal={} 購読={} 未読={} 経路={}",
-                terminal_id,
-                moved.0,
-                moved.1,
-                reason.label()
-            );
-            let _ = app.emit("event-inbox-changed", ());
-        }
+    let moved = try_rebind_once(app, pool, state, terminal_id).await;
+    if moved != (0, 0) {
+        log::info!(
+            "[delivery] 引き継ぎ待ちを回収した terminal={} 購読={} 未読={} 経路={}",
+            terminal_id,
+            moved.0,
+            moved.1,
+            reason.label()
+        );
+        let _ = app.emit("event-inbox-changed", ());
     }
 
     let items = match event_db::list_inbox(pool, terminal_id, event_db::InboxFilter::Undelivered)
@@ -572,12 +612,8 @@ async fn collect_digest(
     };
     let items = if reason.is_turn_end() {
         let settings = app.state::<SettingsManager>().get();
-        let worktree = items
-            .first()
-            .and_then(|i| i.subscriber_worktree_id.as_deref())
-            .and_then(|id| find_worktree(&settings, id));
         let before = items.len();
-        let items = filter_for_turn_end(items, worktree);
+        let items = filter_for_turn_end(items, &settings);
         if items.len() < before {
             log::debug!(
                 "[delivery] Stop 経路では {} 件を注入対象から外した（passive / 自動承認）terminal={}",
@@ -1493,6 +1529,13 @@ mod tests {
 
     /// `passive` は「押し込まないでほしい」の明示指定。Stop の注入はターンを開始させる
     /// ので押し込みと同じ扱いにする（同じタブの他戦略に巻き込まない）。
+    /// `worktree()` が返す wt-1 を1件だけ持つ settings。
+    fn settings_with(auto: Option<bool>) -> AppSettings {
+        let mut s = AppSettings::default();
+        s.worktrees = vec![worktree(auto)];
+        s
+    }
+
     #[test]
     fn test_filter_for_turn_end_excludes_passive() {
         let items = vec![
@@ -1501,7 +1544,10 @@ mod tests {
             item("c", event_db::DELIVERY_INTERRUPT, event_db::KIND_WORKTREE_CLOSED),
         ];
         // interrupt は「走行中でも割り込んでよい」の明示指定なので、ターン境界でも当然通す
-        assert_eq!(ids(&filter_for_turn_end(items, None)), vec!["a", "c"]);
+        assert_eq!(
+            ids(&filter_for_turn_end(items, &settings_with(None))),
+            vec!["a", "c"]
+        );
     }
 
     /// 自動承認が有効な宛先は、注入された内容を人間の確認なしに実行する（#120 §5.5）。
@@ -1512,10 +1558,49 @@ mod tests {
             item("a", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_CLOSED),
             item("b", event_db::DELIVERY_TURN_END, "worktree.message"),
         ];
-        let on = worktree(Some(true));
-        assert_eq!(ids(&filter_for_turn_end(items.clone(), Some(&on))), vec!["a"]);
-        let off = worktree(Some(false));
-        assert_eq!(ids(&filter_for_turn_end(items, Some(&off))), vec!["a", "b"]);
+        assert_eq!(
+            ids(&filter_for_turn_end(items.clone(), &settings_with(Some(true)))),
+            vec!["a"]
+        );
+        assert_eq!(
+            ids(&filter_for_turn_end(items, &settings_with(Some(false)))),
+            vec!["a", "b"]
+        );
+    }
+
+    /// 1タブが `cd` して別ワークツリーで再購読すると、同じ terminal_id の inbox に
+    /// 異なる `subscriber_worktree_id` の行が混ざる。代表1件から自動承認を判定すると
+    /// **実際の宛先ではないワークツリーの設定で全件を通してしまう**ので、行ごとに引く。
+    #[test]
+    fn test_filter_for_turn_end_judges_each_row_by_its_own_worktree() {
+        let mut auto_on = worktree(Some(true));
+        auto_on.id = "wt-auto".to_string();
+        let mut auto_off = worktree(Some(false));
+        auto_off.id = "wt-manual".to_string();
+        let mut settings = AppSettings::default();
+        settings.worktrees = vec![auto_on, auto_off];
+
+        // 1件目は自動承認 OFF のワークツリー宛（＝代表にすると全件が通ってしまう）
+        let mut a = item("a", event_db::DELIVERY_TURN_END, "worktree.message");
+        a.subscriber_worktree_id = Some("wt-manual".to_string());
+        let mut b = item("b", event_db::DELIVERY_TURN_END, "worktree.message");
+        b.subscriber_worktree_id = Some("wt-auto".to_string());
+
+        assert_eq!(ids(&filter_for_turn_end(vec![a, b], &settings)), vec!["a"]);
+    }
+
+    /// 宛先ワークツリーが解決できない行（設定から消えた等）は、自動承認の判定材料が
+    /// 無いので `auto_approval_allows(None, _)` の既定（許可）に落ちる。1件目が
+    /// これだったせいで他の行まで巻き込まれないことを固定する。
+    #[test]
+    fn test_filter_for_turn_end_unresolvable_row_does_not_leak_to_others() {
+        let mut a = item("a", event_db::DELIVERY_TURN_END, "worktree.message");
+        a.subscriber_worktree_id = Some("wt-gone".to_string());
+        let b = item("b", event_db::DELIVERY_TURN_END, "worktree.message"); // wt-1 = 自動承認 ON
+        assert_eq!(
+            ids(&filter_for_turn_end(vec![a, b], &settings_with(Some(true)))),
+            vec!["a"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -102,6 +102,16 @@ impl DigestReason {
     fn is_turn_end(&self) -> bool {
         matches!(self, DigestReason::TurnEnd { .. })
     }
+
+    /// 本文が0件でも「未 ack が N 件残っています」だけを伝えてよい経路か。
+    ///
+    /// `SessionStart` だけ `true`。1セッション1回しか発火しないので、Phase 1 の
+    /// 「注入が失われても件数で気づける」（#120 §5.2）がそのまま成立する。
+    /// `Stop` / `UserPromptSubmit` は毎ターン・毎プロンプト発火するため、同じことを
+    /// やると ack するまで永久に催促が付きまとう。
+    fn reports_carryover_only(&self) -> bool {
+        matches!(self, DigestReason::SessionStart)
+    }
 }
 
 pub enum DeliveryMsg {
@@ -575,17 +585,23 @@ async fn collect_digest(
                 terminal_id
             );
         }
-        // **件数だけの通知でターンを開始させない。** `format_inbox_digest` は本文が0件でも
-        // 未 ack の残件があれば「N 件残っています」を返すが、それを `Stop` で注入すると
-        // 毎ターン「残件があります」と言うためだけに会話が継続する。
-        if items.is_empty() {
-            let _ = reply.send(None);
-            return;
-        }
         items
     } else {
         items
     };
+
+    // **件数だけの通知を毎回出さない。** `format_inbox_digest` は本文が0件でも未 ack の
+    // 残件があれば「N 件残っています」を返す。これは「注入が失われても人間とエージェントが
+    // 気づけるように」という Phase 1 の設計（#120 §5.2）だが、**発火頻度が高い経路では害になる**:
+    //
+    // - `Stop`: 残件を報告するためだけに会話が継続してしまう（ターンを開始させる経路なので致命的）
+    // - `UserPromptSubmit`: ack されない限り**ユーザーの全プロンプトの先頭に ack 催促が付く**
+    //
+    // `SessionStart` は1セッション1回なので Phase 1 のまま件数を伝える（本来の目的どおり）。
+    if items.is_empty() && !reason.reports_carryover_only() {
+        let _ = reply.send(None);
+        return;
+    }
 
     // 配送済みだが未 ack のまま残っている件数（今回本文を出す分は差し引く）
     let carryover = match event_db::count_unacked(pool, terminal_id).await {
@@ -1510,5 +1526,15 @@ mod tests {
         assert!(DigestReason::TurnEnd { prompt_id: None }.is_turn_end());
         assert!(!DigestReason::SessionStart.is_turn_end());
         assert!(!DigestReason::PromptSubmit.is_turn_end());
+    }
+
+    /// 本文0件のときに「未 ack が N 件残っています」だけを注入してよいのは
+    /// `SessionStart` だけ。`Stop` は残件報告のためだけに会話を継続させてしまい、
+    /// `UserPromptSubmit` は ack するまでユーザーの全プロンプトに催促が付きまとう。
+    #[test]
+    fn test_only_session_start_reports_carryover_only() {
+        assert!(DigestReason::SessionStart.reports_carryover_only());
+        assert!(!DigestReason::PromptSubmit.reports_carryover_only());
+        assert!(!DigestReason::TurnEnd { prompt_id: Some("p".into()) }.reports_carryover_only());
     }
 }

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -72,14 +72,51 @@ const AUTO_APPROVAL_PUSHABLE_KINDS: &[&str] = &[event_db::KIND_WORKTREE_CLOSED];
 
 // ─── ハンドル ─────────────────────────────────────────────────────────────────
 
+/// `additionalContext` 経由で未読をまとめて渡すときの、呼び出し元の hook 種別（#124）。
+///
+/// PTY 押し込みと違い、どれも「文字列を返すだけ」で PTY には触らない。ただし
+/// **`TurnEnd` だけはターンを開始させる**（`Stop` の `additionalContext` は会話を継続する）
+/// ため、押し込みと同じ制限（`passive` を巻き込まない・自動承認が有効な宛先へは定型
+/// イベントのみ）を課す。`SessionStart` / `PromptSubmit` は人間の操作が起点なので、
+/// Phase 1 から変わらず全件を渡す。
+#[derive(Debug, Clone, PartialEq)]
+pub enum DigestReason {
+    /// SessionStart フック。アプリ停止中に溜まった分の回収（#123）
+    SessionStart,
+    /// Stop フック。ターン境界配送の本命（#124）。`prompt_id` は「1ターン1回」の鍵
+    TurnEnd { prompt_id: Option<String> },
+    /// UserPromptSubmit フック。Stop の取りこぼし回収（#124）
+    PromptSubmit,
+}
+
+impl DigestReason {
+    /// ログと `event-delivered` の `method` に出す識別子。
+    fn label(&self) -> &'static str {
+        match self {
+            DigestReason::SessionStart => "session",
+            DigestReason::TurnEnd { .. } => "stop",
+            DigestReason::PromptSubmit => "prompt",
+        }
+    }
+
+    fn is_turn_end(&self) -> bool {
+        matches!(self, DigestReason::TurnEnd { .. })
+    }
+}
+
 pub enum DeliveryMsg {
     /// 生存タブの一覧。ここに無い terminal_id の購読 / inbox は orphaned にする
     Reconcile { live_terminal_ids: Vec<String> },
-    /// このタブへ、同じワークツリーの引き継ぎ待ちグループを1つ引き継ぐ
-    Rebind {
+    /// hook 経路（SessionStart / Stop / UserPromptSubmit）へ渡す未読テキストを組む。
+    /// **押し込みと同じワーカーで直列に処理するのが要点**（下の `collect_digest_and_wait` 参照）
+    CollectDigest {
         terminal_id: String,
-        reply: Option<oneshot::Sender<(u64, u64)>>,
+        reason: DigestReason,
+        reply: oneshot::Sender<Option<String>>,
     },
+    /// このタブへ、同じワークツリーの引き継ぎ待ちグループを1つ引き継ぐ（応答は待たない）。
+    /// 完了を待ちたい経路（hook からの回収）は `CollectDigest` が内包している。
+    Rebind { terminal_id: String },
     /// UI からの手動引き継ぎ（引き継ぎ先グループを人間が選ぶ）
     RebindManual {
         worktree_id: String,
@@ -123,10 +160,7 @@ pub fn reconcile_live_terminals(app: &AppHandle, live_terminal_ids: Vec<String>)
 /// AI エージェントが立ち上がったタブから引き継ぎを要求する（応答は待たない）。
 pub fn request_rebind(app: &AppHandle, terminal_id: String) {
     if let Some(h) = handle(app) {
-        h.try_send(DeliveryMsg::Rebind {
-            terminal_id,
-            reply: None,
-        });
+        h.try_send(DeliveryMsg::Rebind { terminal_id });
     }
 }
 
@@ -137,25 +171,35 @@ pub fn notify_event_queued(app: &AppHandle) {
     }
 }
 
-/// 引き継ぎを要求し、完了まで待つ（`SessionStart` から使う）。
+/// hook 経路へ渡す未読テキストを組み、出した分に `delivered_at` を打つ（#124）。
 ///
-/// ワーカーが詰まっていたら `None` を返す。呼び出し元は上位のタイムアウトの内側で
-/// 使うので、「今回は引き継がない」に劣化するだけで済む。
-pub async fn rebind_and_wait(app: &AppHandle, terminal_id: &str) -> Option<(u64, u64)> {
+/// **押し込み (`push_pending`) と同じワーカーで処理させるのが要点。** 別経路で
+/// 「未配送を SELECT → 注入 → 打刻」をやると、その隙間に走った押し込みが同じ行を
+/// PTY へ流し、同じ本文が二重に届く（`mark_delivered` の `WHERE delivered_at IS NULL`
+/// は打刻を冪等にするだけで、読み取りと注入のインターリーブは防げない）。
+///
+/// ワーカーが詰まっていたら `None`（＝今回は注入しない）。呼び出し元は上位のタイム
+/// アウトの内側で使うので、取りこぼしではなく次の機会に回るだけで済む。
+pub async fn collect_digest_and_wait(
+    app: &AppHandle,
+    terminal_id: &str,
+    reason: DigestReason,
+) -> Option<String> {
     let (tx, rx) = oneshot::channel();
     {
         let h = handle(app)?;
         if h.tx
-            .try_send(DeliveryMsg::Rebind {
+            .try_send(DeliveryMsg::CollectDigest {
                 terminal_id: terminal_id.to_string(),
-                reply: Some(tx),
+                reason,
+                reply: tx,
             })
             .is_err()
         {
             return None;
         }
     }
-    rx.await.ok()
+    rx.await.ok().flatten()
 }
 
 // ─── ワーカー ─────────────────────────────────────────────────────────────────
@@ -175,6 +219,15 @@ struct WorkerState {
     /// 1タブが同じワークツリーの死亡タブ全グループを吸い上げ、「新しいタブ1つにつき
     /// 1グループ」という設計不変条件が崩れる。タブが消えたら忘れる。
     claimed: std::collections::HashSet<String>,
+    /// タブごとの「最後に Stop 経路で注入したターン」の `prompt_id`（#124）。
+    ///
+    /// `Stop` の `additionalContext` は会話を継続させるので、継続したターンが終われば
+    /// また `Stop` が発火する。`stop_hook_active` で弾くのが第一の防波堤だが、CC 側の
+    /// 仕様変更で無防備にならないよう `prompt_id` 単位の上限も持つ。実測（#121）で
+    /// **1ユーザー発話に対する 9 回の発火すべてで `prompt_id` は同一**だったので、
+    /// これがターン境界の正確な鍵になる（`session_id` は複数ターンで共通なので粗い）。
+    /// タブが消えたら忘れる。
+    last_turn: HashMap<String, String>,
     /// 前回 `Reconcile` を処理したときの生存タブ一覧（ソート済み）。
     ///
     /// ポーリングは 10 秒ごとに送ってくるが、`events.db` は WAL ではない（sqlx は
@@ -233,6 +286,7 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
                 // 消えたタブの「引き継ぎ済み」マークは忘れる（terminal_id は再利用されないので
                 // 放置しても誤動作はしないが、長時間稼働で単調増加する）。
                 state.claimed.retain(|t| live_terminal_ids.contains(t));
+                state.last_turn.retain(|t, _| live_terminal_ids.contains(t));
                 match event_db::mark_orphaned_subscribers(pool, &live_terminal_ids, now).await {
                     Ok((subs, inbox, deleted)) if subs > 0 || inbox > 0 || deleted > 0 => {
                         log::info!(
@@ -266,7 +320,7 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
                 }
             }
         }
-        DeliveryMsg::Rebind { terminal_id, reply } => {
+        DeliveryMsg::Rebind { terminal_id } => {
             // 自動引き継ぎは1タブにつき1グループまで。`resolve_subscriber` は購読系ツールの
             // 呼び出しごとに要求してくるので、抑止しないと1タブが全グループを吸い上げる。
             // 人間が明示的に選ぶ `RebindManual` はこの制限を受けない。
@@ -279,9 +333,6 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
                 }
                 moved
             };
-            if let Some(reply) = reply {
-                let _ = reply.send(result);
-            }
             if result != (0, 0) {
                 let _ = app.emit("event-inbox-changed", ());
             }
@@ -309,6 +360,14 @@ async fn handle_msg(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerState,
             }
             let _ = app.emit("event-inbox-changed", ());
             drive(app, pool, state).await;
+        }
+        DeliveryMsg::CollectDigest {
+            terminal_id,
+            reason,
+            reply,
+        } => {
+            let digest = collect_digest(app, pool, state, &terminal_id, &reason).await;
+            let _ = reply.send(digest);
         }
         DeliveryMsg::EventQueued => {
             let _ = app.emit("event-inbox-changed", ());
@@ -404,6 +463,172 @@ fn worktree_of_terminal(app: &AppHandle, terminal_id: &str) -> Option<String> {
     let session = sessions.iter().find(|s| s.terminal_id == terminal_id)?;
     let cwd = session.cwd.as_deref()?;
     crate::mcp_server::resolve_worktree_by_cwd(&settings, cwd).map(|w| w.id.clone())
+}
+
+// ─── hook 経路への注入（#124） ────────────────────────────────────────────────
+
+/// 同じターンへ二度注入しないか判定する（#124 §5.1）。
+///
+/// `prompt_id` が取れない場合は通す。`Stop` 由来の継続ターンは `stop_hook_active` で
+/// 先に落ちているので、ここは CC の仕様変更に備えた二枚目の防波堤という位置づけ。
+fn should_deliver_turn(last: Option<&str>, prompt_id: Option<&str>) -> bool {
+    match prompt_id {
+        Some(p) => last != Some(p),
+        None => true,
+    }
+}
+
+/// `Stop` 経路で注入してよい未読だけに絞る。
+///
+/// `Stop` の `additionalContext` は**会話を継続させる＝ターンを開始させる**ので、
+/// PTY 押し込みと同じ危険度を持つ。よって押し込みと同じ2つの制限を課す:
+///
+/// - `delivery=passive` は「押し込まないでほしい」という購読側の明示指定。同じタブに
+///   他の戦略が混ざっていても巻き込まない（Phase 3 で踏んだバグと同じ轍を踏まない）
+/// - 自動承認が有効な宛先へは定型イベントのみ（#120 §5.5）。自由文は inbox に残して
+///   人間の確認を要求する
+fn filter_for_turn_end(
+    items: Vec<event_db::InboxItem>,
+    worktree: Option<&WorktreeEntry>,
+) -> Vec<event_db::InboxItem> {
+    items
+        .into_iter()
+        .filter(|i| i.delivery != event_db::DELIVERY_PASSIVE)
+        .filter(|i| auto_approval_allows(worktree, &i.kind))
+        .collect()
+}
+
+/// 指定タブ宛の未読を hook の `additionalContext` 用テキストにまとめ、本文を出した分に
+/// `delivered_at` を打つ。
+///
+/// 本文を列挙するのは **未配送のみ**。未 ack 全件を毎回再掲すると「再送はしない」方針
+/// （#120 §5.2）に反する。ただしそれだけだと、注入が失われたとき（サイドカーの読み取り
+/// タイムアウト等）にエージェントも人間も気づけない。そこで**未 ack の残存件数だけは
+/// 毎回伝える**。件数を見れば `oretachi_poll_inbox` で取り直せる。
+async fn collect_digest(
+    app: &AppHandle,
+    pool: &SqlitePool,
+    state: &mut WorkerState,
+    terminal_id: &str,
+    reason: &DigestReason,
+) -> Option<String> {
+    if let DigestReason::TurnEnd { prompt_id } = reason {
+        if !should_deliver_turn(
+            state.last_turn.get(terminal_id).map(String::as_str),
+            prompt_id.as_deref(),
+        ) {
+            log::debug!(
+                "[delivery] このターンへは注入済みなので見送る terminal={} prompt_id={:?}",
+                terminal_id,
+                prompt_id
+            );
+            return None;
+        }
+    }
+    // このタブが名乗り出たので、同じワークツリーの引き継ぎ待ち（アプリ再起動やタブ死亡で
+    // 宙に浮いた購読と未読）を引き継ぐ。**回収より先に行う**必要がある。引き継ぎ前に
+    // list_inbox すると、前回の terminal_id 宛のままの行が見えない。
+    if !state.claimed.contains(terminal_id) {
+        let moved = rebind_for_terminal(app, pool, terminal_id).await;
+        if moved != (0, 0) {
+            state.claimed.insert(terminal_id.to_string());
+            log::info!(
+                "[delivery] 引き継ぎ待ちを回収した terminal={} 購読={} 未読={} 経路={}",
+                terminal_id,
+                moved.0,
+                moved.1,
+                reason.label()
+            );
+            let _ = app.emit("event-inbox-changed", ());
+        }
+    }
+
+    let items = match event_db::list_inbox(pool, terminal_id, event_db::InboxFilter::Undelivered)
+        .await
+    {
+        Ok(items) => items,
+        Err(e) => {
+            log::warn!("[delivery] inbox 取得に失敗: {}", e);
+            return None;
+        }
+    };
+    let items = if reason.is_turn_end() {
+        let settings = app.state::<SettingsManager>().get();
+        let worktree = items
+            .first()
+            .and_then(|i| i.subscriber_worktree_id.as_deref())
+            .and_then(|id| find_worktree(&settings, id));
+        let before = items.len();
+        let items = filter_for_turn_end(items, worktree);
+        if items.len() < before {
+            log::debug!(
+                "[delivery] Stop 経路では {} 件を注入対象から外した（passive / 自動承認）terminal={}",
+                before - items.len(),
+                terminal_id
+            );
+        }
+        // **件数だけの通知でターンを開始させない。** `format_inbox_digest` は本文が0件でも
+        // 未 ack の残件があれば「N 件残っています」を返すが、それを `Stop` で注入すると
+        // 毎ターン「残件があります」と言うためだけに会話が継続する。
+        if items.is_empty() {
+            return None;
+        }
+        items
+    } else {
+        items
+    };
+
+    // 配送済みだが未 ack のまま残っている件数（今回本文を出す分は差し引く）
+    let carryover = match event_db::count_unacked(pool, terminal_id).await {
+        Ok((unacked, _)) => (unacked - items.len() as i64).max(0),
+        Err(e) => {
+            log::warn!("[delivery] 未 ack 件数の取得に失敗: {}", e);
+            0
+        }
+    };
+    let digest = event_db::format_inbox_digest(&items, carryover)?;
+
+    let ids: Vec<String> = items.iter().map(|i| i.id.clone()).collect();
+    if let Err(e) = event_db::mark_delivered(pool, &ids, event_db::now_ms()).await {
+        // 打刻に失敗しても本文は返す。未配送のまま残るので次の機会に再度出る
+        // （取りこぼすより一度重複するほうが安全）。
+        log::warn!("[delivery] mark_delivered に失敗: {}", e);
+    }
+    if let DigestReason::TurnEnd { prompt_id } = reason {
+        if let Some(p) = prompt_id {
+            state.last_turn.insert(terminal_id.to_string(), p.clone());
+        }
+    }
+    if !ids.is_empty() {
+        log::info!(
+            "[delivery] {} 件を {} 経由で注入した terminal={}",
+            ids.len(),
+            reason.label(),
+            terminal_id
+        );
+        let _ = app.emit("event-inbox-changed", ());
+    }
+    if reason.is_turn_end() {
+        // 待機中への押し込み (`event-delivered`) と同じ形でフロントへ知らせる。
+        // SessionStart / UserPromptSubmit は人間が画面を見ている場面なのでトーストは出さない。
+        let settings = app.state::<SettingsManager>().get();
+        let worktree = items
+            .first()
+            .and_then(|i| i.subscriber_worktree_id.as_deref())
+            .and_then(|id| find_worktree(&settings, id));
+        let _ = app.emit(
+            "event-delivered",
+            serde_json::json!({
+                "terminalId": terminal_id,
+                "worktreeId": worktree.map(|w| w.id.clone()),
+                "worktreeName": worktree.map(|w| w.name.clone()),
+                "count": ids.len(),
+                "text": digest,
+                "method": "stop",
+            }),
+        );
+    }
+    Some(digest)
 }
 
 // ─── 配送の駆動 ───────────────────────────────────────────────────────────────
@@ -1181,5 +1406,86 @@ mod tests {
         let unset = worktree(None);
         assert!(auto_approval_allows(Some(&unset), "worktree.message"));
         assert!(auto_approval_allows(None, "worktree.message"));
+    }
+
+    // ─── ターン境界配送（#124） ──────────────────────────────────────────────
+
+    fn item(id: &str, delivery: &str, kind: &str) -> event_db::InboxItem {
+        event_db::InboxItem {
+            id: id.to_string(),
+            subscriber_terminal_id: "t-1".to_string(),
+            subscriber_worktree_id: Some("wt-1".to_string()),
+            event_id: format!("ev-{}", id),
+            state: event_db::STATE_PENDING.to_string(),
+            created_at: 1_000_000,
+            delivered_at: None,
+            acked_at: None,
+            orphaned_at: None,
+            delivery: delivery.to_string(),
+            spawn_if_closed: 0,
+            kind: kind.to_string(),
+            body: "{}".to_string(),
+            source_worktree_id: "wt-src".to_string(),
+            actor: None,
+        }
+    }
+
+    fn ids(items: &[event_db::InboxItem]) -> Vec<&str> {
+        items.iter().map(|i| i.id.as_str()).collect()
+    }
+
+    /// `Stop` の additionalContext は会話を継続させるので、同じ prompt_id へ二度返すと
+    /// 永久に回る。実測（#121）では 1 発話に対する 9 回の発火すべてで prompt_id が同一。
+    #[test]
+    fn test_should_deliver_turn_once_per_prompt_id() {
+        assert!(should_deliver_turn(None, Some("p-1")));
+        assert!(!should_deliver_turn(Some("p-1"), Some("p-1")));
+        // 次のユーザー発話は別の prompt_id なので通す
+        assert!(should_deliver_turn(Some("p-1"), Some("p-2")));
+    }
+
+    /// prompt_id が取れないときは通す。継続ターンは stop_hook_active が先に落としており、
+    /// ここで止めると「一度も配送できない」に倒れてしまう。
+    #[test]
+    fn test_should_deliver_turn_without_prompt_id() {
+        assert!(should_deliver_turn(None, None));
+        assert!(should_deliver_turn(Some("p-1"), None));
+    }
+
+    /// `passive` は「押し込まないでほしい」の明示指定。Stop の注入はターンを開始させる
+    /// ので押し込みと同じ扱いにする（同じタブの他戦略に巻き込まない）。
+    #[test]
+    fn test_filter_for_turn_end_excludes_passive() {
+        let items = vec![
+            item("a", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_CLOSED),
+            item("b", event_db::DELIVERY_PASSIVE, event_db::KIND_WORKTREE_CLOSED),
+            item("c", event_db::DELIVERY_INTERRUPT, event_db::KIND_WORKTREE_CLOSED),
+        ];
+        // interrupt は「走行中でも割り込んでよい」の明示指定なので、ターン境界でも当然通す
+        assert_eq!(ids(&filter_for_turn_end(items, None)), vec!["a", "c"]);
+    }
+
+    /// 自動承認が有効な宛先は、注入された内容を人間の確認なしに実行する（#120 §5.5）。
+    /// #126 で自由文 (`worktree.message`) が入った瞬間に default-deny になるのが目的。
+    #[test]
+    fn test_filter_for_turn_end_respects_auto_approval() {
+        let items = vec![
+            item("a", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_CLOSED),
+            item("b", event_db::DELIVERY_TURN_END, "worktree.message"),
+        ];
+        let on = worktree(Some(true));
+        assert_eq!(ids(&filter_for_turn_end(items.clone(), Some(&on))), vec!["a"]);
+        let off = worktree(Some(false));
+        assert_eq!(ids(&filter_for_turn_end(items, Some(&off))), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_digest_reason_labels() {
+        assert_eq!(DigestReason::SessionStart.label(), "session");
+        assert_eq!(DigestReason::PromptSubmit.label(), "prompt");
+        assert_eq!(DigestReason::TurnEnd { prompt_id: None }.label(), "stop");
+        assert!(DigestReason::TurnEnd { prompt_id: None }.is_turn_end());
+        assert!(!DigestReason::SessionStart.is_turn_end());
+        assert!(!DigestReason::PromptSubmit.is_turn_end());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1440,10 +1440,7 @@ pub fn run() {
     {
         // 別ワークツリーで dev ビルドを同時に立ち上げると 4000 の bind に失敗して
         // 起動そのものが panic するため、env で退避できるようにしておく。
-        let tauri_mcp_port = std::env::var("ORETACHI_TAURI_MCP_PORT")
-            .ok()
-            .and_then(|v| v.parse::<u16>().ok())
-            .unwrap_or(4000);
+        let tauri_mcp_port = mcp_server::env_port_override("ORETACHI_TAURI_MCP_PORT", 4000);
         builder = builder.plugin(tauri_plugin_mcp::init_with_config(
             tauri_plugin_mcp::PluginConfig::new("oretachi".to_string())
                 .tcp_localhost(tauri_mcp_port),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1438,8 +1438,15 @@ pub fn run() {
 
     #[cfg(debug_assertions)]
     {
+        // 別ワークツリーで dev ビルドを同時に立ち上げると 4000 の bind に失敗して
+        // 起動そのものが panic するため、env で退避できるようにしておく。
+        let tauri_mcp_port = std::env::var("ORETACHI_TAURI_MCP_PORT")
+            .ok()
+            .and_then(|v| v.parse::<u16>().ok())
+            .unwrap_or(4000);
         builder = builder.plugin(tauri_plugin_mcp::init_with_config(
-            tauri_plugin_mcp::PluginConfig::new("oretachi".to_string()).tcp_localhost(4000),
+            tauri_plugin_mcp::PluginConfig::new("oretachi".to_string())
+                .tcp_localhost(tauri_mcp_port),
         ));
     }
 

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -3687,14 +3687,28 @@ pub fn cleanup_port_file(app_handle: &AppHandle) {
 
 // ─── Server startup ───────────────────────────────────────────────────────────
 
+/// `.env` 由来のポート上書きを解決する。
+///
+/// **空文字は「未設定」と同じ扱いにする。** `.env` には3つのポート上書きを空値で
+/// 並べてあり（既定値のドキュメントを兼ねる）、`dotenvy` はそれを空文字として
+/// プロセス環境へ載せるため、ここで弾かないと既定値へ落ちない。
+pub fn parse_port_override(raw: Option<&str>, default: u16) -> u16 {
+    raw.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(default)
+}
+
+/// env からポート上書きを読む（未設定・空・数値でない場合は `default`）。
+pub fn env_port_override(name: &str, default: u16) -> u16 {
+    parse_port_override(std::env::var(name).ok().as_deref(), default)
+}
+
 pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
     // `settings.json` は本番と全 dev インスタンスで共有されるため、別ワークツリーで
     // dev ビルドを立ち上げると `mcpPort` を奪い合って bind に失敗する。env で退避できる
     // ようにしておく（`MCP_PORT_OVERWRITE=false` と併用すれば mcp-server.json も奪わない）。
-    let port = std::env::var("ORETACHI_MCP_PORT")
-        .ok()
-        .and_then(|v| v.parse::<u16>().ok())
-        .unwrap_or(port);
+    let port = env_port_override("ORETACHI_MCP_PORT", port);
     let manager = app_handle.state::<McpServerManager>();
 
     // 既存サーバーを停止
@@ -3976,6 +3990,22 @@ mod tests {
         "background_tasks": [],
         "session_crons": []
     }"#;
+
+    /// `.env` にはポート上書き3本を**空値**で並べてある（既定値のドキュメントを兼ねる）。
+    /// `dotenvy` は空値もプロセス環境へ載せるので、「空 = 未設定」がここで崩れると
+    /// 本番の MCP ポートが 0 になったり tauri-mcp が起動に失敗したりする。
+    #[test]
+    fn test_parse_port_override_treats_blank_as_unset() {
+        assert_eq!(parse_port_override(None, 4000), 4000);
+        assert_eq!(parse_port_override(Some(""), 4000), 4000);
+        assert_eq!(parse_port_override(Some("   "), 4000), 4000);
+        // 数値でない値も既定へ落とす（起動を止めない）
+        assert_eq!(parse_port_override(Some("abc"), 4000), 4000);
+        assert_eq!(parse_port_override(Some("70000"), 4000), 4000);
+        // 明示された値は使う
+        assert_eq!(parse_port_override(Some("9163"), 4000), 9163);
+        assert_eq!(parse_port_override(Some(" 9163 "), 4000), 9163);
+    }
 
     #[test]
     fn test_parse_stop_hook_fields_initial_firing() {

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -409,6 +409,20 @@ pub struct SetWorktreeDescriptionEvent {
     pub description: Option<String>,
 }
 
+/// Stop フック (--turn-context) が送るペイロード（#124）
+#[derive(Debug, Deserialize)]
+pub struct TurnContextPayload {
+    #[serde(default, rename = "projectDir")]
+    pub project_dir: Option<String>,
+    /// 発火元 PTY タブの `terminal_id`（env `ORETACHI_TERMINAL_ID` 由来）。
+    /// 配送はこのタブ宛の inbox だけを対象にする（同一ワークツリーの別タブ宛を抜き取らない）。
+    #[serde(default, rename = "terminalId")]
+    pub terminal_id: Option<String>,
+    /// Stop フックの stdin JSON（生文字列）。`prompt_id` / `stop_hook_active` をここから読む。
+    #[serde(default, rename = "hookJson")]
+    pub hook_json: Option<String>,
+}
+
 /// UserPromptSubmit フック (--prompt-context) が送るペイロード
 #[derive(Debug, Deserialize)]
 pub struct PromptContextPayload {
@@ -3196,7 +3210,11 @@ async fn session_context_handler(
     // ので次のセッション開始で再度提示される。
     let inbox = match tokio::time::timeout(
         std::time::Duration::from_millis(INBOX_DIGEST_BUDGET_MS),
-        collect_inbox_digest(&app_handle, payload.terminal_id.as_deref()),
+        collect_inbox_digest(
+            &app_handle,
+            payload.terminal_id.as_deref(),
+            crate::event_delivery::DigestReason::SessionStart,
+        ),
     )
     .await
     {
@@ -3220,93 +3238,167 @@ async fn session_context_handler(
     Json(serde_json::json!({ "prompt": prompt, "inbox": inbox }))
 }
 
-/// 指定タブ宛の inbox を SessionStart 注入用テキストにまとめ、本文を出した分に
-/// `delivered_at` を打つ。
+/// 指定タブ宛の inbox を hook 注入用テキストにまとめ、本文を出した分に `delivered_at` を打つ。
 ///
 /// terminal_id が無い（oretachi 管理外のターミナルから起動されたエージェント）場合や
 /// イベント DB が未初期化の場合は None を返し、既存の挙動を一切変えない。
 ///
-/// 本文を列挙するのは **未配送のみ**。未 ack 全件を毎回再掲すると「再送はしない」方針
-/// （#120 §5.2）に反する。ただしそれだけだと、注入が失われたとき（サイドカーの読み取り
-/// タイムアウト等）にエージェントも人間も気づけなくなる（Phase 1 には UI が無い）。
-/// そこで**未 ack の残存件数だけは毎回伝える**。件数を見れば `oretachi_poll_inbox` で
-/// 取り直せるので、注入喪失が恒久的な取りこぼしにならない。
-async fn collect_inbox_digest(app_handle: &AppHandle, terminal_id: Option<&str>) -> Option<String> {
+/// 実体は `event_delivery` の**単一ワーカー**が持つ（#124）。押し込みと同じキューを通すことで
+/// 「未配送を SELECT → 注入 → 打刻」の隙間に押し込みが割り込んで二重配送になる経路を潰す。
+/// ワーカーが詰まっていれば None が返り「今回は注入しない」に劣化するだけで、上位の
+/// `INBOX_DIGEST_BUDGET_MS` タイムアウトを食い潰さない。
+async fn collect_inbox_digest(
+    app_handle: &AppHandle,
+    terminal_id: Option<&str>,
+    reason: crate::event_delivery::DigestReason,
+) -> Option<String> {
     let terminal_id = terminal_id.map(str::trim).filter(|s| !s.is_empty())?;
-    let pool = app_handle
-        .try_state::<crate::event_db::EventPool>()
-        .map(|p| p.0.clone())?;
-    // このタブが立ち上がったので、同じワークツリーの引き継ぎ待ち（アプリ再起動や
-    // タブ死亡で宙に浮いた購読と未読）を引き継ぐ。**回収より先に行う**必要がある。
-    // 引き継ぎ前に list_inbox すると、前回の terminal_id 宛のままの行が見えない。
-    // ワーカーが詰まっていれば None が返り「今回は引き継がない」に劣化するだけで、
-    // 上位の INBOX_DIGEST_BUDGET_MS タイムアウトを食い潰さない（#125）。
-    if let Some((subs, inbox)) =
-        crate::event_delivery::rebind_and_wait(app_handle, terminal_id).await
-    {
-        if subs > 0 || inbox > 0 {
-            log::info!(
-                "[session-context] 引き継ぎ待ちを回収した terminal={} 購読={} 未読={}",
-                terminal_id,
-                subs,
-                inbox
-            );
-        }
+    // DB 未初期化なら `DeliveryHandle` も manage されていないので、ここで弾かなくても
+    // no-op になる。早期 return は無駄なチャネル往復を避けるためだけのもの。
+    app_handle.try_state::<crate::event_db::EventPool>()?;
+    crate::event_delivery::collect_digest_and_wait(app_handle, terminal_id, reason).await
+}
+
+// ─── Simple REST endpoint (/turn-context) ────────────────────────────────────
+
+/// Stop フックの stdin JSON から `(prompt_id, stop_hook_active)` を読む（#124）。
+///
+/// Phase 0 (#121) の実測で CC 2.1.227 の Stop payload には両方が実在することが確認済み。
+/// `stop_hook_active` は初回発火が `false`、`additionalContext` による継続後の発火はすべて
+/// `true` になる。パースできない場合は「継続ターンではない」に倒す（配送側は
+/// `prompt_id` 単位の上限と `delivered_at` でも守られているため、ここで止める必要はない）。
+fn parse_stop_hook_fields(hook_json: Option<&str>) -> (Option<String>, bool) {
+    let Some(v) = hook_json.and_then(|j| serde_json::from_str::<serde_json::Value>(j).ok()) else {
+        return (None, false);
+    };
+    let prompt_id = v
+        .get("prompt_id")
+        .and_then(|p| p.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let stop_hook_active = v
+        .get("stop_hook_active")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    (prompt_id, stop_hook_active)
+}
+
+/// Stop フック (--turn-context) 用。そのタブ宛の未読を `additionalContext` 本文として返す。
+///
+/// **`Stop` の `additionalContext` は会話を継続させる**ので、無条件に返すと未読が残る限り
+/// 永久に回る。防波堤は3枚（#120 §5.1・Phase 0 の訂正コメント）:
+///
+/// 1. `stop_hook_active == true`（= この Stop 自体が hook 由来の継続ターンの終わり）なら返さない
+/// 2. `prompt_id` 単位で1ターン1回（`event_delivery` のワーカーが持つ）
+/// 3. `delivered_at` による二重注入防止（`inbox` の UNIQUE 制約と `mark_delivered`）
+///
+/// CC 側にも継続9回で自然停止する上限があるが、**打ち切りが呼び出し側から判別できない**
+/// （警告が出ず headless の結果 JSON も `is_error: false`）ため依存しない。
+async fn turn_context_handler(
+    State(app_handle): State<AppHandle>,
+    Json(payload): Json<TurnContextPayload>,
+) -> Json<serde_json::Value> {
+    let (prompt_id, stop_hook_active) = parse_stop_hook_fields(payload.hook_json.as_deref());
+    if stop_hook_active {
+        log::debug!(
+            "[turn-context] stop_hook_active=true のため配送しない terminal={:?} prompt_id={:?}",
+            payload.terminal_id,
+            prompt_id
+        );
+        return Json(serde_json::json!({ "inbox": serde_json::Value::Null }));
     }
-    let items = match crate::event_db::list_inbox(
-        &pool,
-        terminal_id,
-        crate::event_db::InboxFilter::Undelivered,
+    // サイドカーの読み取りタイムアウトは 2 秒。それを超えるとレスポンス自体が捨てられる。
+    // DB が詰まっている場合は諦める。諦めた分は打刻していないので次の機会に再度出る。
+    let inbox = match tokio::time::timeout(
+        std::time::Duration::from_millis(INBOX_DIGEST_BUDGET_MS),
+        collect_inbox_digest(
+            &app_handle,
+            payload.terminal_id.as_deref(),
+            crate::event_delivery::DigestReason::TurnEnd {
+                prompt_id: prompt_id.clone(),
+            },
+        ),
     )
     .await
     {
-        Ok(items) => items,
-        Err(e) => {
-            log::warn!("[session-context] inbox 取得に失敗: {}", e);
-            return None;
+        Ok(inbox) => inbox,
+        Err(_) => {
+            log::warn!(
+                "[turn-context] inbox の取得が {}ms を超えたため今回は注入を見送る (terminal={:?})",
+                INBOX_DIGEST_BUDGET_MS,
+                payload.terminal_id
+            );
+            None
         }
     };
-    // 配送済みだが未 ack のまま残っている件数（今回本文を出す分は差し引く）
-    let carryover = match crate::event_db::count_unacked(&pool, terminal_id).await {
-        Ok((unacked, _)) => (unacked - items.len() as i64).max(0),
-        Err(e) => {
-            log::warn!("[session-context] 未 ack 件数の取得に失敗: {}", e);
-            0
-        }
-    };
-    let digest = crate::event_db::format_inbox_digest(&items, carryover)?;
-    let ids: Vec<String> = items.iter().map(|i| i.id.clone()).collect();
-    if let Err(e) = crate::event_db::mark_delivered(&pool, &ids, crate::event_db::now_ms()).await {
-        // 打刻に失敗しても本文は返す。未配送のまま残るので次回のセッション開始で再度出る
-        // （取りこぼすより一度重複するほうが安全）。
-        log::warn!("[session-context] mark_delivered に失敗: {}", e);
+    match &inbox {
+        Some(_) => log::info!(
+            "[turn-context] ターン境界で未読を注入する terminal={:?} prompt_id={:?}",
+            payload.terminal_id,
+            prompt_id
+        ),
+        // 注入しなかったことも残す。Stop はターンごとに必ず来るので、ここが無いと
+        // 「hook が届いていない」のか「未読が無かった」のかログから切り分けられない。
+        None => log::debug!(
+            "[turn-context] 注入なし terminal={:?} prompt_id={:?}",
+            payload.terminal_id,
+            prompt_id
+        ),
     }
-    Some(digest)
+    Json(serde_json::json!({ "inbox": inbox }))
 }
 
 // ─── Simple REST endpoint (/prompt-context) ──────────────────────────────────
 
-/// UserPromptSubmit フック (--prompt-context) 用。現在の description を返す。
-/// ワークツリー単位でスロットルし、期間内の再送・未解決時は {"skip":true} を返す
-/// （サイドカーは skip 時に何も出力せず exit 0 する）。
+/// UserPromptSubmit フック (--prompt-context) 用。現在の description と未読を返す。
+///
+/// description はワークツリー単位でスロットルし、期間内の再送・未解決時は `skip: true` を
+/// 返す（サイドカーは description を出力しない）。
+///
+/// **イベント配送はこのスロットルの対象外**（#120 §5.3）。スロットルは description の再注入
+/// 頻度を抑えるためのもので、600 秒に1回しか未読を渡せないのでは Stop の取りこぼし回収に
+/// ならない。よって `skip` は description 側だけを支配し、`inbox` は毎回計算する。
 const PROMPT_CONTEXT_THROTTLE_SECS: u64 = 600;
 
 async fn prompt_context_handler(
     State(app_handle): State<AppHandle>,
     Json(payload): Json<PromptContextPayload>,
 ) -> Json<serde_json::Value> {
-    let settings = app_handle.state::<SettingsManager>().get();
+    // 未読の回収はワークツリー解決にもスロットルにも依存させない。鍵は terminal_id だけ。
+    // ここで諦めても打刻していないので次のプロンプト送信で再度出る。
+    let inbox = match tokio::time::timeout(
+        std::time::Duration::from_millis(INBOX_DIGEST_BUDGET_MS),
+        collect_inbox_digest(
+            &app_handle,
+            payload.terminal_id.as_deref(),
+            crate::event_delivery::DigestReason::PromptSubmit,
+        ),
+    )
+    .await
+    {
+        Ok(inbox) => inbox,
+        Err(_) => {
+            log::warn!(
+                "[prompt-context] inbox の取得が {}ms を超えたため今回は注入を見送る (terminal={:?})",
+                INBOX_DIGEST_BUDGET_MS,
+                payload.terminal_id
+            );
+            None
+        }
+    };
 
+    let settings = app_handle.state::<SettingsManager>().get();
     let Some(wt) = payload
         .project_dir
         .as_deref()
         .and_then(|d| resolve_worktree_by_dir(&settings, d))
     else {
         log::debug!(
-            "[prompt-context] could not resolve worktree (projectDir={:?}); skipping",
+            "[prompt-context] could not resolve worktree (projectDir={:?}); skipping description",
             payload.project_dir
         );
-        return Json(serde_json::json!({ "skip": true }));
+        return Json(serde_json::json!({ "skip": true, "inbox": inbox }));
     };
 
     let manager = app_handle.state::<McpServerManager>();
@@ -3318,21 +3410,23 @@ async fn prompt_context_handler(
             .unwrap_or_else(|e| e.into_inner());
         if let Some(prev) = map.get(&wt.id) {
             if now.duration_since(*prev).as_secs() < PROMPT_CONTEXT_THROTTLE_SECS {
-                return Json(serde_json::json!({ "skip": true }));
+                return Json(serde_json::json!({ "skip": true, "inbox": inbox }));
             }
         }
         map.insert(wt.id.clone(), now);
     }
 
     log::info!(
-        "[prompt-context] worktree={} terminal={:?} description={:?}",
+        "[prompt-context] worktree={} terminal={:?} description={:?} inbox_len={:?}",
         wt.name,
         payload.terminal_id,
-        wt.description
+        wt.description,
+        inbox.as_ref().map(|s| s.len())
     );
     Json(serde_json::json!({
         "worktreeName": wt.name,
         "description": wt.description,
+        "inbox": inbox,
     }))
 }
 
@@ -3594,6 +3688,13 @@ pub fn cleanup_port_file(app_handle: &AppHandle) {
 // ─── Server startup ───────────────────────────────────────────────────────────
 
 pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
+    // `settings.json` は本番と全 dev インスタンスで共有されるため、別ワークツリーで
+    // dev ビルドを立ち上げると `mcpPort` を奪い合って bind に失敗する。env で退避できる
+    // ようにしておく（`MCP_PORT_OVERWRITE=false` と併用すれば mcp-server.json も奪わない）。
+    let port = std::env::var("ORETACHI_MCP_PORT")
+        .ok()
+        .and_then(|v| v.parse::<u16>().ok())
+        .unwrap_or(port);
     let manager = app_handle.state::<McpServerManager>();
 
     // 既存サーバーを停止
@@ -3758,6 +3859,7 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
             .route("/set-description", post(set_description_handler))
             .route("/session-context", post(session_context_handler))
             .route("/prompt-context", post(prompt_context_handler))
+            .route("/turn-context", post(turn_context_handler))
             .with_state(app_handle.clone())
             .layer(middleware::from_fn(move |mut req: Request, next: Next| {
                 let key = api_key_state.clone();
@@ -3857,6 +3959,51 @@ pub fn start_mcp_server(app_handle: AppHandle, port: u16, remote_access: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Phase 0 (#121) で実測した Stop payload そのもの（CC 2.1.227 / Windows 10）。
+    /// #120 本文は「`stop_hook_active` 相当のフラグは現行ドキュメントに見当たらない」と
+    /// していたが、実在することが確認され訂正されている。ここに生データを残しておく。
+    const STOP_PAYLOAD: &str = r#"{
+        "session_id": "bcbd95af-3066-4bc9-9b6b-98fabdd3ef8b",
+        "transcript_path": "X:/t.jsonl",
+        "cwd": "X:/wt/foo",
+        "prompt_id": "46513e5d-9375-47f3-a6c0-c3a4452eb2fa",
+        "permission_mode": "default",
+        "effort": { "level": "medium" },
+        "hook_event_name": "Stop",
+        "stop_hook_active": false,
+        "last_assistant_message": "2",
+        "background_tasks": [],
+        "session_crons": []
+    }"#;
+
+    #[test]
+    fn test_parse_stop_hook_fields_initial_firing() {
+        let (prompt_id, active) = parse_stop_hook_fields(Some(STOP_PAYLOAD));
+        assert_eq!(prompt_id.as_deref(), Some("46513e5d-9375-47f3-a6c0-c3a4452eb2fa"));
+        assert!(!active, "初回発火は stop_hook_active=false");
+    }
+
+    #[test]
+    fn test_parse_stop_hook_fields_continuation() {
+        let json = STOP_PAYLOAD.replace("\"stop_hook_active\": false", "\"stop_hook_active\": true");
+        let (prompt_id, active) = parse_stop_hook_fields(Some(&json));
+        // 継続ターンでも prompt_id は不変（1発話に対する9回の発火すべてで同一値だった）
+        assert_eq!(prompt_id.as_deref(), Some("46513e5d-9375-47f3-a6c0-c3a4452eb2fa"));
+        assert!(active);
+    }
+
+    #[test]
+    fn test_parse_stop_hook_fields_missing_or_broken() {
+        assert_eq!(parse_stop_hook_fields(None), (None, false));
+        assert_eq!(parse_stop_hook_fields(Some("not json")), (None, false));
+        assert_eq!(parse_stop_hook_fields(Some("{}")), (None, false));
+        // 空文字の prompt_id は「取れなかった」と同じ扱い（1ターン1回の鍵にできない）
+        assert_eq!(
+            parse_stop_hook_fields(Some(r#"{"prompt_id":"  ","stop_hook_active":true}"#)),
+            (None, true)
+        );
+    }
 
     /// name 未設定のグループは UI 側 (useWorkgroups.displayName / i18n workgroup.autoName) が
     /// 並び順から「グループ(N)」を自動生成して表示する。MCP が生の name をそのまま返すと

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -57,12 +57,15 @@ export interface TerminalUnread {
 /** 配送トーストのペイロード（Rust の `event-delivered`）。 */
 export interface DeliveredPayload {
   terminalId: string;
-  sessionId: number;
+  /** PTY 押し込み (`method: "pty"`) のみ。Stop フック経由の注入では PTY を触らないので入らない。 */
+  sessionId?: number;
   worktreeId: string | null;
   worktreeName: string | null;
-  agentName: string | null;
+  /** 同上。押し込み時のみ。 */
+  agentName?: string | null;
   count: number;
   text: string;
+  /** `"pty"`（押し込み）または `"stop"`（Stop フックのターン境界配送、#124）。 */
   method: string;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,9 @@ export default defineConfig(async () => ({
       ? {
           protocol: "ws",
           host,
-          port: 1421,
+          // 既定 (devPort=1420) では従来どおり 1421。devPort をずらしたときも
+          // HMR ポートが元の dev ポートと衝突しないよう追従させる。
+          port: devPort + 1,
         }
       : undefined,
     watch: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import VueI18nPlugin from "@intlify/unplugin-vue-i18n/vite";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+// 別ワークツリーで dev ビルドを同時に立ち上げると 1420 が衝突して起動できないため、
+// env で退避できるようにする（tauri 側は `tauri dev --config` で devUrl を合わせる）。
+// @ts-expect-error process is a nodejs global
+const devPort = Number(process.env.ORETACHI_DEV_PORT) || 1420;
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
@@ -20,7 +24,7 @@ export default defineConfig(async () => ({
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
-    port: 1420,
+    port: devPort,
     strictPort: true,
     host: host || false,
     hmr: host

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import VueI18nPlugin from "@intlify/unplugin-vue-i18n/vite";
 const host = process.env.TAURI_DEV_HOST;
 // 別ワークツリーで dev ビルドを同時に立ち上げると 1420 が衝突して起動できないため、
 // env で退避できるようにする（tauri 側は `tauri dev --config` で devUrl を合わせる）。
+// HMR が devPort + 1 を使うので、**複数インスタンスを立てるときは 2 以上離すこと**
+// （strictPort: true なので衝突すると起動に失敗する）。
 // @ts-expect-error process is a nodejs global
 const devPort = Number(process.env.ORETACHI_DEV_PORT) || 1420;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,46 +1,59 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 import VueI18nPlugin from "@intlify/unplugin-vue-i18n/vite";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+
 // 別ワークツリーで dev ビルドを同時に立ち上げると 1420 が衝突して起動できないため、
 // env で退避できるようにする（tauri 側は `tauri dev --config` で devUrl を合わせる）。
 // HMR が devPort + 1 を使うので、**複数インスタンスを立てるときは 2 以上離すこと**
 // （strictPort: true なので衝突すると起動に失敗する）。
-// @ts-expect-error process is a nodejs global
-const devPort = Number(process.env.ORETACHI_DEV_PORT) || 1420;
+//
+// vite は `.env` を `process.env` へは載せないので、Rust 側（dotenvy）と同じように
+// `.env` で指定できるよう `loadEnv` も見る。シェルの環境変数を優先する。
+// 空文字は未設定と同じ扱い（`.env` には既定値のドキュメントとして空値を置いてある）。
+function resolveDevPort(mode: string): number {
+  // @ts-expect-error process is a nodejs global
+  const fromShell = process.env.ORETACHI_DEV_PORT;
+  // @ts-expect-error process is a nodejs global
+  const fromFile = loadEnv(mode, process.cwd(), "").ORETACHI_DEV_PORT;
+  return Number(fromShell || fromFile) || 1420;
+}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    tailwindcss(),
-    vue(),
-    VueI18nPlugin({ defaultSFCLang: 'json' }),
-  ],
+export default defineConfig(async ({ mode }) => {
+  const devPort = resolveDevPort(mode);
+  return {
+    plugins: [
+      tailwindcss(),
+      vue(),
+      VueI18nPlugin({ defaultSFCLang: 'json' }),
+    ],
 
-  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
-  //
-  // 1. prevent Vite from obscuring rust errors
-  clearScreen: false,
-  // 2. tauri expects a fixed port, fail if that port is not available
-  server: {
-    port: devPort,
-    strictPort: true,
-    host: host || false,
-    hmr: host
-      ? {
-          protocol: "ws",
-          host,
-          // 既定 (devPort=1420) では従来どおり 1421。devPort をずらしたときも
-          // HMR ポートが元の dev ポートと衝突しないよう追従させる。
-          port: devPort + 1,
-        }
-      : undefined,
-    watch: {
-      // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
+    // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+    //
+    // 1. prevent Vite from obscuring rust errors
+    clearScreen: false,
+    // 2. tauri expects a fixed port, fail if that port is not available
+    server: {
+      port: devPort,
+      strictPort: true,
+      host: host || false,
+      hmr: host
+        ? {
+            protocol: "ws",
+            host,
+            // 既定 (devPort=1420) では従来どおり 1421。devPort をずらしたときも
+            // HMR ポートが元の dev ポートと衝突しないよう追従させる。
+            port: devPort + 1,
+          }
+        : undefined,
+      watch: {
+        // 3. tell Vite to ignore watching `src-tauri`
+        ignored: ["**/src-tauri/**"],
+      },
     },
-  },
-}));
+  };
+});


### PR DESCRIPTION
Closes #124 （親: #120 Phase 2）

## 概要

走行中（ターンの途中）の受信側へ、`Stop` フックの `additionalContext` 経由で未読を注入する。注入すると会話がそのまま継続するので、エージェントがその場で着手する。**#120 の配送設計の本命。**

Phase 3 (#131) は busy 宛の押し込みを `Skip("エージェントが走行中")` で落とし、コメントで「busy はターン境界配送（#124 の Stop フック）の担当」と明示していた。本 PR がその穴を埋める。

Phase 0 (#121) の実測により、#120 §5.1 の前提2箇所が訂正されている（[訂正コメント](https://github.com/ishida-supsys/oretachi/issues/120#issuecomment-5251714516)）。本 PR は訂正後を正としている。

## 判断

| 論点 | 判断 |
|---|---|
| hook の登録先 | `Stop` に **2つ目のグループ**を足す（`--notify` の出力仕様は変えない）。`--notify` は6イベント共有で `post_json`（read **500ms** / body を読まない / 失敗時 `exit(1)`）。body を読むために `post_json_read_body`（read 2s）へ切り替えると Stop 以外の5イベントまで遅くなる。加えて additionalContext を返す経路は「失敗しても無出力で必ず `exit 0`」（`notify/src/main.rs` に明記の方針）でなければならず、`exit(1)` しうる `--notify` とは方針が逆。`PermissionRequest` に ExitPlanMode グループを追記しているのと同じ構造 |
| 無限ループ対策 | 3枚。① `stop_hook_active == true` なら配送しない（サイドカーで早期打ち切り＋サーバ側でも判定）② `prompt_id` 単位で1ターン1回 ③ `delivered_at`。**CC 側の継続9回上限には依存しない**（打ち切り時に警告が出ず headless の結果 JSON も `is_error: false` なので、打ち切られたことを呼び出し側から判別できない） |
| drain の置き場所 | `event_delivery.rs` の**単一ワーカーへ集約**した（SessionStart / UserPromptSubmit も含む）。#125 が作った直列キューの外で「未配送を SELECT → 注入 → 打刻」をやると、その隙間に走った `push_pending` が同じ行を PTY へ流して**同じ本文が二重に届く**（`mark_delivered` の `WHERE delivered_at IS NULL` は打刻を冪等にするだけで、読み取りと注入のインターリーブは防げない）。並行する第二のガバナは作っていない |
| Stop 経路の制限 | `passive` を除外し `auto_approval_allows` を通す。**Stop の additionalContext はターンを開始させる**ので押し込みと同じ危険度を持つ。`SessionStart` / `PromptSubmit` は人間の操作が起点なので Phase 1 の挙動を維持した |
| 件数だけの通知 | Stop では出さない。`format_inbox_digest` は本文0件でも未 ack 残件があれば「N 件残っています」を返すが、それを Stop で注入すると**毎ターン残件を報告するためだけに会話が継続する** |
| `UserPromptSubmit` | 600 秒スロットル（`PROMPT_CONTEXT_THROTTLE_SECS`）は **description だけを支配する**よう意味を縮小し、未読の回収はスロットル対象外にした（#120 §5.3）。レスポンスは `{worktreeName, description, skip, inbox}` |
| 押し込み判定 | **一切変更していない**。Stop が先に drain した分だけ押し込みが自然に減る |

## 変更内容

### 1. `notify/src/main.rs` — `--turn-context` モード

既存4モードと同じ「薄い IO ラッパ + 純粋関数」の流儀。純粋関数2本を追加:

- `should_request_turn_context(hook_json)` — `stop_hook_active == true` のときだけ `false`。**継続ターンではサーバを起こさない**（無駄な TCP 往復と読み取り待ちを hook のクリティカルパスから消す）。パース不能・欠落は `true`（サーバ側でも判定し、さらに `prompt_id` と `delivered_at` があるので安全側に倒しても暴走しない）
- `build_turn_context_output(body)` — `{"inbox": ...}` から `hookSpecificOutput.hookEventName = "Stop"` の JSON を組む。未読なしは `None`（＝何も出さない＝そのままターンが終わる）

`--prompt-context` は description と inbox の連結に変更。`skip: true` でも inbox があれば出力する。`inbox` を返さない旧サーバとの後方互換は「欠落 = None」で担保。

### 2. `claude_plugin.rs` — `Stop` に2つ目のグループ

`--turn-context --project-dir ${CLAUDE_PROJECT_DIR}`。既存の `--notify --event Stop --agent cc` はそのまま残す。`generate_plugin_files` は毎起動 hooks.json を書き直すので配布は自動。

### 3. `event_delivery.rs` — 直列ワーカーへ drain を集約

- `DigestReason { SessionStart, TurnEnd { prompt_id }, PromptSubmit }` と `DeliveryMsg::CollectDigest` を追加。`collect_digest_and_wait` は `rebind_and_wait` と同じ oneshot パターン（ワーカーが詰まっていれば `None` に劣化）
- `WorkerState.last_turn: HashMap<terminal_id, prompt_id>`。`Reconcile` で生存タブだけに `retain`
- 旧 `rebind_and_wait` は呼び出し元が無くなったので削除（役割は `CollectDigest` が内包）。`DeliveryMsg::Rebind` の `reply` も未使用になったので落とした
- **`reply.send` が成功してから `mark_delivered` する**（2つ目のコミット）。`collect_digest` はハンドラの `INBOX_DIGEST_BUDGET_MS` タイムアウトの外側（ワーカーのキュー）で走るため、先に打刻すると「配送済みだが誰も受け取っていない」本文が生まれ、再送しない方針（#120 §5.2）のせいで永久に失われる。`push_pending` の「`pty.write` が成功してから打刻する」と同じ不変条件

`decide_push` / `push_pending` / `strongest_delivery` / `spawn_for_closed_tabs` は無変更。

### 4. `mcp_server.rs` — `/turn-context`

`parse_stop_hook_fields`（`prompt_id` / `stop_hook_active` を読む純粋関数）と `turn_context_handler`。`collect_inbox_digest` は `collect_digest_and_wait` を呼ぶ薄いラッパになった。

### 5. 並行 dev ビルドのためのポート退避（副次）

別ワークツリーで dev ビルドが動いていると **4000 (tauri-mcp) の bind 失敗で起動そのものが panic** し、`settings.json` の `mcpPort` も奪い合いになるため、実機確認ができなかった。env で退避できるようにした:

- `ORETACHI_TAURI_MCP_PORT`（既定 4000）
- `ORETACHI_MCP_PORT`（既定は `settings.mcpPort`）
- `ORETACHI_DEV_PORT`（vite。既定 1420。HMR は `devPort + 1` で追従）

いずれも未設定時は従来と同一。`MCP_PORT_OVERWRITE=false` と併用すれば `mcp-server.json` を奪わずに dev を並走できる。

**3本とも `.env` に空値で並べてある**（既定値のドキュメントを兼ねる）。`dotenvy` は空文字もプロセス環境へ載せるため、「空 = 未設定」を `parse_port_override` に切り出してテストで固定した（弾かないと本番の MCP ポートが 0 になる）。また vite は `.env` を `process.env` へ載せないので、`ORETACHI_DEV_PORT` だけ `.env` に書いても効かない状態だった。`loadEnv` も見るようにして Rust 側と挙動を揃えている（シェルの環境変数が優先）。実機で `.env` に `1437` を入れて vite がそのポートで起動することを確認済み。

## テスト

- `cd src-tauri && cargo check` ✅ / `cargo test` ✅ **162 件**（147 → +15）
- `cargo test -p oretachi-notify` ✅ **41 件**（31 → +10）
- `pnpm run type-check` ✅

主なテスト:
- `should_request_turn_context` — **Phase 0 の実測 payload をそのままテスト入力にした**。初回 (`stop_hook_active: false`) は問い合わせ、継続 (`true`) は打ち切り、欠落・不正 JSON・`"true"`（文字列）は問い合わせ側に倒す
- `parse_stop_hook_fields` — 同じ実測 payload から `prompt_id` と `stop_hook_active` が取れること。空白のみの `prompt_id` は「取れなかった」扱い
- `should_deliver_turn` — 同一 `prompt_id` の2回目は false / 別 `prompt_id` は true / `None` は true
- `filter_for_turn_end` — **passive を巻き込まない**（Phase 3 が踏んだバグの再発防止）/ autoApproval ON では `worktree.closed` のみ通る
- `test_roundtrip_turn_end_drain_is_scoped_to_one_tab` — #124 の完了条件「複数タブで誤配送しない」。B タブの drain で A タブ宛が消えず、B タブの2回目は空
- `build_prompt_context_output_inbox_survives_throttle` — `skip: true` でも inbox は出る
- `build_hooks_json_registers_turn_context_alongside_notify` — Stop が2グループ、他イベントは1グループのまま

## 実機確認

本番 oretachi を止めず、dev ビルドを**独立ポート**（MCP 9163 / tauri-mcp 4002 / vite 1425）で起動して検証した。**`MCP_PORT_OVERWRITE=false` にして `mcp-server.json` を奪わないようにし**、テスト用 CC には `APPDATA` を差し替えた一時ディレクトリ（dev の port/apiKey を書いた `mcp-server.json` を置く）と `claude --settings <一時JSON>` で新サイドカーの hook を与えた。同時に走っていた #130 の dev インスタンスの hook 経路は最後まで奪っていない。

| # | 確認項目 | 結果 |
|---|---|---|
| 1 | 走行中への注入と会話の継続 | ✅ ターン実行中に対象をクローズ → ターン終了時に `[turn-context] ターン境界で未読を注入する` → **会話が継続し、エージェントが通知内容を読んで報告・ack を試みた**（12トピックの回答完了後に継続ターンが走った） |
| 2 | 無限ループが起きない | ✅ 注入は `prompt_id` ごとに1回だけ。同じ `prompt_id` の2回目は無出力。`stop_hook_active: true` の Stop も無出力。**headless 実行は正常終了**（CC の9回上限には達していない） |
| 3 | 複数タブで誤配送しない | ✅ A タブ宛の未読が積まれた状態で B タブの `terminal_id` で Stop を撃つ → **無出力**。同じ payload を A タブの `terminal_id` で撃つと本文が返る |
| 4 | UserPromptSubmit の取りこぼし回収 | ✅ 1回目で description + 未読、**600 秒以内の2回目は description が消え未読だけが出る**（スロットル対象外になっている） |
| 5 | `passive` は Stop で注入しない | ✅ 無出力。同じ未読は `oretachi_poll_inbox` では取得できる |
| 6 | oretachi 非稼働時 | ✅ `mcp-server.json` が無い状態で `exit=0` / 無出力（claude 側に警告が出ない） |

検証後、使い捨てワークツリー（`v124-sub` / `v124-tgt2`〜`tgt8`）・ブランチ・settings の登録はすべて削除済み。`mcp-server.json` は一度も上書きしていない。

### 実機で分かったこと（コード修正には至らない）

- **待機中のタブでは Stop より先に押し込み / UserPromptSubmit が drain する。** これは設計どおり（押し込み条件は変更していないので、idle かつ静穏なら従来どおり押し込みが勝つ）。Stop 経路が主役になるのは「ターン実行中に届いた未読」で、そこは 1 で確認した
- サイドカーは `%APPDATA%\com.ia.oretachi\mcp-server.json` からポートと API キーを読むため、dev の検証では `APPDATA` の差し替えが最も副作用の少ない分離手段だった

## セルフレビュー

CLAUDE.md の `codex-review` を実行したが、**MCP ツール呼び出し（`oretachi_set_description`）で無応答のまま10分以上進まなかった**ため打ち切った（直近2回のクレジット切れとは別の症状）。代わりに `/bug-review` + バリデータサブエージェントによる再検証で代替した。

`/bug-review` + バリデータを**2周**実施した（2周目は1周目の修正コミットを含めて再検証）。critical / warning 級の未対応指摘は 0 件。

### 1周目のレビューで対応した指摘

**[WARNING] `UserPromptSubmit` で「件数だけのダイジェスト」が毎プロンプト注入される**（バリデータの新規発見）

`format_inbox_digest` は本文が0件でも未 ack 残件があれば「N 件残っています。`oretachi_poll_inbox` で確認し `oretachi_ack_message` で ack してください」を返す。これは Phase 1 の「注入が失われても気づけるように」（#120 §5.2）という設計だが、**`SessionStart`（1セッション1回）でしか成立しない**。`Stop` 側には「件数だけでターンを開始させない」ガードを入れていたが、`UserPromptSubmit` に同じガードが無く、**ack するまでユーザーの全プロンプトの先頭に催促が付きまとう**状態だった（inbox はスロットル対象外なので 600 秒スロットルでも止まらない）。従来 `/prompt-context` は inbox を返さなかったので、本 PR 由来のデグレ。

→ 件数のみの報告を許すのは `SessionStart` だけにした（`DigestReason::reports_carryover_only`）。回帰テスト追加。実機ログにも「未確認（未 ack）のワークツリーイベントが 4 件残っています」が出ており、実際に踏んでいた。

**[SUGGESTION] `vite.config.ts` の `hmr.port` が 1421 固定**

→ `devPort + 1` に追従させた（既定 1420 では従来どおり 1421）。

### 2周目のレビューで対応した指摘

**[SUGGESTION] 自動承認の判定を代表1件から引いていた**

`filter_for_turn_end` が `items.first().subscriber_worktree_id` からワークツリーを解決して全件に適用していた。1タブが `cd` して別ワークツリーで再購読すると同じ `terminal_id` の inbox に異なる宛先の行が混ざり、**実際の宛先ではないワークツリーの `autoApproval` 設定で全件を判定する**。#131 が手動引き継ぎ先の検証で塞いだのと同じ穴。→ 行ごとにその行自身の `subscriber_worktree_id` で判定するよう変更（`push_pending` より厳密になった）。テスト2件追加。

**[SUGGESTION] 引き継ぎ対象が無いタブが毎ターン DB を叩き続ける**

`state.claimed` には「1グループ引き継いだ」タブしか入らないため、引き継ぐものが無いタブは永久に `claimed` に入らず、`Stop` / `UserPromptSubmit` のたびに `list_orphaned_groups` が走る（events.db は非 WAL）。→ `rebind_probed` に記録して抑止し、**新しい引き継ぎ待ちが生まれる `Reconcile`（生存タブ変化時）で忘れる**。取りこぼさないことは「orphaned グループが増えるのは `mark_orphaned_subscribers` だけ」という事実から担保。

**[SUGGESTION] `reports_carryover_only` のコメントが不正確**

「`SessionStart` は1セッション1回」と書いていたが、SessionStart は `resume` / `clear` / `compact` でも発火する。→ コメントを実態に合わせて修正（頻度が毎プロンプトより桁違いに低いという判断自体は変わらない）。

**[SUGGESTION] `ORETACHI_DEV_PORT` は 2 以上離す必要がある**

HMR が `devPort + 1` を使うため。→ コメントに明記。

### 対応しないと判断した指摘

- **`event-delivered` トーストが「モデルに届いた」を保証しない** → 記録のみ。`reply.send` の成功は axum ハンドラが待っていることしか示さず、その後サイドカーの読み取りが落ちれば本文は失われる。ただし ① 同じ性質は既存の PTY 押し込み経路（`pty.write` 成功 ≠ エージェントが着手）にもある ② 未 ack として残るので UI の未読バッジと `oretachi_poll_inbox` で必ず回収できる。文言変更は i18n を伴い既存経路との一貫性も崩すため見送った

### 1周目で格下げ / 棄却された指摘（対応不要と判断）

- **単一ワーカーの飢餓**（自己指摘）→ 格下げ。`CollectDigest` 分岐は `drive()` を呼ばないので hook 経路自体は 150ms sleep を発生させない。head-of-line blocking は tick / `EventQueued` と同時になった場合のみで、`MIN_PUSH_INTERVAL=30s` と端末数上限から最悪でも約1.8秒。かつタイムアウト時は打刻されず次ターンに回る
- **`--turn-context` の同期コストで毎ターン最大2秒遅延**（自己指摘）→ 格下げ。ハンドラ全体が 1200ms の `timeout` に包まれており、サイドカーの 2s read timeout に到達する経路が実質無い。継続ターンではサイドカーが TCP 往復自体を行わない。既知の webview ハングは JS / tao スレッド側で axum は別ランタイム
- **`prompt_context_handler` の DB 競合**（自己指摘）→ 格下げ。毎プロンプトで走るのは読み取り3本のみ（引き継ぎ対象が無ければ SELECT だけで return）。非 WAL でも読み取り同士は競合しない
- **`event-delivered` トーストと実配送の乖離** → 記録のみ。`reply.send` の成功は「ハンドラがまだ待っている」ことしか保証しない。ただし未 ack として残るので次回の carryover 件数で必ず再浮上し `oretachi_poll_inbox` で回収できる（恒久的な喪失にはならない）
- 独自検証で棄却: `reply.send` → `mark_delivered` の順序 / `should_deliver_turn` / `filter_for_turn_end` の境界 / `parse_stop_hook_fields` の型違い・壊れた JSON / `build_prompt_context_output` の後方互換 / Stop 2グループ化と `migrate_remove_oretachi_hooks` の非干渉 / env ポート上書きの本番影響（未設定時は完全に従来値、`ORETACHI_TAURI_MCP_PORT` は `debug_assertions` 内のみ）

## #126 / #130 との関係

- `event_db.rs` はテスト1件の追加のみ、`mcp_server.rs` は新ルートと2ハンドラの改修のみで、#126 のイベント生成・target 照合とは領域が別。先にマージされた方に合わせて rebase する
- `AUTO_APPROVAL_PUSHABLE_KINDS` は #126 で `worktree.message` が入った瞬間に default-deny として効き始める。Stop 経路にも同じ判定を通してあるので新種別でも自動的に守られる
- `event-delivered` に `method: "stop"` が増える。`sessionId` / `agentName` は押し込み時のみになるため `src/types/event.ts` で optional にした（#130 がサブウィンドウ / トレイへ広げる際はこの2つに依存しないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
