### PR TITLE
feat(event): worktree.created / worktree.message と target ワイルドカード (#126)

### DIFF
--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -112,6 +112,28 @@ pub const PUSH_TTL_MS: i64 = 10 * 60 * 1000;
 /// PTY へ流す1メッセージの最大文字数。`sanitize_for_pty` で切り詰める。
 const PTY_TEXT_MAX_CHARS: usize = 600;
 
+/// `worktree.message` の本文の最大文字数（#126）。
+///
+/// 自由文はエージェントが書くので上限が無いと、他ワークツリーの `SessionStart`
+/// 注入（`format_inbox_digest`）に無制限のテキストが流れ込む。押し込み側は
+/// `PTY_TEXT_MAX_CHARS` で切れるが、注入側は切らないので入口で止める。
+pub const MESSAGE_TEXT_MAX_CHARS: usize = 4000;
+
+/// `SessionStart` / `Stop` の `additionalContext` へ一度に注入する本文の上限文字数（#126）。
+///
+/// 溜まった未読を全部並べると、自由文メッセージ数十件で相手のコンテキストを埋め尽くし、
+/// しかも**全件が配送済みになって二度と出てこない**（再送しない方針のため）。
+/// 載らなかった分は未配送のまま次の機会に回す。
+///
+/// **`MESSAGE_TEXT_MAX_CHARS` より行装飾ぶんだけ大きく取る。** 同じ値にすると、
+/// 上限いっぱいのメッセージ1件が `- [<id>] '<from>' からのメッセージ: ` の接頭辞のぶんだけ
+/// 必ず溢れ、切り詰められたまま配送済みになって全文が二度と注入されない。
+pub const DIGEST_MAX_CHARS: usize = MESSAGE_TEXT_MAX_CHARS + 200;
+
+/// 本文を切り詰めたときに添える案内。inbox 側には全文が未 ack で残っているので、
+/// `…` だけで終わらせず取得方法を必ず示す。
+const TRUNCATED_HINT: &str = "…（本文を切り詰めました。全文は oretachi_poll_inbox で取得できます）";
+
 /// sqlite の書き込みロック待ち上限。SessionStart フックのリクエストパスから触るため、
 /// サイドカーの読み取りタイムアウト（2 秒）より短くする。
 const BUSY_TIMEOUT_MS: u64 = 800;
@@ -1408,6 +1430,20 @@ pub fn format_inbox_line(item: &InboxItem) -> String {
     format!("- [{}] {}", item.id, detail)
 }
 
+/// 1行を `max_chars` 以内に切り詰め、切ったことと全文の取得方法を末尾に添える。
+///
+/// 案内文のぶんも `max_chars` の内側に収める（呼び出し元の予算計算を壊さないため）。
+fn truncate_with_hint(line: &str, max_chars: usize) -> String {
+    let hint_len = TRUNCATED_HINT.chars().count();
+    // 案内すら入らないほど予算が小さいときは素直に切るだけ（呼び出し元の予算は常に
+    // これより大きいが、定数を触ったときに黙って壊れないようにしておく）。
+    if max_chars <= hint_len {
+        return line.chars().take(max_chars).collect();
+    }
+    let body: String = line.chars().take(max_chars - hint_len).collect();
+    format!("{}{}", body, TRUNCATED_HINT)
+}
+
 /// PTY へ流す文字列から制御文字を落とし、長さを切り詰める。
 ///
 /// ワークツリー名 / ブランチ名は利用者が自由に付けられる文字列で、`format_inbox_line` を
@@ -1470,6 +1506,16 @@ pub fn format_inbox_push_text(items: &[InboxItem]) -> Option<(String, usize)> {
         if used > 0 && body.chars().count() + sep.len() + line.chars().count() > budget {
             break;
         }
+        // 1件目は必ず載せるが、**予算を超えるなら行のほうを切る**（#126）。切らずに
+        // 通すと全体が上限を超え、`sanitize_for_pty` が末尾から削るせいで tail の
+        // 「oretachi_ack_message で ack してください」が丸ごと消える。自由文の
+        // `worktree.message` は本文が長くなりうるので、この経路は常用される。
+        // 先頭の `- [<id>] ` は残るので ack に必要な ID は読める。
+        let line = if used == 0 && line.chars().count() > budget {
+            truncate_with_hint(&line, budget)
+        } else {
+            line
+        };
         body.push_str(sep);
         body.push_str(&line);
         used += 1;
@@ -1493,34 +1539,64 @@ pub fn format_inbox_push_text(items: &[InboxItem]) -> Option<(String, usize)> {
 ///   唯一の気付き手段がこれ（Phase 1 には UI が無い）。
 ///
 /// どちらも空なら None（呼び出し側で注入をスキップできるようにする）。
-pub fn format_inbox_digest(items: &[InboxItem], carryover: i64) -> Option<String> {
+///
+/// 戻り値は `(本文, 本文に載せた件数)`。**載らなかった分は呼び出し元が打刻してはいけない**
+/// （`format_inbox_push_text` と同じ規約）。載らなかった分は未配送のまま残り、次の
+/// `Stop` / `SessionStart` で出る。
+pub fn format_inbox_digest(items: &[InboxItem], carryover: i64) -> Option<(String, usize)> {
     if items.is_empty() && carryover <= 0 {
         return None;
     }
     if items.is_empty() {
-        return Some(format!(
-            "[oretachi] 未確認（未 ack）のワークツリーイベントが {} 件残っています。\
-             oretachi_poll_inbox で内容を確認し、oretachi_ack_message で ack してください。",
-            carryover
+        return Some((
+            format!(
+                "[oretachi] 未確認（未 ack）のワークツリーイベントが {} 件残っています。\
+                 oretachi_poll_inbox で内容を確認し、oretachi_ack_message で ack してください。",
+                carryover
+            ),
+            0,
         ));
     }
-    let lines: Vec<String> = items.iter().map(format_inbox_line).collect();
-    let carryover_note = if carryover > 0 {
+    // 総量に上限を設ける（#126）。`worktree.message` は自由文なので1件で数千文字になりうる。
+    // 上限が無いと、待機中に溜まった未読が `Stop` / `SessionStart` の additionalContext を
+    // 埋め尽くし、しかも全件が「配送済み」になって二度と出てこない。
+    let mut lines: Vec<String> = Vec::new();
+    let mut used = 0usize;
+    for item in items {
+        let line = format_inbox_line(item);
+        let total: usize = lines.iter().map(|l: &String| l.chars().count() + 1).sum();
+        if used > 0 && total + line.chars().count() > DIGEST_MAX_CHARS {
+            break;
+        }
+        // 1件目だけは必ず載せる。長すぎるときは行を切って、後続の ack 指示を残す。
+        let line = if used == 0 && line.chars().count() > DIGEST_MAX_CHARS {
+            truncate_with_hint(&line, DIGEST_MAX_CHARS)
+        } else {
+            line
+        };
+        lines.push(line);
+        used += 1;
+    }
+    let deferred = items.len() - used;
+    let carryover_note = if carryover > 0 || deferred > 0 {
         format!(
             "\nこのほかに未 ack のまま残っているものが {} 件あります（oretachi_poll_inbox で確認できます）。",
-            carryover
+            carryover + deferred as i64
         )
     } else {
         String::new()
     };
-    Some(format!(
-        "[oretachi] 購読していたワークツリーイベントが {} 件届いています。\n{}\n\n\
-         内容に応じて必要な動作確認や後続作業を進めてください。\
-         確認したら oretachi_ack_message に上記の [] 内の ID を渡して ack してください。\
-         この本文は自動では再掲されません（ack しないまま忘れた場合は oretachi_poll_inbox で取り直せます）。{}",
-        items.len(),
-        lines.join("\n"),
-        carryover_note
+    Some((
+        format!(
+            "[oretachi] 購読していたワークツリーイベントが {} 件届いています。\n{}\n\n\
+             内容に応じて必要な動作確認や後続作業を進めてください。\
+             確認したら oretachi_ack_message に上記の [] 内の ID を渡して ack してください。\
+             この本文は自動では再掲されません（ack しないまま忘れた場合は oretachi_poll_inbox で取り直せます）。{}",
+            used,
+            lines.join("\n"),
+            carryover_note
+        ),
+        used,
     ))
 }
 
@@ -1670,7 +1746,8 @@ mod tests {
     /// （注入喪失に気づく唯一の手段。本文は再掲しない）。
     #[test]
     fn test_format_inbox_digest_carryover_only_mentions_count_without_body() {
-        let digest = format_inbox_digest(&[], 3).unwrap();
+        let (digest, used) = format_inbox_digest(&[], 3).unwrap();
+        assert_eq!(used, 0);
         assert!(digest.contains("3 件"));
         assert!(digest.contains("oretachi_poll_inbox"));
         assert!(!digest.contains("がクローズされました"));
@@ -1682,7 +1759,8 @@ mod tests {
             KIND_WORKTREE_CLOSED,
             r#"{"worktreeId":"a","worktreeName":"wt-a","branchName":"b1"}"#,
         )];
-        let digest = format_inbox_digest(&items, 2).unwrap();
+        let (digest, used) = format_inbox_digest(&items, 2).unwrap();
+        assert_eq!(used, 1);
         assert!(digest.contains("wt-a"));
         assert!(digest.contains("2 件"));
     }
@@ -2688,6 +2766,70 @@ mod tests {
         assert!(text.contains("rm -rf /"), "本文自体は落とさず1行に潰すだけ: {}", text);
     }
 
+    /// 溜まった自由文メッセージで `SessionStart` / `Stop` の注入が膨れ上がらないこと。
+    /// 上限で載らなかった分は**打刻対象から外れる**（`used` に含めない）ので、
+    /// 「本文に出ていないのに配送済み」になって二度と出ない、という事故を防ぐ。
+    #[test]
+    fn test_format_inbox_digest_caps_total_and_defers_rest() {
+        let body = serde_json::json!({ "text": "あ".repeat(1500), "sourceWorktreeName": "src" })
+            .to_string();
+        let items: Vec<InboxItem> = (0..10)
+            .map(|i| {
+                let mut item = inbox_item(KIND_WORKTREE_MESSAGE, &body);
+                item.id = format!("inbox-{}", i);
+                item
+            })
+            .collect();
+        let (digest, used) = format_inbox_digest(&items, 0).unwrap();
+        assert!(used < items.len(), "全件は載らない: used={}", used);
+        assert!(used >= 1, "最低1件は載せる");
+        assert!(digest.chars().count() < DIGEST_MAX_CHARS + 600, "{}", digest.chars().count());
+        // 載らなかった分は「残っている」と伝える（黙って消さない）
+        assert!(
+            digest.contains(&format!("{} 件あります", items.len() - used)),
+            "{}",
+            digest
+        );
+        assert!(digest.contains("oretachi_ack_message"), "{}", digest);
+    }
+
+    /// 長い自由文メッセージが1件だけ来ても、末尾の ack 指示が残ること。
+    /// 「1件目は必ず載せる」を無条件に通すと全体が上限を超え、`sanitize_for_pty` が
+    /// 末尾から削るせいで一番効かせたい指示が消える。
+    #[test]
+    fn test_format_inbox_push_text_keeps_tail_for_long_message() {
+        let body = serde_json::json!({
+            "text": "あ".repeat(MESSAGE_TEXT_MAX_CHARS),
+            "sourceWorktreeName": "design",
+        })
+        .to_string();
+        let item = inbox_item(KIND_WORKTREE_MESSAGE, &body);
+        let (text, used) = format_inbox_push_text(std::slice::from_ref(&item)).unwrap();
+        assert_eq!(used, 1);
+        assert!(text.chars().count() <= 600, "{}", text.chars().count());
+        assert!(text.contains("oretachi_ack_message"), "{}", text);
+        // ack に必要な ID は行頭に残る
+        assert!(text.contains(&item.id), "{}", text);
+        // 切り詰めたことと全文の取得方法を伝える（`…` だけで終わらせない）
+        assert!(text.contains("切り詰めました"), "{}", text);
+    }
+
+    /// 上限いっぱいのメッセージ1件は digest では切り詰められない。切り詰めたまま
+    /// 配送済みにすると、再送しない方針のせいで全文が二度と注入されない。
+    #[test]
+    fn test_format_inbox_digest_fits_one_max_length_message() {
+        let body = serde_json::json!({
+            "text": "あ".repeat(MESSAGE_TEXT_MAX_CHARS),
+            "sourceWorktreeName": "design",
+        })
+        .to_string();
+        let item = inbox_item(KIND_WORKTREE_MESSAGE, &body);
+        let (digest, used) = format_inbox_digest(std::slice::from_ref(&item), 0).unwrap();
+        assert_eq!(used, 1);
+        assert!(!digest.contains("切り詰めました"), "上限いっぱいでも切られない");
+        assert!(digest.contains(&"あ".repeat(MESSAGE_TEXT_MAX_CHARS)), "全文が入る");
+    }
+
     /// 押し込み本文の締めが種別に依存していないこと。`closed` 決め打ちの文言のままだと
     /// `created` / `message` を「作業が完了した」と誤読させる。
     #[test]
@@ -2886,7 +3028,8 @@ mod tests {
                 r#"{"worktreeId":"b","worktreeName":"wt-b","branchName":"b2"}"#,
             ),
         ];
-        let digest = format_inbox_digest(&items, 0).unwrap();
+        let (digest, used) = format_inbox_digest(&items, 0).unwrap();
+        assert_eq!(used, 2);
         assert!(digest.contains("2 件"));
         assert!(digest.contains("oretachi_ack_message"));
         assert!(digest.contains("wt-a"));

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -29,8 +29,36 @@ pub struct EventPool(pub SqlitePool);
 /// イベント種別: ワークツリーがクローズ（アーカイブ / 削除）された。
 pub const KIND_WORKTREE_CLOSED: &str = "worktree.closed";
 
-/// Phase 1 で受け付けるイベント種別。`worktree.created` / `worktree.message` は #126。
-pub const SUPPORTED_EVENT_KINDS: &[&str] = &[KIND_WORKTREE_CLOSED];
+/// イベント種別: ワークツリーが追加された（#126）。
+/// body は oretachi 自身が組み立てる定型 JSON（`WorktreeCreatedBody`）。
+pub const KIND_WORKTREE_CREATED: &str = "worktree.created";
+
+/// イベント種別: エージェントが `notify_worktree` から送る**自由文**メッセージ（#126）。
+///
+/// `notify_worktree` の既存パラメータ `kind`（`hook` / `approval` / `completed` / `general`）は
+/// トーストの**通知種別**であって購読イベント種別ではない。名前空間を分けるため、
+/// 購読イベントは別パラメータ `event_kind` で受ける（#120 §1）。
+pub const KIND_WORKTREE_MESSAGE: &str = "worktree.message";
+
+/// 購読で受け付けるイベント種別。
+pub const SUPPORTED_EVENT_KINDS: &[&str] = &[
+    KIND_WORKTREE_CLOSED,
+    KIND_WORKTREE_CREATED,
+    KIND_WORKTREE_MESSAGE,
+];
+
+/// 購読対象のワイルドカード（#126）。**まだ存在しないワークツリーの `created` を購読したい**
+/// という要求はワークツリー ID 固定の target では表現できないため、`worktree.created` と
+/// セットで必要になる。
+///
+/// - `*`: 全ワークツリー
+/// - `workgroup:<id>`: そのワークグループに属するワークツリー
+/// - `repo:<name>`: そのリポジトリのワークツリー（名前は `normalize_target` で正規化）
+///
+/// 上記以外はワークツリー ID の厳密一致として扱う。
+pub const TARGET_ALL: &str = "*";
+pub const TARGET_WORKGROUP_PREFIX: &str = "workgroup:";
+pub const TARGET_REPO_PREFIX: &str = "repo:";
 
 /// 配送戦略。
 /// - `turn_end`: 既定。`Stop` フック / `SessionStart` 回収でターン境界に届ける
@@ -63,10 +91,17 @@ pub const ORPHANED_RETENTION_MS: i64 = ORPHANED_RETENTION_DAYS * 24 * 60 * 60 * 
 
 /// イベント連鎖の深さ上限（#120 §5.4 / #125 §3）。これを超えたイベントは配送せず破棄する。
 ///
-/// 現状 `worktree.closed` はワークツリー削除操作からしか発火せず、配送がイベントを生む経路は
-/// 存在しないため実際には常に 0。自由文の `worktree.message`（#126）でエージェント同士が
-/// 往復し始めたときに効かせるためのガードを、#125 の要求どおり後付けではなく先に入れておく。
+/// `worktree.closed` / `worktree.created` はユーザー操作からしか発火しないので常に 0。
+/// 自由文の `worktree.message`（#126）でエージェント同士が往復し始めたときに効く。
 pub const MAX_EVENT_DEPTH: i64 = 3;
+
+/// 連鎖とみなす時間窓（#126）。`worktree.message` を送るときの `depth` は
+/// 「この窓の内側で受け取ったイベントの最大 depth + 1」として自動計算する。
+///
+/// **窓を切るのが要点。** 窓なしに「そのタブが今までに受け取った最大 depth」を使うと、
+/// 一度でも `MAX_EVENT_DEPTH` の深さのイベントを受けたタブが以後**永久に発言不能**になる。
+/// 窓があれば A↔B の高速な往復は閾値で止まり、人間ペースで再開した会話は depth 0 から始まる。
+pub const CHAIN_WINDOW_MS: i64 = 10 * 60 * 1000;
 
 /// PTY 押し込みを許すイベントの鮮度。これより古いイベントは押し込まない。
 ///
@@ -435,6 +470,51 @@ pub async fn insert_event(pool: &SqlitePool, event: &EventRow) -> Result<(), Str
     Ok(())
 }
 
+/// あるワークツリーについて、その種別のイベントが既に記録されているか。
+///
+/// `worktree.created` は「ワークツリーごとに一度きり」の意味を持つが、フロントの
+/// `notify_worktree_added` はセットアップ失敗時にも呼ばれる（`useTaskExecution.ts` の
+/// try / catch 両分岐）ため、経路次第で二度叩かれうる。発火前にここで弾く。
+pub async fn has_event(pool: &SqlitePool, source_worktree_id: &str, kind: &str) -> Result<bool, String> {
+    let row: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM events WHERE source_worktree_id = ? AND kind = ?")
+            .bind(source_worktree_id)
+            .bind(kind)
+            .fetch_one(pool)
+            .await
+            .map_err(|e| e.to_string())?;
+    Ok(row.0 > 0)
+}
+
+/// このタブが連鎖ウィンドウ内に受け取ったイベントの最大 `depth`（#126）。
+///
+/// エージェントが送る `worktree.message` の `depth` はこれ + 1 になる。**エージェントに
+/// depth を申告させない**のが要点で、そうしないと「返信するときに depth を足す」という
+/// 約束を破るだけで `MAX_EVENT_DEPTH` のガードを無効化できてしまう。
+///
+/// 対象は inbox に積まれた（＝実際にこのタブへ配られた）ぶんだけ。まだ ack していなくても
+/// 「受け取った」とみなす —— エージェントは押し込み / SessionStart 注入で本文を見た時点で
+/// 反応できるため、ack を条件にすると連鎖の起点を数え落とす。
+///
+/// 戻り値 `None` は「窓の内側に受信が無い」＝連鎖の起点（depth 0 で送ってよい）。
+pub async fn max_inbound_depth(
+    pool: &SqlitePool,
+    terminal_id: &str,
+    now: i64,
+    window_ms: i64,
+) -> Result<Option<i64>, String> {
+    let row: (Option<i64>,) = sqlx::query_as(
+        "SELECT MAX(e.depth) FROM inbox i JOIN events e ON e.id = i.event_id \
+         WHERE i.subscriber_terminal_id = ? AND i.created_at > ?",
+    )
+    .bind(terminal_id)
+    .bind(now - window_ms)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(row.0)
+}
+
 /// `event_kinds`（JSON 配列文字列）に `kind` が含まれるか。
 /// 空配列 / パース失敗は「絞り込み無し」とはみなさず false（意図しない全配送を防ぐ）。
 pub fn event_kinds_match(event_kinds_json: &str, kind: &str) -> bool {
@@ -447,12 +527,54 @@ pub fn event_kinds_match(event_kinds_json: &str, kind: &str) -> bool {
     arr.iter().any(|v| v.as_str() == Some(kind))
 }
 
+/// 購読対象文字列を正規化する（#126）。
+///
+/// **登録時と照合時で必ず同じ関数を通すこと。** `repo:` はリポジトリ名という人間が打つ
+/// 文字列なので大文字小文字と前後空白を吸収する。ワークツリー ID / ワークグループ ID は
+/// oretachi が発番した UUID なので厳密一致のまま（小文字化しても実害はないが、
+/// 「ID は一字一句一致」という不変条件を崩さない）。
+pub fn normalize_target(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if let Some(rest) = trimmed.strip_prefix(TARGET_REPO_PREFIX) {
+        return format!("{}{}", TARGET_REPO_PREFIX, rest.trim().to_lowercase());
+    }
+    if let Some(rest) = trimmed.strip_prefix(TARGET_WORKGROUP_PREFIX) {
+        return format!("{}{}", TARGET_WORKGROUP_PREFIX, rest.trim());
+    }
+    trimmed.to_string()
+}
+
+/// イベント1件がマッチしうる `target` 文字列の**全集合**を返す（#126）。
+///
+/// ワイルドカードを SQL の `LIKE` やアプリ側の全件走査で実装せず、発火側で「この
+/// イベントに該当する target はこの数個だけ」と列挙して `WHERE target IN (…)` に渡す。
+/// こうするとインデックス（`idx_subs_target`）がそのまま効き、照合規則は純粋関数として
+/// 単体テストできる（`event_kinds_match` / `is_self_echo` と同じ流儀）。
+pub fn matching_targets(
+    source_worktree_id: &str,
+    workgroup_id: Option<&str>,
+    repository_name: Option<&str>,
+) -> Vec<String> {
+    let mut targets = vec![source_worktree_id.to_string(), TARGET_ALL.to_string()];
+    if let Some(gid) = workgroup_id.map(str::trim).filter(|s| !s.is_empty()) {
+        targets.push(normalize_target(&format!("{}{}", TARGET_WORKGROUP_PREFIX, gid)));
+    }
+    if let Some(repo) = repository_name.map(str::trim).filter(|s| !s.is_empty()) {
+        targets.push(normalize_target(&format!("{}{}", TARGET_REPO_PREFIX, repo)));
+    }
+    targets
+}
+
 /// 自己エコー抑止（#120 §5.4）。発火元へ配り返すと往復ループの起点になる。
 ///
 /// - 同じタブが発火元なら配送しない
 /// - 発火元ワークツリーに属するタブへも配送しない。`worktree.closed` は close 経路が
 ///   terminal_id を運んでいないので `source_terminal_id` が None であり、実質こちらが効く
 ///   （そもそも閉じたワークツリーのタブは既に存在しないので配送先として無意味）
+///
+/// `*` 購読（#126）では**自ワークツリー発のイベントも必ず target にマッチする**ため、
+/// ここが唯一の防波堤になる。同一ワークツリーの別タブへも配らないのは、
+/// `worktree.message` が同じワークツリー内で往復する経路を最初から塞ぐため。
 pub fn is_self_echo(sub: &SubscriptionRow, event: &EventRow) -> bool {
     if event.source_terminal_id.as_deref() == Some(sub.subscriber_terminal_id.as_str()) {
         return true;
@@ -472,7 +594,14 @@ pub fn is_self_echo(sub: &SubscriptionRow, event: &EventRow) -> bool {
 /// **`orphaned` な購読にも積む**（#125）。タブが死んでいた / アプリが止まっていた間に届いた
 /// イベントを捨てると、「別ワークツリーの対応がクローズしたのを後で検知したい」という
 /// #120 の動機②そのものが成立しない。押し込み（PTY 注入 / spawn）だけを保留する。
-pub async fn fanout(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usize, String> {
+/// `targets` はこのイベントにマッチしうる購読対象の全集合（`matching_targets` の戻り値）。
+/// ワイルドカード（`*` / `workgroup:` / `repo:`）はここで解決済みの形で渡される（#126）。
+pub async fn fanout(
+    pool: &SqlitePool,
+    event: &EventRow,
+    targets: &[String],
+    now: i64,
+) -> Result<usize, String> {
     // 暴走防止（#120 §5.4）: 連鎖が深すぎるイベントは配送しない。
     if event.depth > MAX_EVENT_DEPTH {
         log::warn!(
@@ -485,14 +614,22 @@ pub async fn fanout(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usi
         );
         return Ok(0);
     }
-    let candidates = sqlx::query_as::<_, SubscriptionRow>(
-        "SELECT * FROM subscriptions WHERE target = ? AND state IN ('active', 'orphaned') AND (expires_at IS NULL OR expires_at > ?)",
-    )
-    .bind(&event.source_worktree_id)
-    .bind(now)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    if targets.is_empty() {
+        return Ok(0);
+    }
+    let sql = format!(
+        "SELECT * FROM subscriptions WHERE target IN ({}) AND state IN ('active', 'orphaned') AND (expires_at IS NULL OR expires_at > ?)",
+        placeholders(targets.len())
+    );
+    let mut query = sqlx::query_as::<_, SubscriptionRow>(&sql);
+    for t in targets {
+        query = query.bind(t);
+    }
+    let candidates = query
+        .bind(now)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())?;
 
     let mut delivered = 0usize;
     for sub in candidates {
@@ -953,16 +1090,21 @@ pub async fn list_pushable(
 ///
 /// 購読テーブルではなく inbox を見るのは、`worktree.closed` では購読行が fanout 直後に
 /// 消えているため。`spawn_if_closed` は積んだ時点の値が inbox に焼き付けてある。
+///
+/// 戻り値は `(購読者ワークツリー, イベント種別, 件数)`。**種別を返すのが要点（#126）。**
+/// 呼び出し元は自動承認が有効な宛先に対して種別ごとに許可判定する必要があり、
+/// 種別を落として件数だけ返すと自由文の `worktree.message` が定型イベントのふりをして
+/// spawn を引き起こせてしまう。
 pub async fn list_spawn_candidates(
     pool: &SqlitePool,
     now: i64,
     push_ttl_ms: i64,
-) -> Result<Vec<(String, i64)>, String> {
-    let rows: Vec<(String, i64)> = sqlx::query_as(
-        "SELECT subscriber_worktree_id, COUNT(*) FROM inbox \
-         WHERE orphaned_at IS NOT NULL AND acked_at IS NULL AND delivered_at IS NULL \
-           AND spawn_if_closed = 1 AND subscriber_worktree_id IS NOT NULL AND created_at > ? \
-         GROUP BY subscriber_worktree_id",
+) -> Result<Vec<(String, String, i64)>, String> {
+    let rows: Vec<(String, String, i64)> = sqlx::query_as(
+        "SELECT i.subscriber_worktree_id, e.kind, COUNT(*) FROM inbox i JOIN events e ON e.id = i.event_id \
+         WHERE i.orphaned_at IS NOT NULL AND i.acked_at IS NULL AND i.delivered_at IS NULL \
+           AND i.spawn_if_closed = 1 AND i.subscriber_worktree_id IS NOT NULL AND i.created_at > ? \
+         GROUP BY i.subscriber_worktree_id, e.kind",
     )
     .bind(now - push_ttl_ms)
     .fetch_all(pool)
@@ -1170,6 +1312,32 @@ pub struct WorktreeClosedBody {
     pub branch_name: String,
 }
 
+/// `worktree.created` の body（#126）。`closed` と違い、購読者がどのリポジトリ /
+/// ワークグループの追加かを判断できるよう解決済みの値も載せる。
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WorktreeCreatedBody {
+    #[serde(rename = "worktreeId")]
+    pub worktree_id: String,
+    #[serde(rename = "worktreeName")]
+    pub worktree_name: String,
+    #[serde(rename = "branchName")]
+    pub branch_name: String,
+    #[serde(rename = "repositoryName", default)]
+    pub repository_name: Option<String>,
+    #[serde(rename = "workgroupId", default)]
+    pub workgroup_id: Option<String>,
+}
+
+/// `worktree.message` の body（#126）。**`text` はエージェントが書いた自由文**なので、
+/// PTY へ流す経路では必ず `sanitize_for_pty` を通すこと。
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WorktreeMessageBody {
+    pub text: String,
+    /// 送信元ワークツリー名（表示用。ID から引けなくなった後でも読めるように焼き付ける）
+    #[serde(rename = "sourceWorktreeName", default)]
+    pub source_worktree_name: Option<String>,
+}
+
 /// inbox 1件を人間 / AI が読める1行に整形する。
 pub fn format_inbox_line(item: &InboxItem) -> String {
     let detail = match item.kind.as_str() {
@@ -1186,6 +1354,42 @@ pub fn format_inbox_line(item: &InboxItem) -> String {
                 )
             })
             .unwrap_or_else(|_| format!("ワークツリー ID '{}' がクローズされました", item.source_worktree_id)),
+        KIND_WORKTREE_CREATED => serde_json::from_str::<WorktreeCreatedBody>(&item.body)
+            .map(|b| {
+                let branch = if b.branch_name.trim().is_empty() {
+                    String::new()
+                } else {
+                    format!("（ブランチ: {}）", b.branch_name)
+                };
+                let repo = b
+                    .repository_name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(|r| format!("[{}] ", r))
+                    .unwrap_or_default();
+                format!(
+                    "{}ワークツリー '{}' {} が作成されました",
+                    repo, b.worktree_name, branch
+                )
+            })
+            .unwrap_or_else(|_| {
+                format!("ワークツリー ID '{}' が作成されました", item.source_worktree_id)
+            }),
+        KIND_WORKTREE_MESSAGE => serde_json::from_str::<WorktreeMessageBody>(&item.body)
+            .map(|b| {
+                let from = b
+                    .source_worktree_name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| item.source_worktree_id.clone());
+                format!("'{}' からのメッセージ: {}", from, b.text)
+            })
+            .unwrap_or_else(|_| {
+                format!("'{}' からのメッセージ: {}", item.source_worktree_id, item.body)
+            }),
         other => format!("イベント '{}': {}", other, item.body),
     };
     format!("- [{}] {}", item.id, detail)
@@ -1233,7 +1437,10 @@ pub fn format_inbox_push_text(items: &[InboxItem]) -> Option<(String, usize)> {
         return None;
     }
     let head = "[oretachi] 購読していたワークツリーイベントが届きました。";
-    let tail = " 購読していた作業が完了したということなので、必要な動作確認や後続作業を進めてください。\
+    // **種別に依存しない文言にすること（#126）。** `worktree.closed` だけだった頃の
+    // 「購読していた作業が完了した」という決め打ちは、`created` / `message` が混ざると
+    // 嘘の前提をエージェントに与える（作成通知を見て「完了した」と解釈させてしまう）。
+    let tail = " 内容に応じて必要な動作確認や後続作業を進めてください。\
                 確認したら oretachi_ack_message に [] 内の ID を渡して ack してください。";
     // 固定文言のぶんを引いた残りに、入る行だけを詰める（最低1件は必ず載せる）。
     // 残件の告知（`more`）も後ろに付くので、そのぶんの余白も先に引いておく。引かないと
@@ -1295,8 +1502,8 @@ pub fn format_inbox_digest(items: &[InboxItem], carryover: i64) -> Option<String
     };
     Some(format!(
         "[oretachi] 購読していたワークツリーイベントが {} 件届いています。\n{}\n\n\
-         購読していた作業が完了したということなので、必要な動作確認や後続作業を進めてください。\
-         内容を確認したら oretachi_ack_message に上記の [] 内の ID を渡して ack してください。\
+         内容に応じて必要な動作確認や後続作業を進めてください。\
+         確認したら oretachi_ack_message に上記の [] 内の ID を渡して ack してください。\
          この本文は自動では再掲されません（ack しないまま忘れた場合は oretachi_poll_inbox で取り直せます）。{}",
         items.len(),
         lines.join("\n"),
@@ -1307,6 +1514,13 @@ pub fn format_inbox_digest(items: &[InboxItem], carryover: i64) -> Option<String
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 所属情報を持たないイベントの `fanout`。ワークツリー ID 厳密一致と `*` にだけ
+    /// マッチする（#126 でワイルドカードが入る前の既存テストと同じ挙動）。
+    async fn fanout_all(pool: &SqlitePool, event: &EventRow, now: i64) -> Result<usize, String> {
+        let targets = matching_targets(&event.source_worktree_id, None, None);
+        fanout(pool, event, &targets, now).await
+    }
 
     fn sub(terminal: &str, worktree: Option<&str>, kinds: &str) -> SubscriptionRow {
         SubscriptionRow {
@@ -1506,9 +1720,9 @@ mod tests {
 
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 1);
             // 同じイベントの再 fanout は UNIQUE 制約でマージされる
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 0);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 0);
 
             let items = list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap();
             assert_eq!(items.len(), 1);
@@ -1542,7 +1756,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
 
             // 1回目の自動注入では拾える
             let first = list_inbox(&pool, "term-a", InboxFilter::Undelivered).await.unwrap();
@@ -1574,7 +1788,7 @@ mod tests {
             // タブ2 は購読していない
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
 
             assert_eq!(list_inbox(&pool, "term-a", InboxFilter::Unacked).await.unwrap().len(), 1);
             assert!(list_inbox(&pool, "term-b", InboxFilter::Unacked).await.unwrap().is_empty());
@@ -1589,7 +1803,7 @@ mod tests {
             upsert_subscription(&pool, &a).await.unwrap();
             let e2 = EventRow { id: "ev-2".to_string(), ..event("wt-target", None) };
             insert_event(&pool, &e2).await.unwrap();
-            assert_eq!(fanout(&pool, &e2, now).await.unwrap(), 2);
+            assert_eq!(fanout_all(&pool, &e2, now).await.unwrap(), 2);
         });
     }
 
@@ -1650,7 +1864,7 @@ mod tests {
             assert!(list_subscriptions(&pool, "term-a", now).await.unwrap().is_empty());
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 0);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 0);
 
             let (subs, _, _) = purge_expired(&pool, now, INBOX_RETENTION_MS).await.unwrap();
             assert_eq!(subs, 1);
@@ -1667,7 +1881,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
 
             let (subs, inbox) = purge_subscriber_worktree(&pool, "wt-subscriber").await.unwrap();
             assert_eq!((subs, inbox), (1, 1));
@@ -1687,7 +1901,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
 
             // 先に購読だけ解除する
             delete_subscription_by_target(&pool, "term-a", &s.target).await.unwrap();
@@ -1733,7 +1947,7 @@ mod tests {
                 .execute(&pool)
                 .await
                 .unwrap();
-            assert_eq!(fanout(&pool, &e2, now).await.unwrap(), 1);
+            assert_eq!(fanout_all(&pool, &e2, now).await.unwrap(), 1);
             assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 2);
 
             let (subs, inbox, _) = purge_expired(&pool, now, INBOX_RETENTION_MS).await.unwrap();
@@ -1759,7 +1973,7 @@ mod tests {
             upsert_subscription(&pool, &b).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 2);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 2);
 
             // term-a だけ生存している
             let (subs, inbox, deleted) =
@@ -1792,7 +2006,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
 
             let (subs, inbox, deleted) = mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
             assert_eq!((subs, inbox, deleted), (1, 1, 0));
@@ -1830,7 +2044,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
             mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
 
             // 期限内は消えない
@@ -1858,7 +2072,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 1);
             // 対象がクローズされたので購読行は消える（fire_worktree_closed と同じ順序）
             delete_subscriptions_for_target(&pool, "wt-target").await.unwrap();
             assert!(list_subscriptions(&pool, "term-old", now).await.unwrap().is_empty());
@@ -1994,7 +2208,7 @@ mod tests {
             upsert_subscription(&pool, &new).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 2);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 2);
 
             // term-new は既に本文を受け取っている
             let new_ids: Vec<String> = list_inbox(&pool, "term-new", InboxFilter::All)
@@ -2025,7 +2239,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
             let ids: Vec<String> = list_inbox(&pool, "term-old", InboxFilter::All)
                 .await
                 .unwrap()
@@ -2054,7 +2268,7 @@ mod tests {
 
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 1);
             // 積まれた行も引き継ぎ待ちの印が付いている（＝押し込みはされない）
             let items = list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap();
             assert_eq!(items[0].orphaned_at, Some(now));
@@ -2076,7 +2290,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
 
             assert_eq!(list_pushable(&pool, now, PUSH_TTL_MS).await.unwrap().len(), 1);
             let later = now + PUSH_TTL_MS + 1;
@@ -2096,7 +2310,7 @@ mod tests {
             let mut e = event("wt-target", None);
             e.depth = MAX_EVENT_DEPTH + 1;
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 0);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 0);
         });
     }
 
@@ -2113,7 +2327,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
             delete_subscriptions_for_target(&pool, "wt-target").await.unwrap();
 
             let items = list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap();
@@ -2124,8 +2338,316 @@ mod tests {
             assert!(list_spawn_candidates(&pool, now, PUSH_TTL_MS).await.unwrap().is_empty());
             mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
             let candidates = list_spawn_candidates(&pool, now, PUSH_TTL_MS).await.unwrap();
-            assert_eq!(candidates, vec![("wt-subscriber".to_string(), 1)]);
+            assert_eq!(
+                candidates,
+                vec![("wt-subscriber".to_string(), KIND_WORKTREE_CLOSED.to_string(), 1)]
+            );
         });
+    }
+
+    // ─── #126: target ワイルドカード ─────────────────────────────────────────
+
+    #[test]
+    fn test_normalize_target_lowercases_repo_only() {
+        // repo 名は人間が打つ文字列なので大小と空白を吸収する
+        assert_eq!(normalize_target("  repo:  OreTachi  "), "repo:oretachi");
+        // ID は oretachi 発番なので一字一句そのまま
+        assert_eq!(normalize_target(" workgroup: WG-1 "), "workgroup:WG-1");
+        assert_eq!(normalize_target("  wt-ABC  "), "wt-ABC");
+        assert_eq!(normalize_target("*"), "*");
+    }
+
+    #[test]
+    fn test_matching_targets_covers_wildcards() {
+        let t = matching_targets("wt-1", Some("wg-1"), Some("OreTachi"));
+        assert!(t.contains(&"wt-1".to_string()));
+        assert!(t.contains(&"*".to_string()));
+        assert!(t.contains(&"workgroup:wg-1".to_string()));
+        // 照合側も `normalize_target` を通るので、購読登録時の正規化と必ず一致する
+        assert!(t.contains(&"repo:oretachi".to_string()));
+
+        // 所属情報が無いイベントでも ID 一致と `*` は必ず候補に入る
+        let t = matching_targets("wt-1", None, None);
+        assert_eq!(t, vec!["wt-1".to_string(), "*".to_string()]);
+        // 空文字は所属無しと同じ扱い（空の `workgroup:` を作らない）
+        let t = matching_targets("wt-1", Some("  "), Some(""));
+        assert_eq!(t, vec!["wt-1".to_string(), "*".to_string()]);
+    }
+
+    /// `*` / `workgroup:` / `repo:` の購読へ `worktree.created` が届く。
+    /// **まだ存在しないワークツリーの作成を購読できる**ことがワイルドカードの存在理由。
+    #[test]
+    fn test_roundtrip_fanout_matches_wildcard_targets() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            for (i, target) in ["*", "workgroup:wg-1", "repo:oretachi"].iter().enumerate() {
+                let mut s = sub(
+                    &format!("term-{}", i),
+                    Some(&format!("wt-sub-{}", i)),
+                    r#"["worktree.created"]"#,
+                );
+                s.id = format!("sub-{}", i);
+                s.target = target.to_string();
+                upsert_subscription(&pool, &s).await.unwrap();
+            }
+            // 対象外の購読（別ワークグループ / 別リポジトリ）は拾わないこと
+            let mut miss = sub("term-x", Some("wt-sub-x"), r#"["worktree.created"]"#);
+            miss.id = "sub-x".to_string();
+            miss.target = "workgroup:wg-other".to_string();
+            upsert_subscription(&pool, &miss).await.unwrap();
+
+            let mut e = event("wt-new", None);
+            e.kind = KIND_WORKTREE_CREATED.to_string();
+            e.body = r#"{"worktreeId":"wt-new","worktreeName":"n","branchName":"b"}"#.to_string();
+            insert_event(&pool, &e).await.unwrap();
+            let targets = matching_targets("wt-new", Some("wg-1"), Some("oretachi"));
+            assert_eq!(fanout(&pool, &e, &targets, now).await.unwrap(), 3);
+            assert_eq!(list_inbox(&pool, "term-x", InboxFilter::All).await.unwrap().len(), 0);
+        });
+    }
+
+    /// `*` 購読は自ワークツリー発のイベントにも必ずマッチするので、`is_self_echo` が
+    /// 唯一の防波堤になる（#126 の安全性④）。
+    #[test]
+    fn test_roundtrip_wildcard_suppresses_self_echo() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            // 同じワークツリーの別タブ（term-b）も含めて `*` を購読する
+            for (i, terminal) in ["term-a", "term-b"].iter().enumerate() {
+                let mut s = sub(terminal, Some("wt-src"), r#"["worktree.message"]"#);
+                s.id = format!("sub-{}", i);
+                s.target = TARGET_ALL.to_string();
+                upsert_subscription(&pool, &s).await.unwrap();
+            }
+            let mut other = sub("term-c", Some("wt-other"), r#"["worktree.message"]"#);
+            other.id = "sub-c".to_string();
+            other.target = TARGET_ALL.to_string();
+            upsert_subscription(&pool, &other).await.unwrap();
+
+            let mut e = event("wt-src", Some("term-a"));
+            e.kind = KIND_WORKTREE_MESSAGE.to_string();
+            e.body = r#"{"text":"hello"}"#.to_string();
+            insert_event(&pool, &e).await.unwrap();
+            // 発火元タブ(term-a)も、同じワークツリーの別タブ(term-b)も受け取らない
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 1);
+            assert_eq!(list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap().len(), 0);
+            assert_eq!(list_inbox(&pool, "term-b", InboxFilter::All).await.unwrap().len(), 0);
+            assert_eq!(list_inbox(&pool, "term-c", InboxFilter::All).await.unwrap().len(), 1);
+        });
+    }
+
+    // ─── #126: depth の伝播と往復の終端 ──────────────────────────────────────
+
+    /// A↔B の往復が `MAX_EVENT_DEPTH` で止まる。**本 issue で自由文が入ることで初めて
+    /// 実在するようになった経路**なので、実際に止まることをここで固定する。
+    #[test]
+    fn test_roundtrip_message_ping_pong_stops_at_max_depth() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            // A と B が互いを購読する
+            for (i, (terminal, worktree, target)) in [
+                ("term-a", "wt-a", "wt-b"),
+                ("term-b", "wt-b", "wt-a"),
+            ]
+            .iter()
+            .enumerate()
+            {
+                let mut s = sub(terminal, Some(worktree), r#"["worktree.message"]"#);
+                s.id = format!("sub-{}", i);
+                s.target = target.to_string();
+                upsert_subscription(&pool, &s).await.unwrap();
+            }
+
+            // 「受け取ったら返信する」を交互に繰り返す。返信は相手に届いた場合にだけ
+            // 次の送信を誘発するので、配送されなくなった時点で往復は自然に止まる。
+            let mut depths = Vec::new();
+            let mut round = 0usize;
+            loop {
+                let (src_wt, src_term) = if round % 2 == 0 {
+                    ("wt-a", "term-a")
+                } else {
+                    ("wt-b", "term-b")
+                };
+                // 送信側の depth は「直近に受け取った最大 depth + 1」（申告制にしない）
+                let depth = max_inbound_depth(&pool, src_term, now, CHAIN_WINDOW_MS)
+                    .await
+                    .unwrap()
+                    .map_or(0, |d| d + 1);
+                let mut e = event(src_wt, Some(src_term));
+                e.id = format!("ev-{}", round);
+                e.kind = KIND_WORKTREE_MESSAGE.to_string();
+                e.body = r#"{"text":"ping"}"#.to_string();
+                e.depth = depth;
+                insert_event(&pool, &e).await.unwrap();
+                depths.push(depth);
+                let delivered = fanout_all(&pool, &e, now).await.unwrap();
+                if delivered == 0 {
+                    break;
+                }
+                round += 1;
+                assert!(round < 20, "往復が止まらない: {:?}", depths);
+            }
+
+            // 片道4本（depth 0→3）まで届き、5本目の depth 4 が MAX_EVENT_DEPTH(3) 超過で
+            // 破棄されて連鎖が切れる。相手には何も届かないので次の返信も誘発されない。
+            assert_eq!(depths, vec![0, 1, 2, 3, 4]);
+
+            // 送れなくなった側が再送しても、受信済みの最大 depth は変わらないので通らない
+            let depth = max_inbound_depth(&pool, "term-a", now, CHAIN_WINDOW_MS)
+                .await
+                .unwrap()
+                .map_or(0, |d| d + 1);
+            assert_eq!(depth, MAX_EVENT_DEPTH + 1);
+            let mut retry = event("wt-a", Some("term-a"));
+            retry.id = "ev-retry".to_string();
+            retry.kind = KIND_WORKTREE_MESSAGE.to_string();
+            retry.depth = depth;
+            insert_event(&pool, &retry).await.unwrap();
+            assert_eq!(fanout_all(&pool, &retry, now).await.unwrap(), 0);
+        });
+    }
+
+    /// 連鎖ウィンドウを跨げば depth は 0 に戻る。窓を切らないと、一度深い連鎖に
+    /// 巻き込まれたタブが**以後永久に発言不能**になる。
+    #[test]
+    fn test_roundtrip_chain_window_resets_depth() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let mut s = sub("term-a", Some("wt-a"), r#"["worktree.message"]"#);
+            s.target = "wt-b".to_string();
+            upsert_subscription(&pool, &s).await.unwrap();
+            let mut e = event("wt-b", Some("term-b"));
+            e.kind = KIND_WORKTREE_MESSAGE.to_string();
+            e.depth = MAX_EVENT_DEPTH;
+            insert_event(&pool, &e).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
+
+            // 窓の内側では連鎖の続きとして扱う
+            assert_eq!(
+                max_inbound_depth(&pool, "term-a", now, CHAIN_WINDOW_MS).await.unwrap(),
+                Some(MAX_EVENT_DEPTH)
+            );
+            // 窓を過ぎれば起点に戻る
+            let later = now + CHAIN_WINDOW_MS + 1;
+            assert_eq!(
+                max_inbound_depth(&pool, "term-a", later, CHAIN_WINDOW_MS).await.unwrap(),
+                None
+            );
+        });
+    }
+
+    // ─── #126: 自動承認 default-deny の材料 ──────────────────────────────────
+
+    /// spawn 候補は種別ごとに分かれて返る。潰して件数だけにすると、押し込めない
+    /// 自由文メッセージが「タブを立てさせる」ところまで通ってしまう。
+    #[test]
+    fn test_roundtrip_spawn_candidates_are_split_by_kind() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let mut s = sub("term-a", Some("wt-sub"), r#"["worktree.closed","worktree.message"]"#);
+            s.spawn_if_closed = 1;
+            s.target = TARGET_ALL.to_string();
+            upsert_subscription(&pool, &s).await.unwrap();
+
+            for (i, kind) in [KIND_WORKTREE_CLOSED, KIND_WORKTREE_MESSAGE].iter().enumerate() {
+                let mut e = event(&format!("wt-src-{}", i), None);
+                e.id = format!("ev-{}", i);
+                e.kind = kind.to_string();
+                insert_event(&pool, &e).await.unwrap();
+                fanout_all(&pool, &e, now).await.unwrap();
+            }
+            mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
+
+            let mut candidates = list_spawn_candidates(&pool, now, PUSH_TTL_MS).await.unwrap();
+            candidates.sort();
+            assert_eq!(
+                candidates,
+                vec![
+                    ("wt-sub".to_string(), KIND_WORKTREE_CLOSED.to_string(), 1),
+                    ("wt-sub".to_string(), KIND_WORKTREE_MESSAGE.to_string(), 1),
+                ]
+            );
+        });
+    }
+
+    /// `worktree.created` はワークツリーごとに一度きり。二重に積むと購読者が同じ作成を
+    /// 2回読むことになる（`notify_worktree_added` は失敗経路からも呼ばれる）。
+    #[test]
+    fn test_roundtrip_has_event_guards_duplicate_created() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            assert!(!has_event(&pool, "wt-new", KIND_WORKTREE_CREATED).await.unwrap());
+            let mut e = event("wt-new", None);
+            e.kind = KIND_WORKTREE_CREATED.to_string();
+            insert_event(&pool, &e).await.unwrap();
+            assert!(has_event(&pool, "wt-new", KIND_WORKTREE_CREATED).await.unwrap());
+            // 種別違い / ワークツリー違いは別扱い
+            assert!(!has_event(&pool, "wt-new", KIND_WORKTREE_CLOSED).await.unwrap());
+            assert!(!has_event(&pool, "wt-other", KIND_WORKTREE_CREATED).await.unwrap());
+        });
+    }
+
+    // ─── #126: 表示整形 ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_inbox_line_renders_new_kinds() {
+        let item = inbox_item(
+            KIND_WORKTREE_CREATED,
+            r#"{"worktreeId":"wt-1","worktreeName":"oretachi-x","branchName":"feature/y","repositoryName":"oretachi"}"#,
+        );
+        let line = format_inbox_line(&item);
+        assert!(line.contains("oretachi-x"), "{}", line);
+        assert!(line.contains("作成されました"), "{}", line);
+        assert!(line.contains("[oretachi]"), "{}", line);
+
+        let item = inbox_item(
+            KIND_WORKTREE_MESSAGE,
+            r#"{"text":"レビュー待ちです","sourceWorktreeName":"design"}"#,
+        );
+        let line = format_inbox_line(&item);
+        assert!(line.contains("design"), "{}", line);
+        assert!(line.contains("レビュー待ちです"), "{}", line);
+    }
+
+    /// 自由文メッセージがブラケットペーストを脱出できない（#126 の安全性⑤）。
+    /// ブランチ名経由（#125）と違い、本文全体が攻撃者制御になるのがこちら。
+    #[test]
+    fn test_format_inbox_push_text_sanitizes_free_form_message() {
+        let body = serde_json::json!({
+            "text": "ok\u{1b}[201~\rrm -rf /\r",
+            "sourceWorktreeName": "evil\u{1b}[201~\r",
+        })
+        .to_string();
+        let item = inbox_item(KIND_WORKTREE_MESSAGE, &body);
+        let (text, used) = format_inbox_push_text(std::slice::from_ref(&item)).unwrap();
+        assert_eq!(used, 1);
+        assert!(!text.contains('\x1b'));
+        assert!(!text.contains('\r'));
+        assert!(!text.contains('\n'));
+        assert!(text.contains("rm -rf /"), "本文自体は落とさず1行に潰すだけ: {}", text);
+    }
+
+    /// 押し込み本文の締めが種別に依存していないこと。`closed` 決め打ちの文言のままだと
+    /// `created` / `message` を「作業が完了した」と誤読させる。
+    #[test]
+    fn test_format_inbox_push_text_is_kind_agnostic() {
+        let item = inbox_item(
+            KIND_WORKTREE_CREATED,
+            r#"{"worktreeId":"wt-1","worktreeName":"n","branchName":"b"}"#,
+        );
+        let (text, _) = format_inbox_push_text(std::slice::from_ref(&item)).unwrap();
+        assert!(!text.contains("作業が完了した"), "{}", text);
+        assert!(text.contains("oretachi_ack_message"), "{}", text);
     }
 
     /// ブランチ名にペースト終端シーケンスを埋め込んでも脱出できない。
@@ -2200,7 +2722,7 @@ mod tests {
             let arrival = long_ago + 6 * 24 * 60 * 60 * 1000;
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, arrival).await.unwrap();
+            fanout_all(&pool, &e, arrival).await.unwrap();
 
             let items = list_inbox(&pool, "term-a", InboxFilter::All).await.unwrap();
             assert_eq!(items[0].orphaned_at, Some(arrival));
@@ -2222,7 +2744,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, now).await.unwrap();
+            fanout_all(&pool, &e, now).await.unwrap();
 
             // 古い生存一覧で誤って orphaned に落ちる
             mark_orphaned_subscribers(&pool, &[], now).await.unwrap();
@@ -2248,7 +2770,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 1);
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 1);
 
             assert_eq!(delete_subscriptions_for_target(&pool, "wt-target").await.unwrap(), 1);
             assert!(list_subscriptions(&pool, "term-a", now).await.unwrap().is_empty());
@@ -2268,7 +2790,7 @@ mod tests {
             upsert_subscription(&pool, &s).await.unwrap();
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            fanout(&pool, &e, old).await.unwrap();
+            fanout_all(&pool, &e, old).await.unwrap();
 
             let (_, inbox, events) = purge_expired(&pool, now, INBOX_RETENTION_MS).await.unwrap();
             assert_eq!((inbox, events), (1, 1));

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -496,6 +496,12 @@ pub async fn has_event(pool: &SqlitePool, source_worktree_id: &str, kind: &str) 
 /// 「受け取った」とみなす —— エージェントは押し込み / SessionStart 注入で本文を見た時点で
 /// 反応できるため、ack を条件にすると連鎖の起点を数え落とす。
 ///
+/// **数えるのは `worktree.message` だけ。** 往復ループを作れるのは自由文メッセージだけで、
+/// `worktree.created` / `worktree.closed` はワークツリーの追加・削除というユーザー操作から
+/// しか発火せず必ず depth 0 で始まる。これらを数に入れると、`*` を購読して作成通知を
+/// 受けているだけのタブが常に depth 1 以上から送ることになり、**本来の会話が使える
+/// 往復回数だけが減る**（ループ耐性は変わらない）。
+///
 /// 戻り値 `None` は「窓の内側に受信が無い」＝連鎖の起点（depth 0 で送ってよい）。
 pub async fn max_inbound_depth(
     pool: &SqlitePool,
@@ -505,10 +511,11 @@ pub async fn max_inbound_depth(
 ) -> Result<Option<i64>, String> {
     let row: (Option<i64>,) = sqlx::query_as(
         "SELECT MAX(e.depth) FROM inbox i JOIN events e ON e.id = i.event_id \
-         WHERE i.subscriber_terminal_id = ? AND i.created_at > ?",
+         WHERE i.subscriber_terminal_id = ? AND i.created_at > ? AND e.kind = ?",
     )
     .bind(terminal_id)
     .bind(now - window_ms)
+    .bind(KIND_WORKTREE_MESSAGE)
     .fetch_one(pool)
     .await
     .map_err(|e| e.to_string())?;
@@ -2510,6 +2517,44 @@ mod tests {
             retry.depth = depth;
             insert_event(&pool, &retry).await.unwrap();
             assert_eq!(fanout_all(&pool, &retry, now).await.unwrap(), 0);
+        });
+    }
+
+    /// `created` / `closed` は必ず depth 0 のユーザー操作起点なので、連鎖の深さに数えない。
+    /// 数えると `*` を購読して作成通知を受けているだけのタブが常に depth 1 から送ることになり、
+    /// 本来の会話に使える往復回数だけが削られる。
+    #[test]
+    fn test_roundtrip_chain_depth_counts_messages_only() {
+        with_pool(async {
+            let pool = memory_pool().await;
+            let now = 1_000_000i64;
+
+            let mut s = sub("term-a", Some("wt-a"), r#"["worktree.created","worktree.message"]"#);
+            s.target = TARGET_ALL.to_string();
+            upsert_subscription(&pool, &s).await.unwrap();
+
+            // 作成通知を受けても連鎖の起点のまま
+            let mut created = event("wt-b", None);
+            created.id = "ev-created".to_string();
+            created.kind = KIND_WORKTREE_CREATED.to_string();
+            insert_event(&pool, &created).await.unwrap();
+            assert_eq!(fanout_all(&pool, &created, now).await.unwrap(), 1);
+            assert_eq!(
+                max_inbound_depth(&pool, "term-a", now, CHAIN_WINDOW_MS).await.unwrap(),
+                None
+            );
+
+            // 自由文メッセージを受けたときだけ連鎖が進む
+            let mut msg = event("wt-b", Some("term-b"));
+            msg.id = "ev-msg".to_string();
+            msg.kind = KIND_WORKTREE_MESSAGE.to_string();
+            msg.depth = 1;
+            insert_event(&pool, &msg).await.unwrap();
+            fanout_all(&pool, &msg, now).await.unwrap();
+            assert_eq!(
+                max_inbound_depth(&pool, "term-a", now, CHAIN_WINDOW_MS).await.unwrap(),
+                Some(1)
+            );
         });
     }
 

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -1266,6 +1266,12 @@ pub async fn purge_expired(
     // 失効した購読の inbox を先に落とす（購読行が消えた後では
     // `purge_subscriber_worktree` の後方互換パスから引けなくなる）。
     // 同じターミナルの**他の**購読宛のメッセージを巻き込まないよう event 単位で絞る。
+    //
+    // 既知の限界（#126）: 突合が `s.target = e.source_worktree_id` なので、
+    // ワイルドカード購読（`*` / `workgroup:` / `repo:`）が失効した場合はここで拾えず、
+    // その未読は `INBOX_RETENTION_DAYS`(30日) まで残る。inbox は行がどの購読由来かを
+    // 持たないため、ワイルドカードを緩く含めると**同じタブの別購読宛のメッセージまで
+    // 消しうる**。取りこぼしより誤削除のほうが害が大きいので、有界な滞留を選んでいる。
     let mut inbox = sqlx::query(
         "DELETE FROM inbox WHERE EXISTS ( \
            SELECT 1 FROM subscriptions s JOIN events e ON e.id = inbox.event_id \

--- a/src-tauri/src/event_db.rs
+++ b/src-tauri/src/event_db.rs
@@ -1825,7 +1825,7 @@ mod tests {
             }
             let e = event("wt-target", None);
             insert_event(&pool, &e).await.unwrap();
-            assert_eq!(fanout(&pool, &e, now).await.unwrap(), 2, "両タブに積まれる");
+            assert_eq!(fanout_all(&pool, &e, now).await.unwrap(), 2, "両タブに積まれる");
 
             // B タブで Stop が発火した相当の drain
             let b = list_inbox(&pool, "term-b", InboxFilter::Undelivered).await.unwrap();

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -64,11 +64,20 @@ const SPAWN_MAX_LIVE_SESSIONS: usize = 12;
 /// 自動承認が有効なワークツリーへ押し込み / spawn してよいイベント種別（#120 §5.5）。
 ///
 /// 自動承認が有効な宛先へは、別のワークツリーから注入された内容が**人間の確認なしに
-/// 実行される**。oretachi が定型文で組み立てるイベント（`worktree.closed`）だけを許可し、
-/// 自由文（`worktree.message`, #126）は押し込まず inbox に残して人間の確認を要求する。
-/// 現時点では対応種別が `worktree.closed` のみなので挙動は変わらないが、自由文が入った
-/// 瞬間に default-deny になるのが目的。
-const AUTO_APPROVAL_PUSHABLE_KINDS: &[&str] = &[event_db::KIND_WORKTREE_CLOSED];
+/// 実行される**。
+///
+/// 許可の基準は「**本文を誰が書いたか**」:
+/// - 許可: oretachi 自身が定型 JSON として組み立てるイベント
+///   （`worktree.closed` / `worktree.created`）。可変部分はワークツリー名・ブランチ名だけで、
+///   いずれも `sanitize_for_pty` を通る
+/// - 不許可: エージェントが本文を書けるイベント（`worktree.message`, #126）。押し込まず
+///   inbox に残し、人間が UI で確認して手動で渡すか、自動承認を切ることを要求する
+///
+/// **新しい種別を足すときは必ずこの基準で判断すること。** 迷ったら入れない（default-deny）。
+const AUTO_APPROVAL_PUSHABLE_KINDS: &[&str] = &[
+    event_db::KIND_WORKTREE_CLOSED,
+    event_db::KIND_WORKTREE_CREATED,
+];
 
 // ─── ハンドル ─────────────────────────────────────────────────────────────────
 
@@ -989,15 +998,21 @@ async fn spawn_for_closed_tabs(
     state: &mut WorkerState,
     now: i64,
 ) {
-    let candidates = match event_db::list_spawn_candidates(pool, now, event_db::PUSH_TTL_MS).await {
+    let rows = match event_db::list_spawn_candidates(pool, now, event_db::PUSH_TTL_MS).await {
         Ok(c) => c,
         Err(e) => {
             log::warn!("[delivery] list_spawn_candidates failed: {}", e);
             return;
         }
     };
-    if candidates.is_empty() {
+    if rows.is_empty() {
         return;
+    }
+    // 種別ごとの内訳のままワークツリー単位にまとめ直す。**件数だけに潰さない**のは、
+    // 自動承認が有効な宛先で「押し込めない種別の未読」を根拠に spawn してしまわないため。
+    let mut candidates: HashMap<String, Vec<(String, i64)>> = HashMap::new();
+    for (worktree_id, kind, count) in rows {
+        candidates.entry(worktree_id).or_default().push((kind, count));
     }
     let sessions = app.state::<crate::pty_manager::PtyManager>().list_sessions();
     // 同じ tick で複数ワークツリーが spawn 候補になったときに上限を素通りしないよう、
@@ -1007,7 +1022,7 @@ async fn spawn_for_closed_tabs(
         + state.inflight_spawn.len();
     let settings = app.state::<SettingsManager>().get();
 
-    for (worktree_id, pending) in candidates {
+    for (worktree_id, by_kind) in candidates {
         if state.inflight_spawn.contains_key(&worktree_id) {
             continue;
         }
@@ -1033,10 +1048,19 @@ async fn spawn_for_closed_tabs(
         if has_agent {
             continue;
         }
-        if !auto_approval_allows(Some(worktree), event_db::KIND_WORKTREE_CLOSED) {
+        // 自動承認が有効な宛先では、押し込みが許される種別の未読だけを spawn の根拠にする。
+        // 種別を無視して合計件数で判断すると、自由文の `worktree.message` が
+        // 「新しいタブを立てさせる」ところまでは通ってしまう（#126）。
+        let pending: i64 = by_kind
+            .iter()
+            .filter(|(kind, _)| auto_approval_allows(Some(worktree), kind))
+            .map(|(_, count)| *count)
+            .sum();
+        if pending == 0 {
             log::info!(
-                "[delivery] 自動承認が有効なため spawn を見送った worktree={}",
-                worktree.name
+                "[delivery] 自動承認が有効な宛先のため spawn を見送った worktree={} 保留種別={:?}",
+                worktree.name,
+                by_kind.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>()
             );
             continue;
         }
@@ -1094,6 +1118,8 @@ async fn spawn_for_closed_tabs(
 
 // ─── UI 向け Tauri コマンド（#120 §7） ────────────────────────────────────────
 
+use crate::mcp_server::describe_target;
+
 /// 購読一覧の1行。DB の生の行に、人間が読むための解決済みの名前と生存状況を足したもの。
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1106,8 +1132,19 @@ pub struct SubscriptionView {
     pub subscriber_session_id: Option<u32>,
     /// `claude` / `gemini` / `codex` / `cline`。非 CC は Stop フック経路が存在しない
     pub agent_name: Option<String>,
+    /// DB に入っている生の `target`。ワイルドカードの場合は `*` / `workgroup:<id>` /
+    /// `repo:<name>` がそのまま入る（#126）
     pub target_worktree_id: String,
+    /// 厳密一致 target のワークツリー名。クローズ済み / ワイルドカードでは None
     pub target_worktree_name: Option<String>,
+    /// `worktree` | `all` | `workgroup` | `repo`（#126）。UI はこれを見て
+    /// 「クローズ済み」バッジを出すかどうかを決める。**種別を渡さずに
+    /// `target_worktree_name` が None であることだけで判断すると、ワイルドカード購読が
+    /// すべて「クローズ済み」と誤表示される。**
+    pub target_kind: String,
+    /// 人間向けの表示名。ワークグループは表示名、リポジトリは名前、`*` は None
+    /// （UI 側でローカライズした文言を出す）
+    pub target_label: Option<String>,
     pub event_kinds: Vec<String>,
     pub delivery: String,
     pub spawn_if_closed: bool,
@@ -1174,11 +1211,14 @@ pub async fn event_list_subscriptions(
                 .find(|(t, _, _)| *t == r.subscriber_terminal_id)
                 .map(|(_, a, b)| (*a, *b))
                 .unwrap_or((0, 0));
+            let (target_kind, target_label) = describe_target(&settings, &r.target);
             SubscriptionView {
                 subscriber_worktree_name: r.subscriber_worktree_id.as_deref().and_then(name_of),
                 subscriber_session_id: session.map(|s| s.session_id),
                 agent_name: session.and_then(|s| s.agent_name.clone()),
                 target_worktree_name: name_of(&r.target),
+                target_kind,
+                target_label,
                 target_worktree_id: r.target,
                 event_kinds: serde_json::from_str(&r.event_kinds).unwrap_or_default(),
                 delivery: r.delivery,
@@ -1469,9 +1509,13 @@ mod tests {
     #[test]
     fn test_auto_approval_allows_canned_kinds_only() {
         let on = worktree(Some(true));
+        // oretachi 自身が定型 JSON で組み立てるイベントは許可
         assert!(auto_approval_allows(Some(&on), event_db::KIND_WORKTREE_CLOSED));
-        // 自由文（#126 で入る予定）は自動承認宛には押し込まない
-        assert!(!auto_approval_allows(Some(&on), "worktree.message"));
+        assert!(auto_approval_allows(Some(&on), event_db::KIND_WORKTREE_CREATED));
+        // エージェントが本文を書ける自由文（#126）は自動承認宛には押し込まない
+        assert!(!auto_approval_allows(Some(&on), event_db::KIND_WORKTREE_MESSAGE));
+        // 知らない種別も default-deny
+        assert!(!auto_approval_allows(Some(&on), "worktree.unknown"));
     }
 
     #[test]
@@ -1481,6 +1525,53 @@ mod tests {
         let unset = worktree(None);
         assert!(auto_approval_allows(Some(&unset), "worktree.message"));
         assert!(auto_approval_allows(None, "worktree.message"));
+    }
+
+    /// `push_pending` / `filter_for_turn_end` の仕分けと同じ形。自動承認が有効な宛先では、
+    /// 同じタブに定型と自由文が混ざっていても**自由文だけが保留**され、定型は通る（#126）。
+    #[test]
+    fn test_auto_approval_partition_blocks_only_free_form() {
+        let on = worktree(Some(true));
+        let items = vec![
+            item("a", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_CLOSED),
+            item("b", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_CREATED),
+            item("c", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_MESSAGE),
+        ];
+        let (allowed, blocked): (Vec<_>, Vec<_>) = items
+            .into_iter()
+            .partition(|i| auto_approval_allows(Some(&on), &i.kind));
+        assert_eq!(ids(&allowed), vec!["a", "b"]);
+        assert_eq!(ids(&blocked), vec!["c"]);
+    }
+
+    /// `spawn_for_closed_tabs` の判定と同じ形。自由文の未読しか無い宛先では、自動承認が
+    /// 有効なら spawn しない（押し込めない未読を根拠にタブを立てない）。
+    #[test]
+    fn test_spawn_pending_count_ignores_blocked_kinds() {
+        let on = worktree(Some(true));
+        let off = worktree(Some(false));
+        let by_kind = vec![
+            (event_db::KIND_WORKTREE_MESSAGE.to_string(), 3i64),
+            (event_db::KIND_WORKTREE_CLOSED.to_string(), 2i64),
+        ];
+        let count = |wt: &WorktreeEntry| -> i64 {
+            by_kind
+                .iter()
+                .filter(|(kind, _)| auto_approval_allows(Some(wt), kind))
+                .map(|(_, c)| *c)
+                .sum()
+        };
+        assert_eq!(count(&on), 2, "自動承認 ON では自由文を数えない");
+        assert_eq!(count(&off), 5, "自動承認 OFF なら従来どおり全部数える");
+
+        // 自由文だけの宛先は spawn 対象にならない（pending == 0）
+        let only_message = vec![(event_db::KIND_WORKTREE_MESSAGE.to_string(), 3i64)];
+        let pending: i64 = only_message
+            .iter()
+            .filter(|(kind, _)| auto_approval_allows(Some(&on), kind))
+            .map(|(_, c)| *c)
+            .sum();
+        assert_eq!(pending, 0);
     }
 
     // ─── ターン境界配送（#124） ──────────────────────────────────────────────

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -528,27 +528,24 @@ fn should_deliver_turn(last: Option<&str>, prompt_id: Option<&str>) -> bool {
     }
 }
 
-/// `Stop` 経路で注入してよい未読だけに絞る。
+/// 自動承認が有効な宛先へ注入してよい未読だけに絞る（#120 §5.5）。
 ///
-/// `Stop` の `additionalContext` は**会話を継続させる＝ターンを開始させる**ので、
-/// PTY 押し込みと同じ危険度を持つ。よって押し込みと同じ2つの制限を課す:
+/// **`Stop` / `SessionStart` / `UserPromptSubmit` のすべての注入経路に掛けること。**
+/// `autoApproval` は Claude Code の承認プロンプトを自動応答する機能なので、どの経路で
+/// 入ったかにかかわらず、注入された自由文は人間の確認なしにツール実行へつながる。
+/// 経路によって掛けたり掛けなかったりすると、`AUTO_APPROVAL_PUSHABLE_KINDS` が宣言する
+/// 「自動承認が有効な宛先へは定型イベントのみ」という不変条件が破れる（#126）。
 ///
-/// - `delivery=passive` は「押し込まないでほしい」という購読側の明示指定。同じタブに
-///   他の戦略が混ざっていても巻き込まない（Phase 3 で踏んだバグと同じ轍を踏まない）
-/// - 自動承認が有効な宛先へは定型イベントのみ（#120 §5.5）。自由文は inbox に残して
-///   人間の確認を要求する
-///
-/// 自動承認の判定は**行ごとにその行自身の `subscriber_worktree_id` で行う**。1タブが
-/// `cd` して別ワークツリーで再購読すると同じ `terminal_id` に異なるワークツリー宛の行が
-/// 混ざるため、代表1件から解決すると**実際の宛先ではないワークツリーの設定で全件を
-/// 判定してしまう**（#131 が手動引き継ぎで塞いだのと同じ穴）。
-fn filter_for_turn_end(
+/// 判定は**行ごとにその行自身の `subscriber_worktree_id` で行う**。1タブが `cd` して
+/// 別ワークツリーで再購読すると同じ `terminal_id` に異なるワークツリー宛の行が混ざるため、
+/// 代表1件から解決すると**実際の宛先ではないワークツリーの設定で全件を判定してしまう**
+/// （#131 が手動引き継ぎで塞いだのと同じ穴）。
+fn filter_auto_approval(
     items: Vec<event_db::InboxItem>,
     settings: &AppSettings,
 ) -> Vec<event_db::InboxItem> {
     items
         .into_iter()
-        .filter(|i| i.delivery != event_db::DELIVERY_PASSIVE)
         .filter(|i| {
             let worktree = i
                 .subscriber_worktree_id
@@ -557,6 +554,27 @@ fn filter_for_turn_end(
             auto_approval_allows(worktree, &i.kind)
         })
         .collect()
+}
+
+/// `Stop` 経路で注入してよい未読だけに絞る。
+///
+/// `Stop` の `additionalContext` は**会話を継続させる＝ターンを開始させる**ので、
+/// PTY 押し込みと同じ危険度を持つ。自動承認の制限（上記）に加えて、
+/// `delivery=passive` を除外する —— これは「押し込まないでほしい」という購読側の明示指定で、
+/// 同じタブに他の戦略が混ざっていても巻き込まない（Phase 3 で踏んだバグと同じ轍を踏まない）。
+///
+/// `SessionStart` / `UserPromptSubmit` は人間の操作が起点でターンを勝手に始めないため、
+/// `passive` も含めて回収する（購読ツールの説明どおり「どの戦略でもセッション開始時の
+/// 回収は使える」）。
+fn filter_for_turn_end(
+    items: Vec<event_db::InboxItem>,
+    settings: &AppSettings,
+) -> Vec<event_db::InboxItem> {
+    let items: Vec<_> = items
+        .into_iter()
+        .filter(|i| i.delivery != event_db::DELIVERY_PASSIVE)
+        .collect();
+    filter_auto_approval(items, settings)
 }
 
 /// 指定タブ宛の未読を hook の `additionalContext` 用テキストにまとめ、本文を出した分に
@@ -619,19 +637,23 @@ async fn collect_digest(
             return;
         }
     };
-    let items = if reason.is_turn_end() {
+    // 自動承認のガードは**全経路**に掛ける。`Stop` はさらに `passive` も外す。
+    let items = {
         let settings = app.state::<SettingsManager>().get();
         let before = items.len();
-        let items = filter_for_turn_end(items, &settings);
+        let items = if reason.is_turn_end() {
+            filter_for_turn_end(items, &settings)
+        } else {
+            filter_auto_approval(items, &settings)
+        };
         if items.len() < before {
             log::debug!(
-                "[delivery] Stop 経路では {} 件を注入対象から外した（passive / 自動承認）terminal={}",
+                "[delivery] {} 経路で {} 件を注入対象から外した（自動承認 / passive）terminal={}",
+                reason.label(),
                 before - items.len(),
                 terminal_id
             );
         }
-        items
-    } else {
         items
     };
 
@@ -656,7 +678,7 @@ async fn collect_digest(
             0
         }
     };
-    let Some(digest) = event_db::format_inbox_digest(&items, carryover) else {
+    let Some((digest, used)) = event_db::format_inbox_digest(&items, carryover) else {
         let _ = reply.send(None);
         return;
     };
@@ -673,7 +695,9 @@ async fn collect_digest(
         return;
     }
 
-    let ids: Vec<String> = items.iter().map(|i| i.id.clone()).collect();
+    // 上限で載らなかった分は打刻しない（未配送のまま次の機会に回す）。全件打刻すると
+    // 本文に出ていない未読が「配送済み」になり、再送しない方針のせいで二度と出ない。
+    let ids: Vec<String> = items.iter().take(used).map(|i| i.id.clone()).collect();
     if let Err(e) = event_db::mark_delivered(pool, &ids, event_db::now_ms()).await {
         // 打刻に失敗しても本文は既に渡している。未配送のまま残るので次の機会に再度出る
         // （取りこぼすより一度重複するほうが安全）。
@@ -870,23 +894,15 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
         if items.is_empty() {
             continue;
         }
-        // 残りに interrupt が混ざっていれば走行中でも割り込む。
-        let delivery = strongest_delivery(&items);
-        let decision = decide_push(session, &delivery, now);
-        if let PushDecision::Skip(reason) = decision {
-            log::debug!(
-                "[delivery] 押し込みを見送る terminal={} 件数={} 理由={}",
-                terminal_id,
-                items.len(),
-                reason
-            );
-            continue;
-        }
-
         // 自動承認が有効な宛先へは定型イベントしか押し込まない。判定は
         // `filter_for_turn_end` と同じく**行ごとにその行自身の `subscriber_worktree_id`**
         // で行う。代表1件から解決すると、1タブが `cd` して別ワークツリーで再購読した
         // ときに「実際の宛先ではないワークツリーの設定」で全件を通してしまう。
+        //
+        // **配送戦略を決める前に仕分ける。** 後回しにすると、保留されるはずの
+        // `interrupt` な自由文メッセージが `strongest_delivery` を押し上げ、
+        // `turn_end` しか指定していない定型イベントまで走行中のエージェントへ
+        // 割り込ませてしまう（保留した行が押し込み判定に影響を残す）。
         let (allowed, blocked): (Vec<_>, Vec<_>) = items.into_iter().partition(|i| {
             let worktree = i
                 .subscriber_worktree_id
@@ -894,12 +910,6 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
                 .and_then(|id| find_worktree(&settings, id));
             auto_approval_allows(worktree, &i.kind)
         });
-        // トーストに出す宛先名は代表1件から引く（表示だけなので判定には使わない）。
-        let worktree = allowed
-            .first()
-            .or_else(|| blocked.first())
-            .and_then(|i| i.subscriber_worktree_id.as_deref())
-            .and_then(|id| find_worktree(&settings, id));
         if !blocked.is_empty() {
             // 保留された分は未配送のまま残り、tick ごとに再評価される（＝毎回ここを通る）ので
             // debug に留める。人間への提示は UI の未読表示が担う。
@@ -908,6 +918,26 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
                 blocked.len(),
                 terminal_id
             );
+        }
+        if allowed.is_empty() {
+            continue;
+        }
+        // トーストに出す宛先名は代表1件から引く（表示だけなので判定には使わない）。
+        let worktree = allowed
+            .first()
+            .and_then(|i| i.subscriber_worktree_id.as_deref())
+            .and_then(|id| find_worktree(&settings, id));
+        // 残りに interrupt が混ざっていれば走行中でも割り込む。
+        let delivery = strongest_delivery(&allowed);
+        let decision = decide_push(session, &delivery, now);
+        if let PushDecision::Skip(reason) = decision {
+            log::debug!(
+                "[delivery] 押し込みを見送る terminal={} 件数={} 理由={}",
+                terminal_id,
+                allowed.len(),
+                reason
+            );
+            continue;
         }
         // 長さ上限で載らなかった分は打刻しない（未配送のまま次回に回す）。
         let Some((text, used)) = event_db::format_inbox_push_text(&allowed) else {
@@ -1553,6 +1583,29 @@ mod tests {
         assert_eq!(ids(&blocked), vec!["c"]);
     }
 
+    /// 保留された行は配送戦略の決定に影響してはいけない。`interrupt` な自由文が
+    /// 混ざっているだけで `turn_end` の定型イベントが走行中のエージェントへ
+    /// 割り込む、という取り違えを固定する（`push_pending` は仕分け後に
+    /// `strongest_delivery` を取る）。
+    #[test]
+    fn test_blocked_items_do_not_escalate_delivery() {
+        let on = worktree(Some(true));
+        let items = vec![
+            item("a", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_CLOSED),
+            item("b", event_db::DELIVERY_INTERRUPT, event_db::KIND_WORKTREE_MESSAGE),
+        ];
+        // 仕分け前の全体では interrupt に見える
+        assert_eq!(strongest_delivery(&items), event_db::DELIVERY_INTERRUPT);
+        let allowed: Vec<_> = items
+            .into_iter()
+            .filter(|i| auto_approval_allows(Some(&on), &i.kind))
+            .collect();
+        // 仕分け後は turn_end。走行中のエージェントへは押し込まれない
+        assert_eq!(strongest_delivery(&allowed), event_db::DELIVERY_TURN_END);
+        let busy = session(Some("claude"), Some("busy"), true);
+        assert!(!is_push(decide_push(&busy, &strongest_delivery(&allowed), 1_000_000)));
+    }
+
     /// `spawn_for_closed_tabs` の判定と同じ形。自由文の未読しか無い宛先では、自動承認が
     /// 有効なら spawn しない（押し込めない未読を根拠にタブを立てない）。
     #[test]
@@ -1687,6 +1740,34 @@ mod tests {
         b.subscriber_worktree_id = Some("wt-auto".to_string());
 
         assert_eq!(ids(&filter_for_turn_end(vec![a, b], &settings)), vec!["a"]);
+    }
+
+    /// **自動承認のガードは全注入経路に掛かること。** `Stop` だけに掛けていると、
+    /// `SessionStart` / `UserPromptSubmit` の additionalContext から自由文が素通りし、
+    /// 自動承認が有効な宛先で人間の確認なしにツール実行へつながる（#126）。
+    /// `passive` の除外だけが `Stop` 固有。
+    #[test]
+    fn test_auto_approval_filter_applies_to_all_injection_paths() {
+        let items = vec![
+            item("a", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_CLOSED),
+            item("b", event_db::DELIVERY_TURN_END, event_db::KIND_WORKTREE_MESSAGE),
+            item("c", event_db::DELIVERY_PASSIVE, event_db::KIND_WORKTREE_CLOSED),
+        ];
+        let auto_on = settings_with(Some(true));
+        // SessionStart / UserPromptSubmit 経路: 自由文は落とし、passive は回収する
+        assert_eq!(
+            ids(&filter_auto_approval(items.clone(), &auto_on)),
+            vec!["a", "c"]
+        );
+        // Stop 経路: 自由文に加えて passive も落とす
+        assert_eq!(ids(&filter_for_turn_end(items.clone(), &auto_on)), vec!["a"]);
+        // 自動承認 OFF なら自由文も通る（passive の扱いだけ経路で違う）
+        let auto_off = settings_with(Some(false));
+        assert_eq!(
+            ids(&filter_auto_approval(items.clone(), &auto_off)),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(ids(&filter_for_turn_end(items, &auto_off)), vec!["a", "b"]);
     }
 
     /// 宛先ワークツリーが解決できない行（設定から消えた等）は、自動承認の判定材料が

--- a/src-tauri/src/event_delivery.rs
+++ b/src-tauri/src/event_delivery.rs
@@ -883,14 +883,23 @@ async fn push_pending(app: &AppHandle, pool: &SqlitePool, state: &mut WorkerStat
             continue;
         }
 
-        // 自動承認が有効な宛先へは定型イベントしか押し込まない。
-        let worktree = items
+        // 自動承認が有効な宛先へは定型イベントしか押し込まない。判定は
+        // `filter_for_turn_end` と同じく**行ごとにその行自身の `subscriber_worktree_id`**
+        // で行う。代表1件から解決すると、1タブが `cd` して別ワークツリーで再購読した
+        // ときに「実際の宛先ではないワークツリーの設定」で全件を通してしまう。
+        let (allowed, blocked): (Vec<_>, Vec<_>) = items.into_iter().partition(|i| {
+            let worktree = i
+                .subscriber_worktree_id
+                .as_deref()
+                .and_then(|id| find_worktree(&settings, id));
+            auto_approval_allows(worktree, &i.kind)
+        });
+        // トーストに出す宛先名は代表1件から引く（表示だけなので判定には使わない）。
+        let worktree = allowed
             .first()
+            .or_else(|| blocked.first())
             .and_then(|i| i.subscriber_worktree_id.as_deref())
             .and_then(|id| find_worktree(&settings, id));
-        let (allowed, blocked): (Vec<_>, Vec<_>) = items
-            .into_iter()
-            .partition(|i| auto_approval_allows(worktree, &i.kind));
         if !blocked.is_empty() {
             // 保留された分は未配送のまま残り、tick ごとに再評価される（＝毎回ここを通る）ので
             // debug に留める。人間への提示は UI の未読表示が担う。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1020,13 +1020,47 @@ async fn save_archive(
 /// 呼び出し元は `git worktree remove` の成功確認後の経路だけ。フロントの
 /// `useWorktreeRemove.ts` は失敗・キャンセル・多重実行では afterRemove に到達しないため、
 /// `Cancelled` / `Busy` / `Failed` では構造的に発火しない。
+/// イベントの target 照合に必要な、ワークツリーの所属情報を解決する（#126）。
+///
+/// 呼び出し元から渡された値を優先し、無ければ settings から引く。**closed 経路では
+/// settings 側の実体が既に消えている**（`removeWorktree` が afterRemove より先に
+/// settings を書き換える）ため、フロントが持っている値を渡してもらうのが本筋で、
+/// settings 参照はそれが無い場合のフォールバック。
+///
+/// ワークグループは未設定なら先頭グループへフォールバックする（`resolve_workgroup` /
+/// フロントの `resolvedGroupId` と同じ規則。購読側の `workgroup:<id>` 解決と一致させる）。
+fn resolve_event_scope(
+    app_handle: &tauri::AppHandle,
+    worktree_id: &str,
+    repository_name: Option<String>,
+    workgroup_id: Option<String>,
+) -> (Option<String>, Option<String>) {
+    let settings = app_handle.state::<SettingsManager>().get();
+    let entry = settings.worktrees.iter().find(|w| w.id == worktree_id);
+    let repo = repository_name
+        .map(|r| r.trim().to_string())
+        .filter(|r| !r.is_empty())
+        .or_else(|| entry.map(|w| w.repository_name.clone()));
+    let group_hint = workgroup_id
+        .map(|g| g.trim().to_string())
+        .filter(|g| !g.is_empty())
+        .or_else(|| entry.and_then(|w| w.workgroup_id.clone()));
+    let group = mcp_server::resolve_workgroup_by_id(&settings, group_hint.as_deref())
+        .map(|g| g.id.clone());
+    (repo, group)
+}
+
 fn fire_worktree_closed(
     app_handle: &tauri::AppHandle,
     id: String,
     name: String,
     branch_name: String,
+    repository_name: Option<String>,
+    workgroup_id: Option<String>,
     actor: &'static str,
 ) {
+    let (repository_name, workgroup_id) =
+        resolve_event_scope(app_handle, &id, repository_name, workgroup_id);
     let handle = app_handle.clone();
     tauri::async_runtime::spawn(async move {
         let Some(pool) = handle.try_state::<event_db::EventPool>() else {
@@ -1060,12 +1094,18 @@ fn fire_worktree_closed(
             log::warn!("[event] failed to record worktree.closed for {}: {}", name, e);
             return;
         }
-        match event_db::fanout(&pool.0, &event, now).await {
+        let targets = event_db::matching_targets(
+            &id,
+            workgroup_id.as_deref(),
+            repository_name.as_deref(),
+        );
+        match event_db::fanout(&pool.0, &event, &targets, now).await {
             Ok(count) => {
                 log::info!(
-                    "[event] worktree.closed worktree={} actor={} delivered={}",
+                    "[event] worktree.closed worktree={} actor={} targets={:?} delivered={}",
                     name,
                     actor,
+                    targets,
                     count
                 );
                 if count > 0 {
@@ -1106,14 +1146,103 @@ fn fire_worktree_closed(
     });
 }
 
+/// `worktree.created` イベントを event_db へ発行する（issue #126）。
+///
+/// `fire_worktree_closed` と対称で fire-and-forget。発火点は `notify_worktree_added`
+/// —— 手動作成（`App.vue`）とタスク実行（`useTaskExecution.ts`）の**両経路が必ず通る
+/// 唯一の Tauri コマンド**で、`notify_worktree_archived` と同じチョークポイント原則に従う。
+///
+/// #126 本文は `mcp_server.rs` の `worktree-added` リスナー（`broadcast_worktree_added` と
+/// 同じ場所）を提案しているが、そのリスナーは `start_mcp_server` でしか登録されず、
+/// MCP サーバが停止中 / 再起動中には発火しない穴が残るため、こちらを選んだ。
+fn fire_worktree_created(
+    app_handle: &tauri::AppHandle,
+    id: String,
+    name: String,
+    branch_name: String,
+    repository_name: Option<String>,
+    workgroup_id: Option<String>,
+) {
+    let (repository_name, workgroup_id) =
+        resolve_event_scope(app_handle, &id, repository_name, workgroup_id);
+    let handle = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        let Some(pool) = handle.try_state::<event_db::EventPool>() else {
+            log::debug!("[event] Event DB not initialized; skipping worktree.created for {}", name);
+            return;
+        };
+        // `created` はワークツリーごとに一度きりの意味を持つが、`useTaskExecution.ts` は
+        // セットアップ成功時と失敗時の両分岐から `notify_worktree_added` を呼ぶ形なので、
+        // 経路次第で二度叩かれうる。二重に積むと購読者が同じ作成を2回読むことになる。
+        match event_db::has_event(&pool.0, &id, event_db::KIND_WORKTREE_CREATED).await {
+            Ok(true) => {
+                log::debug!("[event] worktree.created は既に発行済み worktree={}", name);
+                return;
+            }
+            Ok(false) => {}
+            Err(e) => log::warn!("[event] has_event failed for {}: {}", name, e),
+        }
+        let now = event_db::now_ms();
+        let body = serde_json::json!({
+            "worktreeId": id,
+            "worktreeName": name,
+            "branchName": branch_name,
+            "repositoryName": repository_name,
+            "workgroupId": workgroup_id,
+        })
+        .to_string();
+        let event = event_db::EventRow {
+            id: uuid::Uuid::new_v4().to_string(),
+            source_worktree_id: id.clone(),
+            // 作成経路も terminal_id を運んでいない（作成を実行したタブは特定できない）。
+            source_terminal_id: None,
+            kind: event_db::KIND_WORKTREE_CREATED.to_string(),
+            body,
+            actor: Some("worktree-add".to_string()),
+            created_at: now,
+            // ユーザー操作 / タスク実行が起点なので連鎖の深さは 0。
+            depth: 0,
+            origin: Some("worktree-add".to_string()),
+        };
+        if let Err(e) = event_db::insert_event(&pool.0, &event).await {
+            log::warn!("[event] failed to record worktree.created for {}: {}", name, e);
+            return;
+        }
+        let targets = event_db::matching_targets(
+            &id,
+            workgroup_id.as_deref(),
+            repository_name.as_deref(),
+        );
+        match event_db::fanout(&pool.0, &event, &targets, now).await {
+            Ok(count) => {
+                log::info!(
+                    "[event] worktree.created worktree={} targets={:?} delivered={}",
+                    name,
+                    targets,
+                    count
+                );
+                if count > 0 {
+                    event_delivery::notify_event_queued(&handle);
+                }
+            }
+            Err(e) => log::warn!("[event] fanout failed for {}: {}", name, e),
+        }
+    });
+}
+
 /// ワークツリーのアーカイブ（削除）が完了した後にMCPクライアントへ通知する。
 /// git worktree remove の成功確認後にフロントエンドから呼び出す。
+///
+/// `repository_name` / `workgroup_id` は `repo:` / `workgroup:` 購読の照合用（#126）。
+/// この時点で settings 上の実体は既に消えているためフロントから渡してもらう（省略可）。
 #[tauri::command]
 fn notify_worktree_archived(
     app_handle: tauri::AppHandle,
     id: String,
     name: String,
     branch_name: String,
+    repository_name: Option<String>,
+    workgroup_id: Option<String>,
 ) {
     let _bc = main_thread_watch::enter(main_thread_watch::Activity::NotifyWorktreeArchived);
     let _ = app_handle.emit("worktree-archived", serde_json::json!({
@@ -1121,7 +1250,7 @@ fn notify_worktree_archived(
         "name": name,
         "branchName": branch_name,
     }));
-    fire_worktree_closed(&app_handle, id, name, branch_name, "archive");
+    fire_worktree_closed(&app_handle, id, name, branch_name, repository_name, workgroup_id, "archive");
 }
 
 /// アーカイブせずにワークツリーを削除したときの `worktree.closed` 発行用。
@@ -1133,19 +1262,26 @@ fn notify_worktree_closed(
     id: String,
     name: String,
     branch_name: String,
+    repository_name: Option<String>,
+    workgroup_id: Option<String>,
 ) {
     let _bc = main_thread_watch::enter(main_thread_watch::Activity::NotifyWorktreeClosed);
-    fire_worktree_closed(&app_handle, id, name, branch_name, "delete");
+    fire_worktree_closed(&app_handle, id, name, branch_name, repository_name, workgroup_id, "delete");
 }
 
 /// ワークツリーの追加が完了した後にMCPクライアントへ通知する。
 /// git worktree add の成功確認後にフロントエンドから呼び出す。
+///
+/// `worktree.created` の発火点でもある（#126）。MCP ピアへの broadcast は
+/// `worktree-added` リスナー側が担当し、購読配送はこちらの経路で行う。
 #[tauri::command]
 fn notify_worktree_added(
     app_handle: tauri::AppHandle,
     id: String,
     name: String,
     branch_name: String,
+    repository_name: Option<String>,
+    workgroup_id: Option<String>,
 ) {
     let _bc = main_thread_watch::enter(main_thread_watch::Activity::NotifyWorktreeAdded);
     let _ = app_handle.emit("worktree-added", serde_json::json!({
@@ -1153,6 +1289,7 @@ fn notify_worktree_added(
         "name": name,
         "branchName": branch_name,
     }));
+    fire_worktree_created(&app_handle, id, name, branch_name, repository_name, workgroup_id);
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1192,7 +1192,11 @@ fn fire_worktree_created(
         })
         .to_string();
         let event = event_db::EventRow {
-            id: uuid::Uuid::new_v4().to_string(),
+            // **決定的な id にする。** 上の `has_event` は check-then-act なので、
+            // 同時に2回呼ばれると両方が「未発行」を見て2件積みうる。id を固定すると
+            // 2件目は `INSERT OR REPLACE` で同じ行を上書きし、`fanout` も
+            // `UNIQUE(subscriber_terminal_id, event_id)` で弾かれるため構造的に1件になる。
+            id: format!("{}:{}", event_db::KIND_WORKTREE_CREATED, id),
             source_worktree_id: id.clone(),
             // 作成経路も terminal_id を運んでいない（作成を実行したタブは特定できない）。
             source_terminal_id: None,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1011,15 +1011,6 @@ async fn save_archive(
     archive_db::save(&pool.0, &archive).await
 }
 
-/// `worktree.closed` イベントを event_db へ発行する（issue #123）。
-///
-/// **fire-and-forget**。close フローは既に oneshot + timeout の複雑な経路
-/// （`CloseWorktreeAckRegistry`、ack タイムアウト 45 秒）なので、DB 書き込みと照合で
-/// クローズ処理をブロックしない。DB 未初期化・書き込み失敗はログのみで握りつぶす。
-///
-/// 呼び出し元は `git worktree remove` の成功確認後の経路だけ。フロントの
-/// `useWorktreeRemove.ts` は失敗・キャンセル・多重実行では afterRemove に到達しないため、
-/// `Cancelled` / `Busy` / `Failed` では構造的に発火しない。
 /// イベントの target 照合に必要な、ワークツリーの所属情報を解決する（#126）。
 ///
 /// 呼び出し元から渡された値を優先し、無ければ settings から引く。**closed 経路では
@@ -1050,6 +1041,15 @@ fn resolve_event_scope(
     (repo, group)
 }
 
+/// `worktree.closed` イベントを event_db へ発行する（issue #123）。
+///
+/// **fire-and-forget**。close フローは既に oneshot + timeout の複雑な経路
+/// （`CloseWorktreeAckRegistry`、ack タイムアウト 45 秒）なので、DB 書き込みと照合で
+/// クローズ処理をブロックしない。DB 未初期化・書き込み失敗はログのみで握りつぶす。
+///
+/// 呼び出し元は `git worktree remove` の成功確認後の経路だけ。フロントの
+/// `useWorktreeRemove.ts` は失敗・キャンセル・多重実行では afterRemove に到達しないため、
+/// `Cancelled` / `Busy` / `Failed` では構造的に発火しない。
 fn fire_worktree_closed(
     app_handle: &tauri::AppHandle,
     id: String,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1276,9 +1276,18 @@ impl NotifyService {
             let _ = hook_tx.send(event);
             reply(true)
         } else {
-            self.app_handle
-                .emit("notify-worktree", &event)
-                .map_err(|e: tauri::Error| McpError::internal_error(e.to_string(), None))?;
+            // トーストの emit に失敗しても `?` で返さない。イベント発行は既に済んでいる
+            // ので、ここで Err にすると成功した配送結果まで呼び出し元から見えなくなる
+            // （上のイベント発行側と同じ理由。2経路は互いを巻き添えにしない）。
+            if let Err(e) = self.app_handle.emit("notify-worktree", &event) {
+                log::warn!("[mcp] notify_worktree の emit に失敗: {}", e);
+                // 報告すべきイベント結果が無い（＝従来どおりの呼び出し）なら、
+                // 従来どおりエラーで返す。`"ok"` を返すと debounce と区別が付かない。
+                if event_result.is_none() {
+                    return Err(McpError::internal_error(e.to_string(), None));
+                }
+                return reply(false);
+            }
             log::info!("[mcp] notify_worktree: {} kind={}", worktree_name, event.kind);
             reply(true)
         }
@@ -2906,6 +2915,20 @@ async fn publish_worktree_message(
             )
         })?
         .to_string();
+    // 自由文は他ワークツリーのエージェントのコンテキストへそのまま注入される。
+    // 上限が無いと相手のセッションを本文で埋められるので入口で弾く（切り詰めではなく
+    // エラーにするのは、勝手に削って「送れた」と誤解させないため）。
+    let text_len = text.chars().count();
+    if text_len > crate::event_db::MESSAGE_TEXT_MAX_CHARS {
+        return Err(McpError::invalid_params(
+            format!(
+                "body が長すぎます（{} 文字 / 上限 {} 文字）。要点を絞って送るか、詳細は共有ファイルや issue に置いて参照を送ってください",
+                text_len,
+                crate::event_db::MESSAGE_TEXT_MAX_CHARS
+            ),
+            None,
+        ));
+    }
 
     // await をまたいで State / settings の参照を持たないよう、ここで所有権のある値へ確定させる
     let (source_terminal_id, source_worktree_id, source_worktree_name, repository_name, workgroup_id) = {

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1215,6 +1215,11 @@ impl NotifyService {
         // 経路で、下の `should_send_notify` による debounce（hook 3s / approval 1s）が
         // かかる。購読配送を debounce に載せるとイベントが黙って落ちる（#120 §1）ので、
         // 判定より前にここで発行しきる。
+        //
+        // **失敗しても `?` で早期 return しない。** イベント発行のエラー（DB 未初期化、
+        // terminal_id の解決失敗、body 空など）でトーストまで巻き添えにすると、
+        // 「`kind=approval` に `event_kind` を添えただけで承認待ちトーストが出ない」という
+        // 独立経路の設計と真逆の挙動になる。トーストは必ず送り、失敗はレスポンスで返す。
         let event_result = match event_kind.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
             Some(k) => Some(
                 publish_worktree_message(
@@ -1224,7 +1229,7 @@ impl NotifyService {
                     terminal_id.as_deref(),
                     project_dir.as_deref(),
                 )
-                .await?,
+                .await,
             ),
             None => None,
         };
@@ -1237,12 +1242,25 @@ impl NotifyService {
         };
         // 通知トーストを送ったかどうかにかかわらず、イベント発行の結果は必ず返す
         // （debounce で落ちても購読配送は成立しているため、"ok" だけ返すと嘘になる）。
+        // イベント発行が失敗した場合はツール結果を isError にして呼び出し元に気付かせる
+        // ——トーストは既に送っているので、エラーにしても通知は失われない。
         let reply = |notified: bool| {
-            let text = match &event_result {
-                Some(v) => serde_json::json!({ "ok": true, "notified": notified, "event": v }).to_string(),
-                None => "ok".to_string(),
+            let result = match &event_result {
+                Some(Ok(v)) => CallToolResult::success(vec![Content::text(
+                    serde_json::json!({ "ok": true, "notified": notified, "event": v }).to_string(),
+                )]),
+                Some(Err(e)) => CallToolResult::error(vec![Content::text(
+                    serde_json::json!({
+                        "ok": false,
+                        "notified": notified,
+                        "error": e.message,
+                        "hint": "通知トースト自体は送信済みです。購読イベントの発行だけが失敗しました。",
+                    })
+                    .to_string(),
+                )]),
+                None => CallToolResult::success(vec![Content::text("ok")]),
             };
-            Ok(CallToolResult::success(vec![Content::text(text)]))
+            Ok(result)
         };
 
         let hook_tx = {
@@ -1759,8 +1777,9 @@ impl NotifyService {
             return Err(McpError::invalid_params("target must not be empty", None));
         }
 
-        // 現状 Phase 1 では worktree.closed のみ。未対応種別を黙って受け付けると
-        // 「購読したのに来ない」という分かりにくい失敗になるので明示的に弾く。
+        // 未対応種別を黙って受け付けると「購読したのに来ない」という分かりにくい失敗に
+        // なるので明示的に弾く。既定が `worktree.closed` だけなのは後方互換のため
+        // （`*` の主用途は `worktree.created` なので description で明示している）。
         let kinds = event_kinds
             .unwrap_or_else(|| vec![crate::event_db::KIND_WORKTREE_CLOSED.to_string()]);
         if kinds.is_empty() {
@@ -2699,12 +2718,14 @@ pub fn describe_target(settings: &AppSettings, target: &str) -> (String, Option<
     }
     if let Some(repo) = target.strip_prefix(crate::event_db::TARGET_REPO_PREFIX) {
         // 照合用に小文字化して保存しているので、元の表記が settings にあればそちらを出す。
+        // 比較は `normalize_target` と同じ Unicode の `to_lowercase()` で行う。
+        // `eq_ignore_ascii_case` だと非 ASCII を含む名前で保存値と突き合わなくなる。
         let label = settings
             .repositories
             .iter()
             .map(|r| r.name.as_str())
             .chain(settings.worktrees.iter().map(|w| w.repository_name.as_str()))
-            .find(|name| name.eq_ignore_ascii_case(repo))
+            .find(|name| name.to_lowercase() == repo)
             .unwrap_or(repo)
             .to_string();
         return ("repo".to_string(), Some(label));
@@ -2790,12 +2811,16 @@ fn resolve_subscription_target(
         }
         // 登録済みリポジトリ名と、既存ワークツリーが持つリポジトリ名の両方を突合する
         // （リポジトリ登録を消してもワークツリーだけ残っているケースがあるため）。
+        // 大小の吸収は `normalize_target` と同じ Unicode の `to_lowercase()` で行う
+        // （`eq_ignore_ascii_case` は非 ASCII を畳まないので、日本語混じりの名前を
+        //   大小違いで打つと「見つかりません」になる）。
+        let needle = value.to_lowercase();
         let matched = settings
             .repositories
             .iter()
             .map(|r| r.name.as_str())
             .chain(settings.worktrees.iter().map(|w| w.repository_name.as_str()))
-            .find(|name| name.eq_ignore_ascii_case(value));
+            .find(|name| name.to_lowercase() == needle);
         let Some(name) = matched else {
             let available: Vec<&str> = settings.repositories.iter().map(|r| r.name.as_str()).collect();
             return Err(McpError::invalid_params(
@@ -2848,6 +2873,10 @@ fn resolve_subscription_target(
 /// `depth` はエージェントに申告させず、そのタブが直近に受け取ったイベントから自動計算する。
 /// 申告制にすると「返信時に depth を足す」という約束を破るだけで `MAX_EVENT_DEPTH` の
 /// 暴走防止ガードを無効化できてしまう（A↔B の往復が止まらなくなる）。
+///
+/// 既知の限界（#126）: `depth` が止めるのは**連鎖**であって連打ではない。同じタブから
+/// 立て続けに送れば他ワークツリーの inbox には積まれる。押し込み側は宛先ごとの
+/// 最小間隔（30秒）と保持期限で有界なので、実害は「未読が増える」までに留まる。
 async fn publish_worktree_message(
     app_handle: &AppHandle,
     event_kind: &str,
@@ -4546,6 +4575,27 @@ mod tests {
         let w = resolve_subscription_target(&settings, "oretachi-abcd").unwrap();
         assert_eq!(w.stored, "wt-1");
         assert_eq!(w.worktree_id.as_deref(), Some("wt-1"));
+    }
+
+    /// 非 ASCII を含むリポジトリ名でも、大小を変えて入力できて表示名も元表記に戻る。
+    /// `eq_ignore_ascii_case` は非 ASCII を畳まないので、保存側の `to_lowercase()` と
+    /// 突合方法がずれていると「見つかりません」やラベル崩れになる。
+    #[test]
+    fn resolve_subscription_target_handles_non_ascii_repo_name() {
+        let mut settings = target_settings();
+        settings.repositories[0].name = "テストRepo".into();
+        settings.worktrees[0].repository_name = "テストRepo".into();
+
+        let r = resolve_subscription_target(&settings, "repo:テストREPO").unwrap();
+        assert_eq!(r.stored, "repo:テストrepo");
+        assert!(r.label.contains("テストRepo"), "{}", r.label);
+        assert_eq!(
+            describe_target(&settings, &r.stored),
+            ("repo".to_string(), Some("テストRepo".to_string()))
+        );
+        // 照合側の候補集合とも噛み合う
+        assert!(crate::event_db::matching_targets("wt-1", None, Some("テストRepo"))
+            .contains(&r.stored));
     }
 
     /// 保存値と `matching_targets` の突合が実際に噛み合うこと。ここがずれると

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -437,10 +437,16 @@ pub struct PromptContextPayload {
 pub struct NotifyWorktreeParams {
     #[schemars(description = "通知するワークツリー名")]
     pub worktree_name: String,
-    #[schemars(description = "通知種別: \"approval\"(承認待ち) / \"completed\"(作業完了) / \"general\"(汎用) / \"hook\"(ライフサイクルフック)。省略時は \"general\"")]
+    #[schemars(description = "通知種別: \"approval\"(承認待ち) / \"completed\"(作業完了) / \"general\"(汎用) / \"hook\"(ライフサイクルフック)。省略時は \"general\"。これは画面に出すトーストの種別であり、購読イベントの種別(event_kind)とは別物")]
     pub kind: Option<String>,
     #[schemars(description = "通知本文（ライフサイクルフックのコンテキスト情報など）。省略可")]
     pub body: Option<String>,
+    #[schemars(description = "購読イベントとしても発行する場合の**イベント種別**。現在は \"worktree.message\" のみ。トースト種別 kind とは名前空間が別。指定すると body が自由文メッセージとして、自分のワークツリーを購読している他のワークツリーへ配送される（宛先は購読者が決めるので worktree_name とは無関係）")]
+    pub event_kind: Option<String>,
+    #[schemars(description = "呼び出し元ターミナルの terminal_id。event_kind 指定時の発信元の同定に使う（セッション開始時に oretachi から注入されている）")]
+    pub terminal_id: Option<String>,
+    #[schemars(description = "呼び出し元の作業ディレクトリ絶対パス。event_kind 指定時に terminal_id を省略した場合のフォールバック同定に使う")]
+    pub project_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -718,9 +724,9 @@ pub struct WriteTerminalParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SubscribeWorktreeParams {
-    #[schemars(description = "購読対象のワークツリー名または ID。このワークツリーがクローズされたら通知が届く")]
+    #[schemars(description = "購読対象。ワークツリー名 / ID のほか、ワイルドカードとして \"*\"(全ワークツリー) / \"workgroup:<ID または名前>\" / \"repo:<リポジトリ名>\" を指定できる。**これから作成されるワークツリーの worktree.created を購読したい場合はワイルドカードを使う**（ID 固定では表現できない）")]
     pub target: String,
-    #[schemars(description = "購読するイベント種別。現状 \"worktree.closed\" のみ対応（省略時 [\"worktree.closed\"]）")]
+    #[schemars(description = "購読するイベント種別の配列。\"worktree.closed\"(クローズ) / \"worktree.created\"(作成) / \"worktree.message\"(他ワークツリーのエージェントが notify_worktree で送る自由文)。省略時は [\"worktree.closed\"]")]
     pub event_kinds: Option<Vec<String>>,
     #[schemars(description = "配送戦略: \"turn_end\"(既定。待機中なら PTY へ押し込み、走行中はターン境界を待つ) / \"interrupt\"(走行中でも即 PTY へ割り込む) / \"passive\"(押し込まない。oretachi_poll_inbox で自分から取りに来る)。どの戦略でもセッション開始時の回収と oretachi_poll_inbox は使える")]
     pub delivery: Option<String>,
@@ -1199,33 +1205,64 @@ impl NotifyService {
         Ok(CallToolResult::success(vec![Content::text(result_json)]))
     }
 
-    #[tool(description = "ワークツリーに通知を送信する")]
-    fn notify_worktree(
+    #[tool(description = "ワークツリーに通知を送信する。event_kind に \"worktree.message\" を指定すると、通知に加えて自分のワークツリーを購読している他のワークツリーへ body を自由文メッセージとして配送する（購読方式なので送信側は宛先を指定しない）")]
+    async fn notify_worktree(
         &self,
-        Parameters(NotifyWorktreeParams { worktree_name, kind, body }): Parameters<NotifyWorktreeParams>,
+        Parameters(NotifyWorktreeParams { worktree_name, kind, body, event_kind, terminal_id, project_dir }): Parameters<NotifyWorktreeParams>,
     ) -> Result<CallToolResult, McpError> {
+        // 購読イベントの発行は通知トーストとは**独立した第三の経路**（event_db → 配送
+        // ワーカー）に載せる。`hook_tx`（broadcast channel）も WebView IPC もトースト用の
+        // 経路で、下の `should_send_notify` による debounce（hook 3s / approval 1s）が
+        // かかる。購読配送を debounce に載せるとイベントが黙って落ちる（#120 §1）ので、
+        // 判定より前にここで発行しきる。
+        let event_result = match event_kind.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            Some(k) => Some(
+                publish_worktree_message(
+                    &self.app_handle,
+                    k,
+                    body.as_deref(),
+                    terminal_id.as_deref(),
+                    project_dir.as_deref(),
+                )
+                .await?,
+            ),
+            None => None,
+        };
+
         let event = NotifyWorktreeEvent {
             worktree_name: worktree_name.clone(),
             kind: kind.unwrap_or_else(|| "general".to_string()),
             body,
             agent: None,
         };
-        let manager = self.app_handle.state::<McpServerManager>();
-        // HTTP 経路と同じ debounce ポリシー (hook=3s, approval=1s, 他は対象外) を適用
-        let should_send = should_send_notify(&manager.notify_last_sent, &event.worktree_name, &event.kind);
-        if !should_send {
-            return Ok(CallToolResult::success(vec![Content::text("ok")]));
-        }
+        // 通知トーストを送ったかどうかにかかわらず、イベント発行の結果は必ず返す
+        // （debounce で落ちても購読配送は成立しているため、"ok" だけ返すと嘘になる）。
+        let reply = |notified: bool| {
+            let text = match &event_result {
+                Some(v) => serde_json::json!({ "ok": true, "notified": notified, "event": v }).to_string(),
+                None => "ok".to_string(),
+            };
+            Ok(CallToolResult::success(vec![Content::text(text)]))
+        };
+
+        let hook_tx = {
+            let manager = self.app_handle.state::<McpServerManager>();
+            // HTTP 経路と同じ debounce ポリシー (hook=3s, approval=1s, 他は対象外) を適用
+            if !should_send_notify(&manager.notify_last_sent, &event.worktree_name, &event.kind) {
+                return reply(false);
+            }
+            manager.hook_tx.clone()
+        };
         if event.kind == "hook" {
             // hook イベントは broadcast channel 経由で MCP ピアに直接送信する（WebView IPC をバイパス）
-            let _ = manager.hook_tx.send(event);
-            Ok(CallToolResult::success(vec![Content::text("ok")]))
+            let _ = hook_tx.send(event);
+            reply(true)
         } else {
             self.app_handle
                 .emit("notify-worktree", &event)
                 .map_err(|e: tauri::Error| McpError::internal_error(e.to_string(), None))?;
             log::info!("[mcp] notify_worktree: {} kind={}", worktree_name, event.kind);
-            Ok(CallToolResult::success(vec![Content::text("ok")]))
+            reply(true)
         }
     }
 
@@ -1704,7 +1741,7 @@ impl NotifyService {
         }
     }
 
-    #[tool(description = "指定ワークツリーのクローズを購読する。別ワークツリーで進めている関連作業が完了（クローズ）したことを、自分のセッションで検知したいときに使う。届いた通知は待機中なら PTY へ押し込まれ、次のセッション開始時にも自動で提示され、oretachi_poll_inbox でも取得できる。ターミナルを閉じたりアプリを再起動したりしても購読は引き継ぎ待ちとして保持され、同じワークツリーで次に AI エージェントが立ち上がったときに引き継がれる")]
+    #[tool(description = "他ワークツリーのイベント（クローズ / 作成 / エージェントからの自由文メッセージ）を購読する。別ワークツリーで進めている関連作業の完了や開始を自分のセッションで検知したいときに使う。target には \"*\" / \"workgroup:<ID>\" / \"repo:<名前>\" のワイルドカードも指定でき、まだ存在しないワークツリーの作成も購読できる。届いた通知は待機中なら PTY へ押し込まれ、次のセッション開始時にも自動で提示され、oretachi_poll_inbox でも取得できる。ターミナルを閉じたりアプリを再起動したりしても購読は引き継ぎ待ちとして保持され、同じワークツリーで次に AI エージェントが立ち上がったときに引き継がれる")]
     async fn oretachi_subscribe_worktree(
         &self,
         Parameters(SubscribeWorktreeParams {
@@ -1770,29 +1807,18 @@ impl NotifyService {
         }
 
         // await をまたいで State / settings の参照を保持しないよう、ここで所有権のある値へ確定させる
-        let (subscriber, target_id, target_name) = {
+        let (subscriber, resolved) = {
             let subscriber = resolve_subscriber(
                 &self.app_handle,
                 terminal_id.as_deref(),
                 project_dir.as_deref(),
             )?;
             let settings = self.app_handle.state::<SettingsManager>().get();
-            let wt = resolve_worktree_by_name_or_id(&settings, target.as_str())?;
-            // ホーム / リポジトリ擬似ワークツリーは削除自体が禁止されているので
-            // worktree.closed は構造的に永久に発火しない。購読を受け付けると
-            // 「購読成功したのに一生通知が来ない」状態になるため拒否する。
-            if wt.is_home || wt.is_repository {
-                let kind = if wt.is_home { "ホーム" } else { "リポジトリ" };
-                return Err(McpError::invalid_params(
-                    format!(
-                        "'{}' は{}擬似ワークツリーでクローズされることがないため購読できません",
-                        wt.name, kind
-                    ),
-                    None,
-                ));
-            }
-            (subscriber, wt.id.clone(), wt.name.clone())
+            let resolved = resolve_subscription_target(&settings, target.as_str())?;
+            (subscriber, resolved)
         };
+        let target_id = resolved.stored.clone();
+        let target_name = resolved.label.clone();
 
         // 逆引きできないと自己エコー抑止も購読者クローズ時の掃除も効かないため受け付けない
         let Some(subscriber_worktree_id) = subscriber.worktree_id.clone() else {
@@ -1801,10 +1827,13 @@ impl NotifyService {
                 None,
             ));
         };
-        if subscriber_worktree_id == target_id {
+        // 厳密一致のときだけ「自分自身は購読できない」を課す。ワイルドカードでは
+        // 自ワークツリーのイベントも必ず target にマッチするが、そちらは `is_self_echo` が
+        // 配送段階で落とすので購読自体は成立する（他のワークツリーのぶんが届く）。
+        if resolved.worktree_id.as_deref() == Some(subscriber_worktree_id.as_str()) {
             return Err(McpError::invalid_params(
                 format!(
-                    "自分自身が居るワークツリー '{}' のクローズは購読できません（クローズされた時点でこのセッションも消えるため通知先がありません）",
+                    "自分自身が居る{}のクローズは購読できません（クローズされた時点でこのセッションも消えるため通知先がありません）",
                     target_name
                 ),
                 None,
@@ -1850,8 +1879,17 @@ impl NotifyService {
                 "expiresAt": sub.expires_at,
                 "subscriberTerminalId": subscriber.terminal_id,
                 "message": format!(
-                    "ワークツリー '{}' のクローズを購読しました。クローズされると次のセッション開始時に通知が提示されます（oretachi_poll_inbox でも取得できます）。",
-                    target_name
+                    "{}の {} を購読しました。イベントが発生すると次のセッション開始時に通知が提示されます（oretachi_poll_inbox でも取得できます）。{}",
+                    target_name,
+                    kinds.join(" / "),
+                    // `*` は将来立つワークツリーも含めて全部に反応する。自動 spawn と
+                    // 組み合わせると意図せずタブが立つので、そこだけは明示的に警告する
+                    // （端末数上限 / クールダウンで爆発はしないが、驚きは残る）。
+                    if resolved.worktree_id.is_none() && sub.spawn_if_closed != 0 {
+                        " 注意: ワイルドカード購読と spawn_if_closed を併用しているため、未読が溜まると自動でタブが立ちます（生存端末数の上限と再試行のクールダウンで制限されます）。"
+                    } else {
+                        ""
+                    }
                 ),
             })
             .to_string(),
@@ -1879,12 +1917,13 @@ impl NotifyService {
                 project_dir.as_deref(),
             )?;
             // 購読対象が既にクローズ済みで settings から消えている場合もあるため、
-            // 逆引きできなければ渡された文字列をそのまま ID として扱う
+            // 解決できなければ正規化した文字列をそのまま保存値として扱う（#126 の
+            // ワイルドカードも `resolve_subscription_target` が同じ正規化を通す）
             let target_id = target.as_ref().map(|t| {
                 let settings = self.app_handle.state::<SettingsManager>().get();
-                resolve_worktree_by_name_or_id(&settings, t.as_str())
-                    .map(|w| w.id.clone())
-                    .unwrap_or_else(|_| t.clone())
+                resolve_subscription_target(&settings, t.as_str())
+                    .map(|r| r.stored)
+                    .unwrap_or_else(|_| crate::event_db::normalize_target(t))
             });
             (subscriber, target_id)
         };
@@ -1932,18 +1971,18 @@ impl NotifyService {
             .await
             .map_err(|e| McpError::internal_error(e, None))?;
 
-        // ワークツリー名の付与は表示目的のみ。既にクローズ済みなら ID だけになる。
+        // 名前の付与は表示目的のみ。厳密一致 target が既にクローズ済みなら ID だけになる。
         let settings = self.app_handle.state::<SettingsManager>().get();
         let items: Vec<serde_json::Value> = subs
             .iter()
             .map(|s| {
-                let name = settings
-                    .worktrees
-                    .iter()
-                    .find(|w| w.id == s.target)
-                    .map(|w| w.name.clone());
+                let (target_kind, target_label) = describe_target(&settings, &s.target);
+                let name = if target_kind == "worktree" { target_label.clone() } else { None };
                 serde_json::json!({
                     "subscriptionId": s.id,
+                    "target": s.target,
+                    "targetKind": target_kind,
+                    "targetLabel": target_label,
                     "targetWorktreeId": s.target,
                     "targetWorktreeName": name,
                     "eventKinds": serde_json::from_str::<serde_json::Value>(&s.event_kinds).unwrap_or(serde_json::Value::Null),
@@ -2637,6 +2676,312 @@ fn resolve_worktree<'a>(
     Err(McpError::invalid_params(missing_hint.to_string(), None))
 }
 
+/// 保存済みの購読 `target` を `(種別, 表示名)` へ分解する（#126）。
+///
+/// 種別は `worktree` | `all` | `workgroup` | `repo`。**UI / ツール応答はこの種別を見て
+/// 「クローズ済み」の判定をすること。** 名前が引けないことだけを根拠にすると、
+/// ワイルドカード購読がすべて「対象がクローズ済み」と誤表示される。
+///
+/// `*` は表示名を持たない（表示側でローカライズする）。`workgroup:` は表示名を解決する
+/// （未リネームのグループは name が None なので、生の ID を出すと人間が読めない）。
+pub fn describe_target(settings: &AppSettings, target: &str) -> (String, Option<String>) {
+    if target == crate::event_db::TARGET_ALL {
+        return ("all".to_string(), None);
+    }
+    if let Some(gid) = target.strip_prefix(crate::event_db::TARGET_WORKGROUP_PREFIX) {
+        let label = settings
+            .workgroups
+            .iter()
+            .find(|g| g.id == gid)
+            .map(|g| workgroup_display_name(settings, g))
+            .unwrap_or_else(|| gid.to_string());
+        return ("workgroup".to_string(), Some(label));
+    }
+    if let Some(repo) = target.strip_prefix(crate::event_db::TARGET_REPO_PREFIX) {
+        // 照合用に小文字化して保存しているので、元の表記が settings にあればそちらを出す。
+        let label = settings
+            .repositories
+            .iter()
+            .map(|r| r.name.as_str())
+            .chain(settings.worktrees.iter().map(|w| w.repository_name.as_str()))
+            .find(|name| name.eq_ignore_ascii_case(repo))
+            .unwrap_or(repo)
+            .to_string();
+        return ("repo".to_string(), Some(label));
+    }
+    (
+        "worktree".to_string(),
+        settings
+            .worktrees
+            .iter()
+            .find(|w| w.id == target)
+            .map(|w| w.name.clone()),
+    )
+}
+
+/// 購読の `target` の解決結果（#126）。
+struct ResolvedTarget {
+    /// DB に保存する正規化済みの target 文字列
+    stored: String,
+    /// 人間 / エージェントへ返す表示名
+    label: String,
+    /// 厳密一致（単一ワークツリー）の場合のみ Some。ワイルドカードでは None
+    worktree_id: Option<String>,
+}
+
+/// 購読の `target` を解決する。ワークツリー ID / 名前のほか、`*` / `workgroup:<id|名前>` /
+/// `repo:<名前>` のワイルドカードを受ける（#126）。
+///
+/// **まだ存在しないワークツリーの `worktree.created` を購読したい**という要求は ID 固定の
+/// target では表現できないため、ワイルドカードは `worktree.created` とセットで必要になる。
+fn resolve_subscription_target(
+    settings: &AppSettings,
+    raw: &str,
+) -> Result<ResolvedTarget, McpError> {
+    let trimmed = raw.trim();
+    if trimmed == crate::event_db::TARGET_ALL {
+        return Ok(ResolvedTarget {
+            stored: crate::event_db::TARGET_ALL.to_string(),
+            label: "全ワークツリー".to_string(),
+            worktree_id: None,
+        });
+    }
+
+    if let Some(value) = trimmed.strip_prefix(crate::event_db::TARGET_WORKGROUP_PREFIX) {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(McpError::invalid_params(
+                "workgroup: の後にワークグループ ID または名前を指定してください",
+                None,
+            ));
+        }
+        // ID 優先、次に表示名。どちらでも解決できなければ利用可能な一覧を添えて返す
+        // （エージェントが自己修復できるようにするのが既存 target 解決の流儀）。
+        let gid = resolve_workgroup_target(settings, Some(value), None)
+            .or_else(|_| resolve_workgroup_target(settings, None, Some(value)))
+            .map_err(|e| McpError::invalid_params(e, None))?
+            .ok_or_else(|| {
+                McpError::invalid_params("ワークグループを解決できませんでした", None)
+            })?;
+        let label = settings
+            .workgroups
+            .iter()
+            .find(|g| g.id == gid)
+            .map(|g| workgroup_display_name(settings, g))
+            .unwrap_or_else(|| gid.clone());
+        return Ok(ResolvedTarget {
+            stored: crate::event_db::normalize_target(&format!(
+                "{}{}",
+                crate::event_db::TARGET_WORKGROUP_PREFIX,
+                gid
+            )),
+            label: format!("ワークグループ '{}'", label),
+            worktree_id: None,
+        });
+    }
+
+    if let Some(value) = trimmed.strip_prefix(crate::event_db::TARGET_REPO_PREFIX) {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(McpError::invalid_params(
+                "repo: の後にリポジトリ名を指定してください",
+                None,
+            ));
+        }
+        // 登録済みリポジトリ名と、既存ワークツリーが持つリポジトリ名の両方を突合する
+        // （リポジトリ登録を消してもワークツリーだけ残っているケースがあるため）。
+        let matched = settings
+            .repositories
+            .iter()
+            .map(|r| r.name.as_str())
+            .chain(settings.worktrees.iter().map(|w| w.repository_name.as_str()))
+            .find(|name| name.eq_ignore_ascii_case(value));
+        let Some(name) = matched else {
+            let available: Vec<&str> = settings.repositories.iter().map(|r| r.name.as_str()).collect();
+            return Err(McpError::invalid_params(
+                format!(
+                    "リポジトリ '{}' が見つかりません。利用可能: [{}]",
+                    value,
+                    available.join(", ")
+                ),
+                None,
+            ));
+        };
+        return Ok(ResolvedTarget {
+            stored: crate::event_db::normalize_target(&format!(
+                "{}{}",
+                crate::event_db::TARGET_REPO_PREFIX,
+                name
+            )),
+            label: format!("リポジトリ '{}'", name),
+            worktree_id: None,
+        });
+    }
+
+    let wt = resolve_worktree_by_name_or_id(settings, trimmed)?;
+    // ホーム / リポジトリ擬似ワークツリーは削除自体が禁止されているので worktree.closed が
+    // 構造的に永久に発火しない。**この制約は厳密一致 target のときだけ**で、`*` を弾く
+    // 理由にはならない（`*` は他のワークツリーのイベントで成立する）。
+    if wt.is_home || wt.is_repository {
+        let kind = if wt.is_home { "ホーム" } else { "リポジトリ" };
+        return Err(McpError::invalid_params(
+            format!(
+                "'{}' は{}擬似ワークツリーでクローズされることがないため購読できません",
+                wt.name, kind
+            ),
+            None,
+        ));
+    }
+    Ok(ResolvedTarget {
+        stored: wt.id.clone(),
+        label: format!("ワークツリー '{}'", wt.name),
+        worktree_id: Some(wt.id.clone()),
+    })
+}
+
+/// `notify_worktree` の `event_kind` 指定時に購読イベントを発行する（#126）。
+///
+/// **発信元は呼び出し元のワークツリー**であって、`notify_worktree` の `worktree_name`
+/// （トーストの宛先）ではない。#120 は「送信側が宛先を知っている前提を置くと破綻する」
+/// ため購読方式を採っており、宛先を決めるのは購読者側。
+///
+/// `depth` はエージェントに申告させず、そのタブが直近に受け取ったイベントから自動計算する。
+/// 申告制にすると「返信時に depth を足す」という約束を破るだけで `MAX_EVENT_DEPTH` の
+/// 暴走防止ガードを無効化できてしまう（A↔B の往復が止まらなくなる）。
+async fn publish_worktree_message(
+    app_handle: &AppHandle,
+    event_kind: &str,
+    body: Option<&str>,
+    terminal_id: Option<&str>,
+    project_dir: Option<&str>,
+) -> Result<serde_json::Value, McpError> {
+    if event_kind != crate::event_db::KIND_WORKTREE_MESSAGE {
+        return Err(McpError::invalid_params(
+            format!(
+                "event_kind '{}' は notify_worktree からは発行できません。指定できるのは '{}' のみです（'{}' / '{}' は oretachi がワークツリーの追加・削除時に自動で発行します）",
+                event_kind,
+                crate::event_db::KIND_WORKTREE_MESSAGE,
+                crate::event_db::KIND_WORKTREE_CREATED,
+                crate::event_db::KIND_WORKTREE_CLOSED,
+            ),
+            None,
+        ));
+    }
+    let text = body
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            McpError::invalid_params(
+                "event_kind を指定する場合は body（購読者へ届けるメッセージ本文）が必要です",
+                None,
+            )
+        })?
+        .to_string();
+
+    // await をまたいで State / settings の参照を持たないよう、ここで所有権のある値へ確定させる
+    let (source_terminal_id, source_worktree_id, source_worktree_name, repository_name, workgroup_id) = {
+        let subscriber = resolve_subscriber(app_handle, terminal_id, project_dir)?;
+        let Some(worktree_id) = subscriber.worktree_id.clone() else {
+            return Err(McpError::invalid_params(
+                "呼び出し元ターミナルの作業ディレクトリから oretachi 管理下のワークツリーを特定できませんでした。oretachi が管理しているワークツリー内で実行してください",
+                None,
+            ));
+        };
+        let settings = app_handle.state::<SettingsManager>().get();
+        let wt = settings.worktrees.iter().find(|w| w.id == worktree_id);
+        let group = wt
+            .and_then(|w| resolve_workgroup(&settings, w))
+            .map(|g| g.id.clone());
+        (
+            subscriber.terminal_id,
+            worktree_id,
+            wt.map(|w| w.name.clone()),
+            wt.map(|w| w.repository_name.clone()),
+            group,
+        )
+    };
+
+    let pool = event_pool(app_handle)?;
+    let now = crate::event_db::now_ms();
+    // 受信した最大 depth + 1。受信が無ければ 0（連鎖の起点）。
+    let depth = crate::event_db::max_inbound_depth(
+        &pool,
+        &source_terminal_id,
+        now,
+        crate::event_db::CHAIN_WINDOW_MS,
+    )
+    .await
+    .map_err(|e| McpError::internal_error(e, None))?
+    .map_or(0, |d| d + 1);
+
+    let body_json = serde_json::json!({
+        "text": text,
+        "sourceWorktreeName": source_worktree_name,
+    })
+    .to_string();
+    let event = crate::event_db::EventRow {
+        id: uuid::Uuid::new_v4().to_string(),
+        source_worktree_id: source_worktree_id.clone(),
+        // 自己エコー抑止（同じタブへ配り返さない）と depth 伝播の起点になる
+        source_terminal_id: Some(source_terminal_id.clone()),
+        kind: crate::event_db::KIND_WORKTREE_MESSAGE.to_string(),
+        body: body_json,
+        actor: Some("mcp".to_string()),
+        created_at: now,
+        depth,
+        origin: Some(format!("mcp-notify:{}", source_terminal_id)),
+    };
+    // 閾値超過でも events には残す（監査とループ解析用）。配送は `fanout` が落とす。
+    crate::event_db::insert_event(&pool, &event)
+        .await
+        .map_err(|e| McpError::internal_error(e, None))?;
+
+    let targets = crate::event_db::matching_targets(
+        &source_worktree_id,
+        workgroup_id.as_deref(),
+        repository_name.as_deref(),
+    );
+    let delivered = crate::event_db::fanout(&pool, &event, &targets, now)
+        .await
+        .map_err(|e| McpError::internal_error(e, None))?;
+    if delivered > 0 {
+        crate::event_delivery::notify_event_queued(app_handle);
+    }
+    log::info!(
+        "[mcp] notify_worktree event_kind={} source={} terminal={} depth={} targets={:?} delivered={}",
+        event_kind,
+        source_worktree_id,
+        source_terminal_id,
+        depth,
+        targets,
+        delivered
+    );
+
+    // 閾値超過は静かに捨てず呼び出し元へ返す。返さないとエージェントは「送れた」と
+    // 誤解したまま相手の応答を待ち続ける。
+    let message = if depth > crate::event_db::MAX_EVENT_DEPTH {
+        format!(
+            "連鎖の深さが {} に達したためメッセージは配送されませんでした（上限 {}）。ワークツリー間の自動往復を止めるための制限です。続ける場合は人間に確認してください。",
+            depth,
+            crate::event_db::MAX_EVENT_DEPTH
+        )
+    } else if delivered == 0 {
+        "メッセージを発行しましたが、このワークツリーを購読しているセッションがありませんでした。".to_string()
+    } else {
+        format!("{} 件の購読者へメッセージを配送しました。", delivered)
+    };
+    Ok(serde_json::json!({
+        "eventId": event.id,
+        "eventKind": event.kind,
+        "sourceWorktreeId": source_worktree_id,
+        "sourceTerminalId": source_terminal_id,
+        "depth": depth,
+        "maxDepth": crate::event_db::MAX_EVENT_DEPTH,
+        "delivered": delivered,
+        "message": message,
+    }))
+}
+
 /// 購読系ツールを呼んでいるタブの同定結果（issue #123）。
 struct SubscriberIdentity {
     /// 購読の主キー。PTY spawn 時に発番された UUID
@@ -2833,10 +3178,19 @@ fn resolve_artifact_worktree<'a>(
 /// ワークツリーの所属ワークグループを解決する。workgroup_id が未設定/不明な場合は
 /// 先頭グループにフォールバック（フロントの resolvedGroupId と同仕様）。
 fn resolve_workgroup<'a>(settings: &'a AppSettings, worktree: &WorktreeEntry) -> Option<&'a Workgroup> {
-    worktree
-        .workgroup_id
-        .as_ref()
-        .and_then(|id| settings.workgroups.iter().find(|g| &g.id == id))
+    resolve_workgroup_by_id(settings, worktree.workgroup_id.as_deref())
+}
+
+/// `resolve_workgroup` の ID 版。ワークツリーの実体が既に settings から消えた後でも
+/// 所属グループを解決したい経路（`worktree.closed` の target 照合）で使う（#126）。
+pub fn resolve_workgroup_by_id<'a>(
+    settings: &'a AppSettings,
+    workgroup_id: Option<&str>,
+) -> Option<&'a Workgroup> {
+    workgroup_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(|id| settings.workgroups.iter().find(|g| g.id == id))
         .or_else(|| settings.workgroups.first())
 }
 
@@ -2844,7 +3198,7 @@ fn resolve_workgroup<'a>(settings: &'a AppSettings, worktree: &WorktreeEntry) ->
 /// （フロントの useWorkgroups.displayName / i18n `workgroup.autoName` と一致させる）。
 /// 生の name をそのまま返すと、リネームしていない既定グループが全部 null になり
 /// レポート側で「グループが出てこない」状態になるため、ここで解決しておく。
-fn workgroup_display_name(settings: &AppSettings, group: &Workgroup) -> String {
+pub fn workgroup_display_name(settings: &AppSettings, group: &Workgroup) -> String {
     if let Some(name) = group.name.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         return name.to_string();
     }
@@ -4129,6 +4483,129 @@ mod tests {
         let err = resolve_workgroup_target(&settings, None, Some("リリース準備")).unwrap_err();
         assert!(err.contains("複数"), "{}", err);
         assert!(err.contains("workgroup_id"), "{}", err);
+    }
+
+    // ─── #126: 購読 target のワイルドカード ──────────────────────────────────
+
+    fn target_settings() -> AppSettings {
+        let mut settings = wg_settings();
+        settings.repositories = vec![crate::settings::Repository {
+            id: "r-1".into(),
+            name: "OreTachi".into(),
+            path: "X:/repo".into(),
+            exec_script: None,
+            copy_targets: None,
+            package_manager: None,
+            package_manager_args: None,
+            notification_hooks: None,
+            pull_before_add: None,
+            branch_name_pattern: None,
+        }];
+        settings.worktrees = vec![WorktreeEntry {
+            id: "wt-1".into(),
+            name: "oretachi-abcd".into(),
+            repository_id: "r-1".into(),
+            repository_name: "OreTachi".into(),
+            path: "X:/wt".into(),
+            branch_name: "feature/x".into(),
+            hotkey_char: None,
+            auto_approval: None,
+            auto_approval_prompt: None,
+            description: None,
+            description_open: None,
+            workgroup_id: Some("wg-2".into()),
+            is_home: false,
+            is_repository: false,
+        }];
+        settings
+    }
+
+    #[test]
+    fn resolve_subscription_target_accepts_wildcards() {
+        let settings = target_settings();
+
+        let all = resolve_subscription_target(&settings, " * ").unwrap();
+        assert_eq!(all.stored, "*");
+        assert!(all.worktree_id.is_none());
+
+        // ワークグループは ID でも表示名でも解決でき、保存は ID に正規化される
+        for raw in ["workgroup:wg-2", "workgroup: リリース準備 "] {
+            let g = resolve_subscription_target(&settings, raw).unwrap();
+            assert_eq!(g.stored, "workgroup:wg-2", "{}", raw);
+            assert!(g.label.contains("リリース準備"), "{}", g.label);
+            assert!(g.worktree_id.is_none());
+        }
+
+        // リポジトリ名は大小を問わず、保存は小文字へ正規化される（照合側と一致）
+        let r = resolve_subscription_target(&settings, "repo:oreTACHI").unwrap();
+        assert_eq!(r.stored, "repo:oretachi");
+        assert!(r.label.contains("OreTachi"), "{}", r.label);
+        assert!(r.worktree_id.is_none());
+
+        // 厳密一致は従来どおりワークツリー ID を保存する
+        let w = resolve_subscription_target(&settings, "oretachi-abcd").unwrap();
+        assert_eq!(w.stored, "wt-1");
+        assert_eq!(w.worktree_id.as_deref(), Some("wt-1"));
+    }
+
+    /// 保存値と `matching_targets` の突合が実際に噛み合うこと。ここがずれると
+    /// 「購読は成功するのに一生届かない」という一番分かりにくい失敗になる。
+    #[test]
+    fn resolve_subscription_target_agrees_with_matching_targets() {
+        let settings = target_settings();
+        let wt = &settings.worktrees[0];
+        let group = resolve_workgroup(&settings, wt).map(|g| g.id.clone());
+        let targets = crate::event_db::matching_targets(
+            &wt.id,
+            group.as_deref(),
+            Some(&wt.repository_name),
+        );
+        for raw in ["*", "workgroup:wg-2", "repo:OreTachi", "oretachi-abcd"] {
+            let resolved = resolve_subscription_target(&settings, raw).unwrap();
+            assert!(
+                targets.contains(&resolved.stored),
+                "target '{}' -> '{}' が {:?} に含まれない",
+                raw,
+                resolved.stored,
+                targets
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_subscription_target_rejects_unknown_wildcards() {
+        let settings = target_settings();
+        assert!(resolve_subscription_target(&settings, "repo:").is_err());
+        assert!(resolve_subscription_target(&settings, "workgroup:").is_err());
+        let err = resolve_subscription_target(&settings, "repo:unknown")
+            .err()
+            .expect("未知のリポジトリはエラー");
+        assert!(format!("{:?}", err).contains("OreTachi"), "利用可能な候補を添える");
+    }
+
+    /// UI / ツール応答は種別で判断する。名前が引けないことだけを根拠にすると、
+    /// ワイルドカード購読がすべて「対象がクローズ済み」と誤表示される。
+    #[test]
+    fn describe_target_distinguishes_wildcards_from_closed_worktree() {
+        let settings = target_settings();
+        assert_eq!(describe_target(&settings, "*"), ("all".to_string(), None));
+        let (kind, label) = describe_target(&settings, "workgroup:wg-1");
+        assert_eq!(kind, "workgroup");
+        // 未リネームのグループでも生の ID ではなく表示名を返す
+        assert_eq!(label.as_deref(), Some("グループ(1)"));
+        assert_eq!(
+            describe_target(&settings, "repo:oretachi"),
+            ("repo".to_string(), Some("OreTachi".to_string()))
+        );
+        assert_eq!(
+            describe_target(&settings, "wt-1"),
+            ("worktree".to_string(), Some("oretachi-abcd".to_string()))
+        );
+        // クローズ済みの厳密一致だけが「名前なしの worktree」になる
+        assert_eq!(
+            describe_target(&settings, "wt-gone"),
+            ("worktree".to_string(), None)
+        );
     }
 
     /// Claude Code は plan モードで `readOnlyHint` が立っていない MCP ツールを

--- a/src/App.vue
+++ b/src/App.vue
@@ -1004,6 +1004,8 @@ async function onAddWorktreeConfirm(entry: WorktreeEntry, sourceBranch?: string,
         id: entry.id,
         name: entry.name,
         branchName: entry.branchName,
+        repositoryName: entry.repositoryName,
+        workgroupId: entry.workgroupId,
       });
     } catch {
       // 通知失敗はワークツリー追加の成否に影響しない

--- a/src/components/SubscriptionTable.vue
+++ b/src/components/SubscriptionTable.vue
@@ -24,6 +24,12 @@ function formatDate(ts: number | null): string {
   return ts ? new Date(ts).toLocaleString() : "-";
 }
 
+/** 購読対象の表示文字列。`*` は表示名を持たないのでローカライズした文言を出す（#126）。 */
+function targetText(item: SubscriptionView): string {
+  if (item.targetKind === "all") return t("targetAll");
+  return item.targetLabel ?? item.targetWorktreeId;
+}
+
 /** そのワークツリーで引き継ぎ先に選べる生存 AI 端末。 */
 function candidatesFor(worktreeId: string) {
   return props.agentTerminals.filter((c) => c.worktreeId === worktreeId);
@@ -76,8 +82,19 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
             <span v-else-if="item.agentName" class="badge badge-agent">{{ item.agentName }}</span>
           </td>
           <td class="cell-target">
-            <span class="branch-badge">{{ item.targetWorktreeName ?? item.targetWorktreeId }}</span>
-            <span v-if="!item.targetWorktreeName" class="badge badge-muted">{{ t('targetClosed') }}</span>
+            <span class="branch-badge">{{ targetText(item) }}</span>
+            <!-- 「クローズ済み」は厳密一致 target でのみ意味を持つ。ワイルドカード購読は
+                 対象ワークツリー名を持たないので、名前の有無だけで判定すると全部誤表示になる -->
+            <span
+              v-if="item.targetKind === 'worktree' && !item.targetWorktreeName"
+              class="badge badge-muted"
+            >{{ t('targetClosed') }}</span>
+            <span v-else-if="item.targetKind !== 'worktree'" class="badge badge-wildcard">
+              {{ t(`targetKind.${item.targetKind}`) }}
+            </span>
+            <span v-for="kind in item.eventKinds" :key="kind" class="badge badge-kind">
+              {{ kind.replace('worktree.', '') }}
+            </span>
           </td>
           <td class="cell-delivery">
             {{ item.delivery }}
@@ -260,6 +277,19 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
   color: #f5c2e7;
 }
 
+/* ワイルドカード target（* / workgroup: / repo:）の種別バッジ */
+.badge-wildcard {
+  background: #313244;
+  color: #94e2d5;
+}
+
+/* 購読中のイベント種別。通知種別(kind)とは別物であることを画面でも区別できるようにする */
+.badge-kind {
+  background: #1e1e2e;
+  color: #cdd6f4;
+  border: 1px solid #45475a;
+}
+
 .tab-badge {
   font-family: monospace;
   font-size: 11px;
@@ -372,6 +402,12 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
     "noCandidate": "no live agent tab",
     "pendingHandover": "Unread messages awaiting handover",
     "targetClosed": "closed",
+    "targetAll": "All worktrees",
+    "targetKind": {
+      "all": "wildcard",
+      "workgroup": "workgroup",
+      "repo": "repository"
+    },
     "ptyOnly": "PTY push only",
     "nonCcHint": "Only Claude Code has hooks. Other agents have no Stop hook, so messages are delivered by writing into the PTY.",
     "spawnIfClosed": "auto spawn",
@@ -395,6 +431,12 @@ function onRebind(worktreeId: string, deadTerminalId: string, event: Event): voi
     "noCandidate": "エージェント端末なし",
     "pendingHandover": "引き継ぎ待ちの未読メッセージ",
     "targetClosed": "クローズ済み",
+    "targetAll": "全ワークツリー",
+    "targetKind": {
+      "all": "ワイルドカード",
+      "workgroup": "ワークグループ",
+      "repo": "リポジトリ"
+    },
     "ptyOnly": "PTY 押し込みのみ",
     "nonCcHint": "フックは Claude Code 固有です。他のエージェントには Stop フックが無いため、PTY への押し込みでのみ通知が届きます",
     "spawnIfClosed": "自動 spawn",

--- a/src/composables/useTaskExecution.ts
+++ b/src/composables/useTaskExecution.ts
@@ -328,6 +328,8 @@ export function useTaskExecution(deps: {
         id: entry.id,
         name: entry.name,
         branchName: entry.branchName,
+        repositoryName: entry.repositoryName,
+        workgroupId: entry.workgroupId,
       });
     } catch (e) {
       // ワークツリーは作成済み・永続化済みなのでロールバックしない（settings との乖離=
@@ -338,6 +340,8 @@ export function useTaskExecution(deps: {
           id: entry.id,
           name: entry.name,
           branchName: entry.branchName,
+          repositoryName: entry.repositoryName,
+          workgroupId: entry.workgroupId,
         });
       } catch {
         // 通知失敗はワークツリー追加の成否に影響しない

--- a/src/composables/useWorktreeRemove.ts
+++ b/src/composables/useWorktreeRemove.ts
@@ -299,6 +299,8 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
             id: worktree.id,
             name: worktree.name,
             branchName: worktree.branchName,
+            repositoryName: worktree.repositoryName,
+            workgroupId: worktree.workgroupId,
           }).catch(() => { /* 通知失敗は無視 */ });
         }
       },
@@ -308,6 +310,8 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
           id: worktree.id,
           name: worktree.name,
           branchName: worktree.branchName,
+          repositoryName: worktree.repositoryName,
+          workgroupId: worktree.workgroupId,
         });
       },
       onSettled,
@@ -328,6 +332,10 @@ export function useWorktreeRemove(options: WorktreeRemoveOptions) {
         id: worktree.id,
         name: worktree.name,
         branchName: worktree.branchName,
+        // repo: / workgroup: 購読の照合に使う。この時点で settings 上の実体は
+        // 既に消えているため、フロントが持っている値を渡す (issue #126)
+        repositoryName: worktree.repositoryName,
+        workgroupId: worktree.workgroupId,
       }).catch(() => { /* 通知失敗は削除の成否に影響しない */ });
     };
     return await _execute(

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -17,9 +17,16 @@ export interface SubscriptionView {
   subscriberSessionId: number | null;
   /** "claude" / "gemini" / "codex" / "cline"。null は AI エージェント未検出 */
   agentName: string | null;
+  /** DB に入っている生の target。ワイルドカードなら "*" / "workgroup:<id>" / "repo:<name>" */
   targetWorktreeId: string;
-  /** クローズ済みの対象は null になる */
+  /** 厳密一致 target のワークツリー名。クローズ済み・ワイルドカードでは null */
   targetWorktreeName: string | null;
+  /** "worktree" | "all" | "workgroup" | "repo"（#126）。
+   *  **「クローズ済み」の判定はこれを見ること。** targetWorktreeName が null であることだけを
+   *  根拠にすると、ワイルドカード購読がすべて「クローズ済み」と誤表示される。 */
+  targetKind: string;
+  /** 人間向けの表示名。"*" は null（UI 側でローカライズする） */
+  targetLabel: string | null;
   eventKinds: string[];
   /** "turn_end" | "interrupt" | "passive" */
   delivery: string;


### PR DESCRIPTION
Closes #126 （親: #120 Phase 4）

## 概要

イベント種別を `worktree.closed` 以外へ広げ、`target` をワークツリー ID 固定からワイルドカードへ拡張する。これで #120 の動機①「設計タスクをしているワークツリーで sub-issue をいくつか立て、sub-issue 同士の依存性のある進行を設計タスク側で遂行したい」が成立する。

**本 issue は「自由文の注入経路」と「宛先の無差別化」を同時に開く。** #131 (Phase 3) が入れた default-deny・深度/TTL・自己エコー抑止・端末数上限は「#126 で自由文が入った瞬間に効き始める」前提で作られていたので、**実際に効くことの実証**を成果物に含めた（下記「安全性の実証」）。

`#124` (Phase 2) / `#130` のマージ後に rebase 済み。

## 判断

| 論点 | 判断 |
|---|---|
| `worktree.created` の発火点 | **`lib.rs` の `notify_worktree_added`**（`fire_worktree_closed` と対称）。#126 本文は `mcp_server.rs` の `worktree-added` リスナーを提案しているが、そこは `start_mcp_server` でしか登録されず **MCP サーバ停止中 / 再起動中に発火しない穴**が残る。`notify_worktree_added` は手動作成（`App.vue`）とタスク実行（`useTaskExecution.ts`）の**両経路が必ず通る唯一の Tauri コマンド**で、Phase 1 が `notify_worktree_archived` を選んだのと同じチョークポイント原則に一致する |
| `worktree.message` をどちらの経路に載せるか | **どちらにも載せない。** `hook_tx`（broadcast channel）も WebView IPC もトースト用の経路で `should_send_notify` の debounce がかかる。購読配送は `event_db` → 配送ワーカーという既存の第三の経路に載せ、debounce 判定より**前**に発行しきる |
| target 照合の実装 | 発火側で `matching_targets()` が「このイベントにマッチしうる target の全集合」を列挙し、`fanout` は `WHERE target IN (…)` で引く。`LIKE` や全件走査にしないのでインデックス（`idx_subs_target`）がそのまま効き、照合規則を純粋関数として単体テストできる |
| depth の伝播 | **エージェントに申告させない。** 送信 depth は「そのタブが連鎖ウィンドウ(10分)内に受け取った `worktree.message` の最大 depth + 1」を DB から自動計算する。申告制にすると「返信時に depth を足す」約束を破るだけでガードを迂回できる |
| 自動承認宛先への許可集合 | `worktree.closed` + `worktree.created` を許可、`worktree.message` は不許可。基準は「**本文を誰が書いたか**」——  oretachi が定型 JSON で組み立てるものは許可、エージェントが本文を書けるものは不許可。定数のドキュメントコメントに明文化した |

## 変更内容

### 1. `event_db.rs` — 種別・target 照合・depth

- `KIND_WORKTREE_CREATED` / `KIND_WORKTREE_MESSAGE` を `SUPPORTED_EVENT_KINDS` に追加
- `normalize_target()` / `matching_targets()`（純粋関数）。`repo:` は trim + lowercase で正規化し、**登録時と照合時で必ず同じ関数を通す**
- `fanout(pool, event, targets, now)` へシグネチャ変更（`placeholders(n)` を再利用した IN 句）
- `max_inbound_depth()` + `CHAIN_WINDOW_MS`（10分）。窓を切らないと、一度でも深い連鎖に巻き込まれたタブが**以後永久に発言不能**になる
- `has_event()` — `worktree.created` の二重発火ガード（`useTaskExecution.ts` は成功時と失敗時の両分岐から `notify_worktree_added` を呼ぶ）
- `WorktreeCreatedBody` / `WorktreeMessageBody` と `format_inbox_line` の分岐
- **`format_inbox_push_text` / `format_inbox_digest` の締め文言を種別非依存に**。`closed` 決め打ちの「購読していた作業が完了したということなので」は、`created` / `message` が混ざるとエージェントに嘘の前提を与える
- `list_spawn_candidates` を `(worktree_id, kind, count)` に変更（下記の穴を塞ぐため）

### 2. `lib.rs` — `worktree.created` の発火

`fire_worktree_closed` と対称な `fire_worktree_created` を追加し、`notify_worktree_added` から fire-and-forget で呼ぶ。`repo:` / `workgroup:` 照合用の所属情報は `resolve_event_scope()` で解決する（**closed 経路では settings 上の実体が既に消えている**ため、フロントが持っている値を渡してもらい、settings 参照はフォールバック）。

### 3. `mcp_server.rs` — `event_kind` と target ワイルドカード

- `notify_worktree` に `event_kind` / `terminal_id` / `project_dir` を追加。既存の `kind`（hook / approval / completed / general）は**通知トーストの種別のまま一切変えず**、`event_kind` の説明文で名前空間の違いを明示
- **意味論の明示**: `worktree.message` の *source* は呼び出し元ワークツリーであって `worktree_name`（トーストの宛先）ではない。購読方式なので宛先は購読者が決める。ツール description とレスポンスに書いた
- 深度超過は静かに捨てず、ツールのレスポンスで「連鎖の深さが N に達したため配送されませんでした」と返す。返さないとエージェントは「送れた」と誤解して相手の応答を待ち続ける
- `oretachi_subscribe_worktree` の target に `*` / `workgroup:<ID|名前>` / `repo:<名前>` を追加（`resolve_subscription_target`）。「ホーム/リポジトリ擬似ワークツリーは購読不可」「自分自身は購読不可」は**厳密一致 target のときだけ**適用する（`*` を弾く理由にはならない。自ワークツリー分は `is_self_echo` が配送段階で落とす）
- `describe_target()` — 保存済み target を `(種別, 表示名)` に分解する共通関数

### 4. `event_delivery.rs` — default-deny を実際に効かせる

- `AUTO_APPROVAL_PUSHABLE_KINDS` に `worktree.created` を追加（`message` は入れない）
- **`spawn_for_closed_tabs` が `auto_approval_allows(worktree, KIND_WORKTREE_CLOSED)` と種別をハードコードしていた穴を塞いだ。** 新種別が入った瞬間、押し込めないはずの自由文メッセージが「closed のふり」で spawn を通せる状態だった
- `push_pending` の自動承認判定も**行単位**にした（#124 の f81a76d が `filter_for_turn_end` に入れたのと同じ修正。代表1件から解決すると、1タブが `cd` して別ワークツリーで再購読したときに実際の宛先ではない設定で全件を通してしまう）
- `SubscriptionView` に `target_kind` / `target_label` を追加

### 5. フロント

`SubscriptionTable.vue` の対象セルを `targetLabel` 基準にし、「クローズ済み」バッジは `targetKind === 'worktree'` のときだけ出す（**これが無いとワイルドカード購読が全部「クローズ済み」と誤表示される**）。購読中のイベント種別をバッジで表示し、通知種別と混ざらないことを画面でも確認できるようにした。

## テスト

- `cd src-tauri && cargo check --all-targets` / `cargo test` ✅ **181 件**
- `cargo test -p oretachi-notify` ✅ 41 件
- `pnpm run type-check` ✅

追加した主なテスト:
- `test_roundtrip_fanout_matches_wildcard_targets` — `*` / `workgroup:` / `repo:` に届き、対象外の購読には届かない
- `test_roundtrip_wildcard_suppresses_self_echo` — `*` 購読で発火元タブにも同一ワークツリーの別タブにも配らない
- `test_roundtrip_message_ping_pong_stops_at_max_depth` — A↔B の往復が片道4本（depth 0→3）で止まり、送れなくなった側が再送しても通らない
- `test_roundtrip_chain_depth_counts_messages_only` / `test_roundtrip_chain_window_resets_depth`
- `test_auto_approval_partition_blocks_only_free_form` / `test_spawn_pending_count_ignores_blocked_kinds`
- `test_format_inbox_push_text_sanitizes_free_form_message` — 本文全体が攻撃者制御でもブラケットペーストを脱出できない
- `test_format_inbox_push_text_is_kind_agnostic`
- `resolve_subscription_target_agrees_with_matching_targets` — 登録側の正規化と照合側の候補集合が噛み合うこと（ここがずれると「購読は成功するのに一生届かない」という一番分かりにくい失敗になる）

## 実機確認

本番 oretachi を止めずに dev ビルドで検証した。途中から**バンドル識別子を一時的に変えて app_data を完全分離**（`com.ia.oretachi.verify126`）した —— 本番が settings.json を常時書き戻すためポート指定が奪い合いになり、共有の `events.db` を汚す危険もあったため。検証後、使い捨てワークツリー・ブランチ・分離した app_data・`tauri.conf.json` はすべて元に戻し、共有 `events.db` に入ったテスト行（購読4 / inbox 10 / events 9）も削除済み。

### 完了条件の確認

| 項目 | 結果 |
|---|---|
| `worktree.created` の発火と配送 | タスク実行経路で新規ワークツリーを作成 → `[event] worktree.created worktree=oretachi-5nhu targets=["<id>", "*", "workgroup:wg-…", "repo:oretachi"] delivered=1`。**購読を登録した時点では存在しなかったワークツリー**の作成が `*` 購読者へ届いた |
| `worktree.message` と `event_kind` | `notify_worktree` の応答が `{"ok":true,"notified":true,"event":{...}}` を返し、トースト（`kind`）と購読イベント（`event_kind`）が別々に流れることを確認 |
| `repo:<name>` | `repo:OreTachi` で登録 → `repo:oretachi` に正規化。別リポジトリ (`repo:tsuruhashi3`) を購読しているタブには**届かない**ことも確認 |
| `workgroup:<id>` | 追加した瞬間から届くようになり、`delivered` が 1 → 2 に増えることを確認 |

### 安全性の実証（#126 の主題）

1. **自動承認との組み合わせが default-deny 側へ落ちる** — 自動承認が有効なワークツリーの Claude Code タブへ、同一 tick で2種類が来た状態を作った:
   ```
   [delivery] 自動承認が有効な宛先のため 1 件の押し込みを保留した（人間の確認が必要）terminal=50008b52…
   [delivery] 待機中のエージェントへ 1 件を押し込んだ terminal=50008b52… agent=Some("claude") delivery=turn_end
   ```
   **自由文だけが保留され、定型の `worktree.closed` は押し込まれた。** 保留は tick ごとに繰り返され（4回連続を確認）、端末の画面には一切入らないことを `oretachi_read_terminal` で確認。
   spawn 側も同様: `[delivery] 自動承認が有効な宛先のため spawn を見送った worktree=tw126a 保留種別=["worktree.message"]` → その後 `worktree.closed` が来た時点で初めて `未読 1 件のため新しいタブを要求した`。**種別ハードコードのままなら、この見送りは起きずタブが立っていた。**

2. **深度の伝播と往復の停止** — A↔B に相互購読を張って `notify_worktree` で往復させた:
   ```
   depth=1 delivered=1 → depth=2 delivered=1 → depth=3 delivered=1 → depth=4 delivered=0
   "連鎖の深さが 4 に達したためメッセージは配送されませんでした（上限 3）"
   ```
   4本目で配送が止まり、以後 B は何度送っても通らない（相手に届かないので次の返信も誘発されない）。

3. **`*` + `spawn_if_closed` で端末が増えない** — `*` 購読 + `spawn_if_closed=true` の状態で複数のイベントを流し、約4分間観測して **spawn 要求は 1 回だけ**・生存ターミナル数は 2 のまま（上限拒否ログ 0 件）。単一フライトと「既に AI タブがあれば spawn しない」が効いている。

4. **自己エコー抑止** — `*` を購読しているタブ自身が `worktree.message` を送っても、自分の inbox には積まれない（poll_inbox が 0 件）。同一ワークツリーの別タブにも積まれない。

5. **`sanitize_for_pty`** — 本文に `ESC[201~ CR whoami CR` を仕込んだメッセージを、自動承認 OFF のワークツリーの Claude Code タブへ実際に押し込んだ。端末には
   `レビュー依頼です[201~whoami 以上` と**リテラル文字列として1行で入り**、ESC / CR は落ち、`whoami` は実行されなかった。

### 既知の限界・スコープ外（記録）

- **`oretachi_import_worktree`（既存ワークツリーの取り込み）では `worktree.created` が発火しない。** 取り込み経路はフロントが `commitWorktree` で直接登録し `notify_worktree_added` を通らないため。#120 §1 の「ワークツリー追加成功時（`broadcast_worktree_added` と同じ箇所）」という定義どおりで、取り込みは MCP ピアへの broadcast も出していない。必要なら別 issue で扱う
- **`poll_inbox` / `SessionStart` 注入は `sanitize_for_pty` を通さない。** どちらも JSON でエージェントのコンテキストへ渡す経路で PTY を触らないため、エスケープの実行リスクが無い（PTY 押し込みだけが対象）。既存の設計どおり
- **`is_self_echo` は同一ワークツリーの別タブへも配らない。** `worktree.message` が同一ワークツリー内で往復する経路を最初から塞ぐための意図的な仕様

## セルフレビュー

CLAUDE.md の `codex-review` を実行したが、**codex CLI の Windows サンドボックスが壊れており**（`windows sandbox: helper_unknown_error: setup refresh had errors`）`git diff` を含む全 shell 実行が失敗して差分を読めず、レビュー結果を得られなかった（#127 / #131 はクレジット切れ、今回は別要因）。代わりに `/bug-review` + バリデータサブエージェントでの再検証で代替した。

自分で見つけて直したもの:

- **`spawn_for_closed_tabs` の種別ハードコード**（本 PR の核心のひとつ。実機でも見送りログで確認）
- `push_pending` の自動承認判定が代表1件のままだった（#124 が Stop 経路にだけ入れた修正の取りこぼし）
- 連鎖の深さに `created` / `closed` まで数えており、`*` 購読者の会話に使える往復回数が削られていた
- 押し込み / SessionStart の締め文言が `closed` 決め打ちのままだった
- `SubscriptionTable.vue` がワイルドカード購読を全部「クローズ済み」と誤表示する状態だった
- `resolve_event_scope` の挿入で `fire_worktree_closed` の doc コメントが外れていた

バリデータが確認した指摘（warning 1 / suggestion 5）への対応:

| 指摘 | 対応 |
|---|---|
| **[WARNING]** `publish_worktree_message` の失敗を `?` で早期 return しており、`event_kind` を添えただけで**承認待ちトーストまで出なくなる**。「独立した第三の経路」という宣言と真逆 | 修正。トーストは必ず送り、イベント発行の失敗は `isError` つきのレスポンスで返す |
| `has_event` の二重発火ガードが check-then-act で、同時呼び出しに対して穴 | 修正。event id を決定的な `worktree.created:<worktree_id>` にし、2件目は `INSERT OR REPLACE` と inbox の UNIQUE で構造的に潰れるようにした |
| 非 ASCII のリポジトリ名で `eq_ignore_ascii_case` と保存側の `to_lowercase()` がずれる | 修正（配送は元から壊れていないが、入力の大小違いとラベル表示が崩れていた）。テストを追加 |
| `purge_expired` がワイルドカード購読の未読を拾えない | **対応せず、コメントに明記。** inbox は行がどの購読由来かを持たないため、ワイルドカードを緩く含めると同じタブの別購読宛まで消しうる。取りこぼしより誤削除の害が大きいので、30日の有界な滞留を選んだ |
| 「Phase 1 では worktree.closed のみ」というコメントが古い | 修正 |
| `worktree.message` に発行レート制限が無い（`depth` は連鎖しか止めず連打は止めない） | **対応せず、コメントに明記。** 押し込み側は宛先ごとの最小間隔30秒と保持期限で有界なので、実害は未読が増えるまでに留まる |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
