### PR TITLE
feat(event): サブウィンドウ / トレイでの購読配送の可視化 (#130)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -65,11 +65,10 @@ import {
   reportSpawnResult,
   terminalUnread,
 } from "./composables/useEventSubscriptions";
-import type {
-  DeliveredPayload,
-  SpawnRejectedPayload,
-  SpawnTerminalRequest,
-} from "./types/event";
+import { useEventDeliveryToast } from "./composables/useEventDeliveryToast";
+import { collectUnreadByTab } from "./utils/terminalUnread";
+import { mainWindowShowsDelivery } from "./utils/eventToastScope";
+import type { SpawnTerminalRequest } from "./types/event";
 import { terminalMountCount, terminalUnmountCount, terminalActiveCount } from "./components/TerminalView.vue";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { cancelApproval } from "./utils/autoApproval";
@@ -97,6 +96,9 @@ const { worktrees, loadWorktreesFromSettings, syncWorktreesFromSettings, addWork
 const { detachedWorktrees, isDetached, moveToSubWindow, moveToMainWindow, focusSubWindow, unregisterSubWindow, getPendingInitData, clearPendingInitData, getDetachedSessionId, registerTerminalSession, closeAllSubWindows } = useSubWindows();
 const { autoApprovalPromptMap, lastJudgedCommandMap, showAutoApprovalPromptDialog, autoApprovalPromptTargetId, restoreFromSettings: restoreAutoApprovalPrompts, onClickAutoApproval, onSaveAutoApprovalPrompt } = useAutoApprovalPrompt(settings, scheduleSave, isDetached);
 const { notifications, initNotificationListener, addNotification, clearNotification, purgeStaleNotifications, getNotifiedWorktreeIds, getTotalNotificationCount } = useNotifications();
+// 購読イベントの配送トースト（#120 §7 / #130）。Rust 側は全 webview へブロードキャストするので、
+// **そのワークツリーを表示しているウィンドウだけ**が出す。分離済みならサブウィンドウの担当。
+useEventDeliveryToast({ shouldShow: (wid) => mainWindowShowsDelivery(wid, isDetached) });
 const { openTrayPopup, closeTrayPopup, getPendingWorktrees, clearPendingWorktrees, setCurrentTrayWorktreeId, isTrayShowingWorktree, focusTrayWindow } = useTrayPopup();
 const { closeAllCodeReviewWindows } = useCodeReviewWindow();
 const { openArtifactViewer, closeArtifactWindow } = useArtifactWindow();
@@ -180,14 +182,8 @@ const terminalWebSessions = reactive(new Map<number, import("./types/terminal").
 // session_id → terminalId の逆引きで詰め替える。
 const terminalUnreadByTab = computed(() => {
   const result = new Map<number, number>();
-  if (terminalUnread.value.size === 0) return result;
   for (const [, bundle] of worktreeFrameBundles) {
-    for (const [tid, termRef] of bundle.terminalRefs) {
-      const sid = termRef?.sessionId;
-      if (sid == null) continue;
-      const count = terminalUnread.value.get(sid);
-      if (count) result.set(tid, count);
-    }
+    collectUnreadByTab(terminalUnread.value, bundle.terminalRefs, result);
   }
   return result;
 });
@@ -1527,39 +1523,6 @@ onMounted(async () => {
     },
   );
 
-  // 購読イベントの配送（issue #120 §7 / #125）。
-  // 配送を画面に出さないと「勝手にエージェントが動き出した」ように見えるので、
-  // PTY へ押し込んだ瞬間にトーストで知らせる。
-  await listen<DeliveredPayload>("event-delivered", (event) => {
-    const p = event.payload;
-    // 本文は最大 600 字。トーストは幅 260px なので、そのまま出すと画面を埋める。
-    // 全文はエージェント側の画面と購読パネルで読めるので、ここは要約で足りる。
-    const detail = p.text.length > 120 ? `${p.text.slice(0, 120)}…` : p.text;
-    toast.add({
-      severity: "success",
-      summary: t("eventDeliveredSummary", { name: p.worktreeName ?? "", count: p.count }),
-      detail,
-      life: 8000,
-    });
-  });
-
-  // 自動 spawn が端末数上限で拒否された。黙って落とすと「spawn すると言ったのに
-  // 何も起きない」になるので必ず出す。
-  await listen<SpawnRejectedPayload>("event-spawn-rejected", (event) => {
-    const p = event.payload;
-    toast.add({
-      severity: "warn",
-      summary: t("eventSpawnRejectedSummary"),
-      detail: t("eventSpawnRejectedDetail", {
-        name: p.worktreeName,
-        live: p.liveSessions,
-        limit: p.limit,
-        pending: p.pending,
-      }),
-      life: 10000,
-    });
-  });
-
   // 購読者タブが無いワークツリーへ、配送のために新しいタブを立てる（spawn_if_closed）。
   // **成否にかかわらず event_spawn_result を返す**こと。返さないと Rust 側の単一フライトが
   // 60 秒解放されないが、逆に返さないからといって撃ち直しループにはならない。
@@ -2451,7 +2414,9 @@ onMounted(async () => {
           <i v-if="slotProps.message.severity === 'info'" class="pi pi-spinner pi-spin toast-spinner" />
           <div>
             <div class="font-semibold">{{ slotProps.message.summary }}</div>
-            <div class="text-sm">{{ slotProps.message.detail }}</div>
+            <!-- 配送トーストは本文が空になりうる（未知のイベント種別で text が無い場合）。
+                 空の行を描かないようガードする（SubWindowApp.vue の outlet と同じ） -->
+            <div v-if="slotProps.message.detail" class="text-sm">{{ slotProps.message.detail }}</div>
           </div>
         </div>
       </template>
@@ -2468,9 +2433,6 @@ onMounted(async () => {
 <i18n lang="json">
 {
   "en": {
-    "eventDeliveredSummary": "Worktree event delivered ({count})",
-    "eventSpawnRejectedSummary": "Auto spawn declined",
-    "eventSpawnRejectedDetail": "{name} has {pending} unread message(s) but {live} terminals are open (limit {limit}). Close some terminals or open the worktree manually.",
     "eventSpawnedSummary": "Agent started for a subscription",
     "eventSpawnedDetail": "Opened a tab in {name} to deliver {count} unread message(s).",
     "taskAddSummary": "Add Task",
@@ -2509,9 +2471,6 @@ onMounted(async () => {
     "removeRepositoryConfirm": "Unregister \"{name}\"?\n\nThis closes its {terminals} terminal(s) and permanently deletes the artifacts and saved terminal sessions created there. The repository folder itself is not touched."
   },
   "ja": {
-    "eventDeliveredSummary": "ワークツリーイベントを配送しました ({count}件)",
-    "eventSpawnRejectedSummary": "自動 spawn を見送りました",
-    "eventSpawnRejectedDetail": "{name} に未読が {pending} 件ありますが、ターミナルが {live} 個開いています（上限 {limit}）。ターミナルを整理するか、手動でワークツリーを開いてください",
     "eventSpawnedSummary": "購読のためエージェントを起動しました",
     "eventSpawnedDetail": "{name} に未読 {count} 件を届けるためタブを開きました",
     "taskAddSummary": "タスク追加",

--- a/src/SubWindowApp.vue
+++ b/src/SubWindowApp.vue
@@ -23,6 +23,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { logDebug } from "./utils/log";
 import IdeSelectDialog from "./components/IdeSelectDialog.vue";
 import AutoApprovalPromptDialog from "./components/AutoApprovalPromptDialog.vue";
+import Toast from "primevue/toast";
+import { useEventDeliveryToast } from "./composables/useEventDeliveryToast";
+import { initTerminalUnread, terminalUnread } from "./composables/useEventSubscriptions";
+import { collectUnreadByTab } from "./utils/terminalUnread";
+import { subWindowShowsDelivery } from "./utils/eventToastScope";
 import type { SubTerminalEntry, WebSessionInfo, AiSessionInfo } from "./types/terminal";
 import type { FrameNode } from "./types/frame";
 import { useI18n } from "vue-i18n";
@@ -54,6 +59,18 @@ const terminalWebSessions = reactive(new Map<number, WebSessionInfo>());
 
 // terminalId → AIエージェントセッション情報（タブツールチップ用）
 const terminalAiSessions = reactive(new Map<number, AiSessionInfo>());
+
+// タブ（フロントの terminalId）→ 未 ack のワークツリーイベント件数（#120 §7 / #130）。
+// バックエンドは pty の session_id で数えるので、上の pty-ai-agent-changed と同じ
+// session_id → terminalId の逆引きで詰め替える。
+const terminalUnreadByTab = computed(() =>
+  collectUnreadByTab(terminalUnread.value, terminalEntries),
+);
+
+// 配送トースト（#130）。**メインは isDetached のワークツリーを出さない**ので、
+// 分離済みワークツリーの配送を出すのはこのウィンドウの責任。
+// `<script setup>` の同期部分で呼ぶ必要がある（onMounted の await を跨ぐと useToast が失敗する）。
+useEventDeliveryToast({ shouldShow: (wid) => subWindowShowsDelivery(wid, worktreeId) });
 
 // 自動承認フラグ
 const autoApproval = ref(false);
@@ -240,6 +257,9 @@ onMounted(async () => {
   collect(await listen("settings-changed", async () => {
     await loadSettings();
   }));
+
+  // タブ未読バッジの同期（#130）。event-inbox-changed は全 webview に届くので中継は不要。
+  collect(await initTerminalUnread());
 
   // アーティファクト変更時にカウントを更新
   collect(await listen<{ worktreeId: string; artifactId: string; command: string }>("artifact-changed", (event) => {
@@ -605,6 +625,7 @@ async function onCancelAiJudging() {
           :terminal-agent-status="terminalAgentStatus"
           :terminal-web-sessions="terminalWebSessions"
           :terminal-ai-sessions="terminalAiSessions"
+          :terminal-unread="terminalUnreadByTab"
           @switch-terminal="switchTerminal"
           @close-terminal="closeTerminal"
           @title-change="onTerminalTitleChange"
@@ -636,6 +657,21 @@ async function onCancelAiJudging() {
       @save="onSaveAutoApprovalPrompt"
       @cancel="showAutoApprovalPromptDialog = false"
     />
+
+    <!-- 配送トースト (#130)。ToastService は main.ts が全ウィンドウモードに登録済みなので
+         outlet を置くだけでよい。見た目を揃えるため App.vue と同じ #message スロットを使う
+         (スタイルは styles.css の .toast-message-content でグローバル定義済み)。
+         サブウィンドウは進行中トースト (severity=info) を出さないのでスピナーは持たない。 -->
+    <Toast position="bottom-right">
+      <template #message="slotProps">
+        <div class="toast-message-content">
+          <div>
+            <div class="font-semibold">{{ slotProps.message.summary }}</div>
+            <div v-if="slotProps.message.detail" class="text-sm">{{ slotProps.message.detail }}</div>
+          </div>
+        </div>
+      </template>
+    </Toast>
 
     <!-- TerminalView のマウント先。手動 DOM reparenting で terminal-host に移動する -->
     <div data-offscreen style="position:fixed; left:-10000px; top:-10000px; width:1000px; height:1000px; overflow:hidden; pointer-events:none">

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -18,6 +18,8 @@ import type { UrlArtifactEntry } from "./types/artifact";
 import { invoke } from "@tauri-apps/api/core";
 import type { TrayWorktreeData } from "./composables/useTrayPopup";
 import { useWorktreeTaskMap } from "./composables/useWorktreeTaskMap";
+import { initTerminalUnread, terminalUnread } from "./composables/useEventSubscriptions";
+import { collectUnreadByTab } from "./utils/terminalUnread";
 import type { FrameNode } from "./types/frame";
 import type { TrayTerminalEntry } from "./types/terminal";
 import { useI18n } from "vue-i18n";
@@ -46,6 +48,14 @@ const terminalEntries = reactive(new Map<number, TrayTerminalEntry>());
 
 // TerminalView ref 管理
 const terminalRefs = reactive(new Map<number, InstanceType<typeof TerminalView>>());
+
+// タブ（フロントの terminalId）→ 未 ack のワークツリーイベント件数（#120 §7 / #130）。
+// バックエンドは pty の session_id で数えるので詰め替える。terminalEntries は表示中
+// ワークツリーの分だけなので、他ワークツリーの未読が混ざることはない。
+// トレイはトーストを出さない（メイン / サブウィンドウと二重になるため）。バッジのみ。
+const terminalUnreadByTab = computed(() =>
+  collectUnreadByTab(terminalUnread.value, terminalEntries),
+);
 
 // 閉鎖処理の再入防止フラグ
 let closing = false;
@@ -341,9 +351,13 @@ useHotkeyListener(() => {
 let unlistenInit: UnlistenFn | null = null;
 let unlistenSettings: UnlistenFn | null = null;
 let unlistenArtifact: UnlistenFn | null = null;
+let unlistenUnread: UnlistenFn | null = null;
 
 onMounted(async () => {
   await loadSettings();
+
+  // タブ未読バッジの同期（#130）。event-inbox-changed は全 webview に届くので中継は不要。
+  unlistenUnread = await initTerminalUnread();
 
   // 表示中ワークツリーにアーティファクトが登録されたら URL 一覧を追従させる
   unlistenArtifact = await listen<{ worktreeId: string }>("artifact-changed", async (event) => {
@@ -387,6 +401,7 @@ onUnmounted(() => {
   unlistenInit?.();
   unlistenSettings?.();
   unlistenArtifact?.();
+  unlistenUnread?.();
 });
 </script>
 
@@ -500,6 +515,7 @@ onUnmounted(() => {
         v-else-if="terminalEntries.size > 0"
         :node="root"
         :terminal-entries="terminalEntries"
+        :terminal-unread="terminalUnreadByTab"
         @switch-terminal="switchTerminal"
         @close-terminal="closeTerminal"
         @title-change="() => {}"

--- a/src/composables/useEventDeliveryToast.ts
+++ b/src/composables/useEventDeliveryToast.ts
@@ -1,0 +1,107 @@
+import { onScopeDispose } from "vue";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useToast } from "primevue/usetoast";
+import { useI18n } from "vue-i18n";
+import type { DeliveredPayload, SpawnRejectedPayload } from "../types/event";
+
+/** ワークツリー間イベントの配送トースト（issue #120 §7 / #125 / #130）。
+ *
+ *  配送を画面に出さないと「勝手にエージェントが動き出した」ように見える。
+ *  #125 の可視化はメインウィンドウに閉じていたが、**サブウィンドウへ分離した
+ *  ワークツリーこそ黙って動き出したように見える**ので、同じトーストを共有する。
+ *
+ *  ## 表示責任
+ *
+ *  Rust 側は `app.emit`（全 webview へのブロードキャスト）なので、素直に listen すると
+ *  1回の配送で複数ウィンドウがトーストする。`shouldShow` で「そのワークツリーを表示して
+ *  いるウィンドウ」だけに絞り、1配送=1トーストを保つ。
+ *
+ *  ## イベント種別で分岐しないこと
+ *
+ *  本文は Rust 側（`format_inbox_push_text`）が組み立てた `payload.text` を**そのまま**出す。
+ *  `DeliveredPayload` に種別フィールドは無く、ここで `worktree.closed` を前提に文面を
+ *  組み立てることもしない。#126 が `worktree.message`（自由文）を足しても、それ以外の
+ *  未知の種別が来ても、この経路は壊れない。 */
+
+/** トーストの detail に載せる本文の上限。トーストは幅 260px なので全文（最大 600 字）は入らない。
+ *  全文はエージェント側の画面とホームの購読パネルで読める。 */
+const DETAIL_MAX_CHARS = 120;
+
+export interface EventDeliveryToastOptions {
+  /** この配送 / 拒否をこのウィンドウが表示すべきか。
+   *  `worktreeId` はワークツリーを解決できなかったとき null になりうる。 */
+  shouldShow: (worktreeId: string | null) => boolean;
+}
+
+/** `event-delivered` / `event-spawn-rejected` を listen してトーストを出す。
+ *
+ *  **`<script setup>` の同期部分から呼ぶこと。** `useToast` / `useI18n` はコンポーネント
+ *  インスタンスが有効な間しか呼べず、`onMounted` の `await` を跨いだ後では失敗する。
+ *  listen の登録自体は非同期に進み、スコープ破棄時に自動で解除される。 */
+export function useEventDeliveryToast(opts: EventDeliveryToastOptions): { stop: () => void } {
+  const toast = useToast();
+  // 呼び出し側の SFC がローカル <i18n> ブロックを持つとスコープがそちらになるため、
+  // 明示的にグローバルカタログ（src/i18n/{en,ja}.ts）を見る。
+  const { t } = useI18n({ useScope: "global" });
+
+  let unlisteners: UnlistenFn[] = [];
+  let stopped = false;
+
+  function onDelivered(payload: DeliveredPayload): void {
+    if (!opts.shouldShow(payload.worktreeId ?? null)) return;
+    // 本文が欠けていても summary だけで成立させる（未知の種別・将来のペイロード変更に備える）
+    const text = typeof payload.text === "string" ? payload.text : "";
+    const detail = text.length > DETAIL_MAX_CHARS ? `${text.slice(0, DETAIL_MAX_CHARS)}…` : text;
+    toast.add({
+      severity: "success",
+      summary: t("eventDelivery.deliveredSummary", {
+        // 文言が {name} を描画するので、名前が引けないときも空にしない
+        name: payload.worktreeName ?? payload.worktreeId ?? "?",
+        count: payload.count ?? 0,
+      }),
+      detail: detail || undefined,
+      life: 8000,
+    });
+  }
+
+  // 自動 spawn が端末数上限で拒否された。黙って落とすと「spawn すると言ったのに
+  // 何も起きない」になるので必ず出す。
+  function onSpawnRejected(payload: SpawnRejectedPayload): void {
+    if (!opts.shouldShow(payload.worktreeId ?? null)) return;
+    toast.add({
+      severity: "warn",
+      summary: t("eventDelivery.spawnRejectedSummary"),
+      detail: t("eventDelivery.spawnRejectedDetail", {
+        name: payload.worktreeName ?? "",
+        live: payload.liveSessions,
+        limit: payload.limit,
+        pending: payload.pending,
+      }),
+      life: 10000,
+    });
+  }
+
+  void (async () => {
+    const fns = await Promise.all([
+      listen<DeliveredPayload>("event-delivered", (e) => onDelivered(e.payload)),
+      listen<SpawnRejectedPayload>("event-spawn-rejected", (e) => onSpawnRejected(e.payload)),
+    ]);
+    // 登録が終わる前に stop されていたら、その場で解除する（取り残すとリークする）
+    if (stopped) {
+      for (const fn of fns) fn();
+      return;
+    }
+    unlisteners = fns;
+  })();
+
+  function stop(): void {
+    if (stopped) return;
+    stopped = true;
+    for (const fn of unlisteners) fn();
+    unlisteners = [];
+  }
+
+  onScopeDispose(stop);
+
+  return { stop };
+}

--- a/src/composables/useEventSubscriptions.ts
+++ b/src/composables/useEventSubscriptions.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from "vue";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
   OrphanedGroupView,
   SubscriptionView,
@@ -81,14 +81,36 @@ export async function loadSubscriptions(): Promise<void> {
   }
 }
 
+/** `loadSubscriptions` と同じ理由の直列化。`event-inbox-changed` は Reconcile /
+ *  EventQueued / 引き継ぎ / ack など複数箇所から連続で飛ぶので、素朴に叩くと
+ *  `event_terminal_unread` の invoke が並走し、**先発（古い）が後着したときに
+ *  新しいスナップショットを上書き**する。このイベントは変化があったときしか
+ *  飛ばないので、一度ズレると次の変化まで誤った件数で固定される。 */
+let unreadLoading = false;
+let pendingUnreadReload = false;
+
 export async function loadTerminalUnread(): Promise<void> {
-  const rows = await safeInvoke<TerminalUnread[]>("event_terminal_unread", []);
-  liveTerminals.value = rows;
-  const next = new Map<number, number>();
-  for (const row of rows) {
-    if (row.unacked > 0) next.set(row.sessionId, row.unacked);
+  if (unreadLoading) {
+    pendingUnreadReload = true;
+    return;
   }
-  terminalUnread.value = next;
+  unreadLoading = true;
+  try {
+    const rows = await safeInvoke<TerminalUnread[]>("event_terminal_unread", []);
+    liveTerminals.value = rows;
+    const next = new Map<number, number>();
+    for (const row of rows) {
+      if (row.unacked > 0) next.set(row.sessionId, row.unacked);
+    }
+    terminalUnread.value = next;
+  } finally {
+    unreadLoading = false;
+  }
+
+  if (pendingUnreadReload) {
+    pendingUnreadReload = false;
+    await loadTerminalUnread();
+  }
 }
 
 /** 直近の操作エラー。UI が拾ってトーストなどで見せる（握り潰すと黙って失敗する）。 */
@@ -155,4 +177,46 @@ export async function initEventSubscriptions(): Promise<void> {
     void loadSubscriptions();
   });
   await loadSubscriptions();
+}
+
+/** 現在の購読者数。リスナーは1本だけ張り、最後の解除で本当に外す。 */
+let unreadRefCount = 0;
+let unreadUnlisten: UnlistenFn | null = null;
+let unreadPending: Promise<void> | null = null;
+
+/** 未読件数だけを同期する軽量版（#130）。購読パネルを持たないサブウィンドウ /
+ *  トレイポップアップ用。
+ *
+ *  `initEventSubscriptions` との違いは2つ:
+ *  - 購読一覧 / 引き継ぎ待ち一覧は読まない（表示しないので無駄な invoke になる）
+ *  - **unlisten を返す**。サブ / トレイは閉じるウィンドウなので、
+ *    `useEventListeners` の `collect()` や `onUnmounted` で必ず解除する。
+ *
+ *  `initEventSubscriptions` とはフラグを分ける（共有すると片方の抑止でもう片方が
+ *  黙って無効化され、「バッジが出ない」という発見しづらい状態になる）。
+ *  多重呼び出しは参照カウントで扱う。単純な bool ガードだと2人目が no-op の
+ *  unlisten を受け取り、1人目が解除した時点でリスナー不在のまま誰も気づけない。 */
+export async function initTerminalUnread(): Promise<UnlistenFn> {
+  unreadRefCount += 1;
+  if (unreadRefCount === 1) {
+    unreadPending = (async () => {
+      unreadUnlisten = await listen("event-inbox-changed", () => {
+        void loadTerminalUnread();
+      });
+      await loadTerminalUnread();
+    })();
+  }
+  await unreadPending;
+
+  let released = false;
+  return () => {
+    // 同じ購読者が2回解除しても他人のぶんを巻き込まないようにする
+    if (released) return;
+    released = true;
+    unreadRefCount -= 1;
+    if (unreadRefCount > 0) return;
+    unreadUnlisten?.();
+    unreadUnlisten = null;
+    unreadPending = null;
+  };
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -27,6 +27,17 @@ export default {
     titleApproval: 'Approval Required',
     titleCompleted: 'Task Completed',
   },
+  // Toasts for cross-worktree event delivery (issue #120 §7 / #130).
+  // Shared by the main window and sub-windows through a common composable, so it lives
+  // in the global catalog rather than an SFC-local <i18n> block.
+  eventDelivery: {
+    // The main window shows deliveries for every attached worktree, so without the
+    // destination name you cannot tell which tab just started moving. (#125 passed
+    // {name} but never rendered it.)
+    deliveredSummary: 'Delivered to {name} ({count})',
+    spawnRejectedSummary: 'Auto spawn declined',
+    spawnRejectedDetail: '{name} has {pending} unread message(s) but {live} terminals are open (limit {limit}). Close some terminals or open the worktree manually.',
+  },
   update: {
     title: 'oretachi Update',
     available: 'A new version {version} is available. Update now?',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -27,6 +27,15 @@ export default {
     titleApproval: '承認が必要です',
     titleCompleted: 'タスク完了',
   },
+  // ワークツリー間イベントの配送トースト (issue #120 §7 / #130)。
+  // メイン / サブウィンドウが共通の composable から引くため、SFC ローカルではなくここに置く。
+  eventDelivery: {
+    // メインは非分離の全ワークツリーぶんを出すので、宛先名が無いとどのタブが
+    // 動き出したのか分からない（#125 の文言は {name} を渡しながら使っていなかった）
+    deliveredSummary: '{name} へワークツリーイベントを配送しました ({count}件)',
+    spawnRejectedSummary: '自動 spawn を見送りました',
+    spawnRejectedDetail: '{name} に未読が {pending} 件ありますが、ターミナルが {live} 個開いています（上限 {limit}）。ターミナルを整理するか、手動でワークツリーを開いてください',
+  },
   update: {
     title: 'oretachi アップデート',
     available: '新しいバージョン {version} が利用可能です。今すぐ更新しますか？',

--- a/src/utils/eventToastScope.test.ts
+++ b/src/utils/eventToastScope.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mainWindowShowsDelivery, subWindowShowsDelivery } from "./eventToastScope";
+
+const DETACHED = new Set(["wt-detached"]);
+const isDetached = (id: string) => DETACHED.has(id);
+
+describe("配送トーストの表示責任 (1配送=1トースト)", () => {
+  // [worktreeId, メインが出すか, サブ(wt-detached 担当)が出すか]
+  const cases: Array<[string | null, boolean, boolean]> = [
+    // 分離済み: サブウィンドウの担当。メインは抑制する
+    ["wt-detached", false, true],
+    // 非分離: メインの担当。別ワークツリーのサブウィンドウは出さない
+    ["wt-attached", true, false],
+    // 解決不能: どのサブウィンドウにも紐づかないのでメインが拾う
+    [null, true, false],
+  ];
+
+  for (const [worktreeId, expectMain, expectSub] of cases) {
+    it(`worktreeId=${JSON.stringify(worktreeId)} は ちょうど1つのウィンドウが出す`, () => {
+      const main = mainWindowShowsDelivery(worktreeId, isDetached);
+      const sub = subWindowShowsDelivery(worktreeId, "wt-detached");
+      expect(main).toBe(expectMain);
+      expect(sub).toBe(expectSub);
+      // 不変条件: 重複も取りこぼしも無い
+      expect([main, sub].filter(Boolean).length).toBe(1);
+    });
+  }
+
+  it("無関係なサブウィンドウは他ワークツリー宛を出さない", () => {
+    expect(subWindowShowsDelivery("wt-detached", "wt-other")).toBe(false);
+    expect(subWindowShowsDelivery(null, "wt-other")).toBe(false);
+  });
+
+  it("worktreeId が空文字のサブウィンドウ (クエリ欠落) は何も出さない", () => {
+    expect(subWindowShowsDelivery("wt-detached", "")).toBe(false);
+    expect(subWindowShowsDelivery(null, "")).toBe(false);
+  });
+});

--- a/src/utils/eventToastScope.ts
+++ b/src/utils/eventToastScope.ts
@@ -1,0 +1,30 @@
+/** 配送トーストの表示責任（issue #130）。
+ *
+ *  Rust 側は `event-delivered` / `event-spawn-rejected` を `app.emit`、つまり全 webview へ
+ *  ブロードキャストする。素直に listen すると1回の配送でメインとサブウィンドウが同時に
+ *  トーストするので、「そのワークツリーを表示しているウィンドウ」だけが出すよう振り分ける。
+ *
+ *  **1配送=1トースト**がこの2関数の不変条件。純粋関数として切り出してテストで固定する。 */
+
+/** メインウィンドウ。分離済み（サブウィンドウ持ち）のワークツリーは出さない。
+ *
+ *  `worktreeId` が null（バックエンドがワークツリーを解決できなかった）ときは**出す**。
+ *  どのサブウィンドウにも紐づけられない以上、メインが出さなければ誰も出さない。 */
+export function mainWindowShowsDelivery(
+  worktreeId: string | null,
+  isDetached: (id: string) => boolean,
+): boolean {
+  if (worktreeId === null) return true;
+  return !isDetached(worktreeId);
+}
+
+/** サブウィンドウ。自分が担当するワークツリー宛だけ出す。
+ *
+ *  `worktreeId` が null のものはメインの担当なので出さない（両方が出すと重複する）。 */
+export function subWindowShowsDelivery(
+  worktreeId: string | null,
+  ownWorktreeId: string,
+): boolean {
+  if (worktreeId === null) return false;
+  return worktreeId === ownWorktreeId;
+}

--- a/src/utils/terminalUnread.test.ts
+++ b/src/utils/terminalUnread.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { collectUnreadByTab } from "./terminalUnread";
+
+describe("collectUnreadByTab", () => {
+  it("session_id キーを フロント terminalId キーへ詰め替える", () => {
+    const unread = new Map([
+      [101, 2],
+      [102, 5],
+    ]);
+    const entries = new Map([
+      [1, { sessionId: 101 }],
+      [2, { sessionId: 102 }],
+    ]);
+    expect([...collectUnreadByTab(unread, entries)]).toEqual([
+      [1, 2],
+      [2, 5],
+    ]);
+  });
+
+  it("未読が無いセッションのタブは入れない (FramePane が falsy で出し分けるため)", () => {
+    const unread = new Map([[101, 3]]);
+    const entries = new Map([
+      [1, { sessionId: 101 }],
+      [2, { sessionId: 999 }],
+    ]);
+    const result = collectUnreadByTab(unread, entries);
+    expect(result.has(2)).toBe(false);
+    expect(result.get(1)).toBe(3);
+  });
+
+  it("sessionId が未確定 / エントリが無いタブを飛ばす", () => {
+    const unread = new Map([[101, 1]]);
+    const entries: Array<[number, { sessionId?: number | null } | undefined | null]> = [
+      [1, undefined],
+      [2, null],
+      [3, {}],
+      [4, { sessionId: null }],
+      [5, { sessionId: 101 }],
+    ];
+    expect([...collectUnreadByTab(unread, entries)]).toEqual([[5, 1]]);
+  });
+
+  it("未読ゼロなら累積先をそのまま返す", () => {
+    const into = new Map([[9, 1]]);
+    const result = collectUnreadByTab(new Map(), [[1, { sessionId: 101 }]], into);
+    expect(result).toBe(into);
+    expect([...result]).toEqual([[9, 1]]);
+  });
+
+  it("複数のワークツリーバンドルを 1 つのマップへ累積できる", () => {
+    const unread = new Map([
+      [101, 1],
+      [201, 4],
+    ]);
+    const result = new Map<number, number>();
+    collectUnreadByTab(unread, new Map([[1, { sessionId: 101 }]]), result);
+    collectUnreadByTab(unread, new Map([[7, { sessionId: 201 }]]), result);
+    expect([...result]).toEqual([
+      [1, 1],
+      [7, 4],
+    ]);
+  });
+});

--- a/src/utils/terminalUnread.ts
+++ b/src/utils/terminalUnread.ts
@@ -1,0 +1,37 @@
+/** タブ未読バッジ用のキー詰め替え（issue #120 §7 / #130）。
+ *
+ *  バックエンド（`event_terminal_unread`）は PTY の `session_id` で未 ack 件数を数えるが、
+ *  `FramePane.vue` のバッジは**フロントの terminalId**で引く。メイン / サブウィンドウ /
+ *  トレイポップアップの3箇所が同じ逆引きループを持つことになるので、ここへ寄せる。
+ *
+ *  Vue の reactivity には触れない純粋関数なので `utils/`（`composables/` ではない）。 */
+
+/** `sessionId` を持つ端末エントリの最小形。`TerminalView` インスタンス /
+ *  `SubTerminalEntry` / `TrayTerminalEntry` のいずれもこの形に当てはまる。 */
+export interface SessionBearing {
+  sessionId?: number | null;
+}
+
+/** `session_id → 未 ack 件数` を `フロント terminalId → 未 ack 件数` へ詰め替える。
+ *
+ *  @param unreadBySession `useEventSubscriptions` の `terminalUnread`
+ *  @param entries `[フロント terminalId, sessionId を持つ何か]` の列
+ *  @param into 累積先。メインウィンドウのようにワークツリーごとの複数マップを
+ *              1つへまとめたい場合に渡す
+ */
+export function collectUnreadByTab(
+  unreadBySession: Map<number, number>,
+  entries: Iterable<[number, SessionBearing | undefined | null]>,
+  into: Map<number, number> = new Map(),
+): Map<number, number> {
+  // 未読ゼロが常態なので、空なら列を回さずに抜ける
+  if (unreadBySession.size === 0) return into;
+  for (const [terminalId, entry] of entries) {
+    const sessionId = entry?.sessionId;
+    if (sessionId == null) continue;
+    const count = unreadBySession.get(sessionId);
+    // 0 件は入れない（`FramePane` 側が `v-if="terminalUnread?.get(tid)"` の falsy 判定で出し分ける）
+    if (count) into.set(terminalId, count);
+  }
+  return into;
+}


### PR DESCRIPTION
Closes #130 （親: #120 Phase 3 残件 / 切り出し元: #131）

## 概要

#125/#131 で購読の再バインドと待機中エージェントへの PTY 押し込みが入り、可視化も同 PR で入ったが**メインウィンドウのみ**に閉じていた。**分離したワークツリーこそエージェントが黙って動き出したように見える**ので、#120 §7 の目的は半分しか達成できていなかった。サブウィンドウ / トレイポップアップへ広げる。

## 設計上の発見: Rust の変更はゼロ

Rust 側は `event-delivered` / `event-spawn-rejected` / `event-inbox-changed` をすべて **`app.emit`（全 webview へのブロードキャスト）** で出しており、`emit_to` は `src-tauri/` に1箇所も無い。つまりサブ / トレイの webview は**そのまま `listen()` するだけで同じイベントを受け取れる**。`sub-ai-session` のようなメインからの中継は不要だった。

`main.ts` は `?mode=` に関わらず `PrimeVue` / `ToastService` / `i18n` を全ウィンドウへ登録済みで、`FrameContainer` / `FramePane` の `terminalUnread` prop とバッジ描画も完成済み。**足りていたのは各ウィンドウの `<Toast>` outlet と、prop に渡す値を作る部分だけ**だった。

## 判断: トーストの表示責任

ブロードキャストの裏返しで、素直に listen すると1回の配送で複数ウィンドウがトーストする。**1配送=1トースト**を保つため、表示責任を切り分けた。

| ウィンドウ | 配送トースト | タブ未読バッジ |
|---|---|---|
| メイン | `isDetached(worktreeId)` なら**出さない** | 出す（既存） |
| サブウィンドウ | `payload.worktreeId === 自分の worktreeId` のときだけ出す | 出す（新規） |
| トレイポップアップ | **出さない** | 出す（新規） |

この述語は設計の要なので `src/utils/eventToastScope.ts` に純粋関数として切り出し、`worktreeId: null`（バックエンドがワークツリーを解決できなかった場合）を含むテーブルテストで「重複も取りこぼしも無い」ことを固定した。null はどのサブウィンドウにも紐づかないのでメインが拾う。

**#130 本文は `TrayPopupApp.vue` にも `<Toast>` を足すと書いているが、意図的に外した。** トレイは表示中ワークツリーをメイン / サブウィンドウと同時に映すため、トーストを出すと必ず二重になる。トレイは未読バッジのみとする（この点はユーザー確認済み）。

## 重要な制約: イベント種別で分岐しない

#126 が `worktree.message`（自由文イベント）を追加するため、`worktree.closed` 前提で本文を組み立てるとマージ順で表示が壊れる。

`DeliveredPayload` に**種別フィールドは無く**、バックエンドの `format_inbox_push_text` が組み立てた `text` を運んでくるだけなので、**それをそのまま描画する**ことで種別非依存が構造的に保証される。加えて `text` が空 / 非文字列でも summary だけで成立するようガードし、outlet 側も空 `detail` の行を描かないようにした（メイン側の既存 outlet も揃えた）。#126 とのマージ順を気にする必要はない。

## 変更内容

- **`src/utils/terminalUnread.ts`（新規）** — `collectUnreadByTab`。pty `session_id` → フロント `terminalId` の詰め替え。メイン / サブ / トレイの3箇所に同型のループを書かないための共通化（Vue reactivity 非依存なので `utils/`）
- **`src/utils/eventToastScope.ts`（新規）** — 上記の表示責任の述語
- **`src/composables/useEventDeliveryToast.ts`（新規）** — `event-delivered` / `event-spawn-rejected` の listen とトーストをメイン / サブで共有。`<script setup>` の同期部分から呼ぶ（`onMounted` の `await` を跨ぐと `useToast` が失敗する）。listen 登録は非同期に進み、`onScopeDispose` で解除する
- **`useEventSubscriptions.initTerminalUnread`** — 未読件数だけを同期する軽量版。購読パネルを持たないサブ / トレイ用で、**unlisten を返す**（`initEventSubscriptions` はメイン専用で返さない）
- **`SubWindowApp.vue`** — `<Toast>` outlet、`terminal-unread` prop、`initTerminalUnread`
- **`TrayPopupApp.vue`** — `terminal-unread` prop、`initTerminalUnread`
- **i18n** — 配送トーストの文言を SFC ローカル `<i18n>` からグローバルカタログへ（共通 composable から引くため）

## 実機確認

本番 oretachi を止めずに dev ビルド（`mcpPort` を一時的に 9161 へ、MCP は node の raw JSON-RPC）で検証した。使い捨てワークツリーを9本作って確認し、終了後に git ワークツリー・ブランチ・設定（`mcpPort` / `moveToSubWindowOnMcpSpawn` / `detachedWorktreeIds` / `mcp-server.json`）はすべて元に戻している。

| 確認項目 | 結果 |
|---|---|
| **サブウィンドウの配送トースト**（完了条件） | ✅ 分離した `verify130-sub` で `worktree.closed` 配送時に右下へ表示。summary「ワークツリーイベントを配送しました (1件)」+ 本文を 120 字で要約 |
| **サブウィンドウのタブ未読バッジ**（完了条件） | ✅ タブに件数バッジ（1 → 3 と増加）を目視 |
| **同時刻にメインがトーストを出さない** | ✅ 両ウィンドウを重ならない位置に並べて同一配送を 150 フレーム連写。サブは 6 フレーム連続で緑（トースト life 8 秒に一致）、メインは全フレームで変化なし |
| **非分離時はメインに出る（退行なし）** | ✅ 同じワークツリーをメインへ戻して配送 → メインにトースト + タブ未読バッジ |
| **グローバル i18n カタログからの文言解決** | ✅ 上記トーストが実文言で描画されることを確認（SFC ローカル `<i18n>` を持つ App.vue から `useI18n({ useScope: "global" })` で引ける） |

### 未確認事項

- **トレイポップアップの未読バッジは目視できていない。** トレイは通知トレイボタンのクリックか global hotkey でしか開かず、検証中にデスクトップがロックされて `SendKeys` が `Access is denied` で拒否されたため。global hotkey (`Ctrl+Alt+O`) は先に起動している本番インスタンスが握るので dev 側では発火しない。コード経路は `collectUnreadByTab` + `terminal-unread` prop でサブウィンドウと完全に同一（サブ側は目視済み）
- **`event-spawn-rejected`** は端末数上限（12）まで開くのが現実的でないため実機では確認していない。レンダリング経路は `event-delivered` と同一 composable なので上記1で担保される
- **未知のイベント種別**は #126 未マージのため実機で起こせない。ただし `DeliveredPayload` に種別フィールドが無く `text` をそのまま描画する構造上、分岐は実装に存在しない

## セルフレビュー

CLAUDE.md の `codex-review` を実行したが、25 分間まったく出力が無く中断した（#127 / #131 と同様に3回連続で完走できていない）。代わりに `/bug-review` + バリデータサブエージェントによる再検証で代替した。

確認された指摘（対応済み）:

- **`loadTerminalUnread` に多重実行ガードが無い。** `event-inbox-changed` は Reconcile / EventQueued / 引き継ぎ / ack など複数箇所から連続発火するため、`event_terminal_unread` の invoke が並走し、**先発（古い）が後着すると新しい件数を上書きして固定される**。このイベントは変化時しか飛ばないので自然回復しない。同ファイルの `loadSubscriptions` が同じ理由で `isLoading` + `pendingReload` を持っているのに、新経路だけが非対称に無防備だった → 同型のガードを `loadTerminalUnread` 自体に持たせ、メイン経路とも共有
- **`initTerminalUnread` の単純な bool ガードが、2人目の呼び出しに no-op の unlisten を返していた。** 1人目が解除した時点でリスナー不在のまま誰も気づけない → 参照カウント化し、二重解除も無害にした
- **`deliveredSummary` が `{name}` を受け取りながら文言で使っていなかった**（#125 からの引き継ぎ）。メインは非分離の全ワークツリーぶんを出すので、宛先名が無いとどのタブが動き出したのか分からない → 文言に `{name}` を追加し、名前が引けないときのフォールバックも入れた
- メイン側の `<Toast>` スロットが空 `detail` で空行を描いていた → サブ側と揃えてガード

棄却された指摘（偽陽性と判断した根拠）:

- **`initTerminalUnread()` の await で `sub-init` / `tray-init` を取りこぼす** → メインは `sub-ready` / `tray-ready` を受けてから初めて init データを送り、それまで `getPendingInitData` / `getPendingWorktrees` に保持する。`sub-ready` の emit は `onMounted` 最終行なので順序は安全
- **`collectUnreadByTab` でワークツリーをまたいだ未読の誤表示** → pty `session_id` は `PtyManager.next_id` のプロセス全体で単調増加する単一カウンタ、フロントの `terminalId` も `useWorktrees.ts` のモジュール単一カウンタでアプリ全体一意。加えて `session_id` は DB に一切保存されない（inbox / 購読の主キーは UUID の `terminal_id`）ので再起動をまたいだ誤紐付けも起きない
- **`<script setup>` 同期部での `useToast` / `useI18n` とリーク** → `main.ts` が全ウィンドウで登録済み。登録完了前に stop された場合も明示的に解除している。`onScopeDispose` + 明示 `stop()` の二重呼び出しは `stopped` フラグで冪等

### 既知の限界（対応せず記録）

サブウィンドウが webview クラッシュした場合、`sub-window-closing` が飛ばないので `isDetached` が true のまま残り、メインが抑制し続けてトーストが誰にも出ない。ただしこの状態ではそのワークツリー自体が操作不能なので二次被害であり、未読バッジは残る。また、サブウィンドウが背面 / 最小化のときはトーストが見えない（以前はほぼ常に可視なメインが出していた）。表示責任を分ける以上のトレードオフとして許容する。

`event-inbox-changed` 1発あたり `event_terminal_unread` の invoke がウィンドウ数ぶん（メイン + サブ N 個 + トレイ）走る。端末数が多い環境では無視できない可能性があるが、今回入れた直列化で連続発火は畳まれる。デバウンスは入れていない。

## テスト

- `pnpm run type-check` ✅
- `pnpm test` ✅ **94 件**（`terminalUnread` 5 件、`eventToastScope` 5 件を追加）
- `src-tauri/` は変更なし

## 並行作業との関係

#124 (Phase 2) / #126 (Phase 4) と並行しているが、本 PR はフロントのみ（`src-tauri/` の変更ゼロ）なので衝突しない見込み。衝突した場合は先にマージされた方へ rebase する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
