### PR TITLE
feat(tray): トレイポップアップのフッターに 前へ / ウィンドウ表示 / アーカイブ化して次へ を追加 (#129)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1190,6 +1190,7 @@ async function onTrayButtonClick() {
         autoApproval: autoApprovalMap.get(worktreeId) ?? false,
         aiJudging: aiJudgingWorktrees.has(worktreeId),
         description: worktree.description,
+        canArchive: !isPseudoWorktree(worktree),
       });
     } else {
       // メインウィンドウのターミナル情報を収集
@@ -1255,6 +1256,7 @@ async function onTrayButtonClick() {
         autoApprovalPrompt: autoApprovalPromptMap.get(worktreeId) ?? '',
         lastJudgedCommand: lastJudgedCommandMap.get(worktreeId) ?? '',
         description: worktree.description,
+        canArchive: !isPseudoWorktree(worktree),
       });
     }
   }
@@ -1262,6 +1264,51 @@ async function onTrayButtonClick() {
   if (worktreeDataList.length === 0) return;
 
   await openTrayPopup(worktreeDataList);
+}
+
+/**
+ * 指定ワークツリーを実ウィンドウの前面に出す。
+ * MCP (mcp-show-worktree) とトレイの「ウィンドウで開く」(tray-show-worktree) で共有する。
+ * ctx はログ識別用の呼び出し元名。
+ */
+async function showWorktreeInWindows(worktreeId: string, ctx: string): Promise<void> {
+  const targetWt = worktrees.value.find((w) => w.id === worktreeId);
+  if (!targetWt) {
+    logDebug(`[Terminal] ${ctx}: worktree ${worktreeId} not found, skipping`);
+    return;
+  }
+  // サブウィンドウへ分離済みならそのウィンドウを前面に出す（メイン側のタブは動かさない）
+  if (isDetached(worktreeId)) {
+    try {
+      await focusSubWindow(worktreeId);
+    } catch (e) {
+      logDebug(`[Terminal] ${ctx}: focusSubWindow failed: ${e}`);
+    }
+    return;
+  }
+  // ホームへ戻ったときにカードが見えるよう、所属グループが非アクティブなら併せて切り替える。
+  // ホーム/リポジトリ擬似ワークツリーは専用パネル側の表示なのでグループ切替の対象外。
+  if (!isPseudoWorktree(targetWt)) {
+    const groupId = resolvedGroupId(targetWt.workgroupId);
+    if (groupId && groupId !== activeWorkgroupId.value) {
+      activeWorkgroupId.value = groupId;
+    }
+    // グループを選んだらリポジトリ一覧ではなくワークツリー一覧を出す
+    // （WorkgroupBar / cycleWorkgroup のグループ切替と同じ扱い）
+    listMode.value = "worktree";
+  }
+  try {
+    await switchToWorktree(worktreeId);
+  } catch (e) {
+    logDebug(`[Terminal] ${ctx}: switchToWorktree failed: ${e}`);
+    return;
+  }
+  // トレイ常駐のためメインウィンドウは hide / minimize されているのが常態。
+  // setFocus だけでは画面に出てこないので show → unminimize から行う。
+  const win = getCurrentWindow();
+  await win.show();
+  await win.unminimize();
+  await win.setFocus();
 }
 
 function onFrameAddTerminal(wid: string, leafId: string) {
@@ -1579,44 +1626,7 @@ onMounted(async () => {
 
   // MCP: 指定ワークツリーをフォーカスする
   await listen<{ worktree_id: string }>("mcp-show-worktree", async (event) => {
-    const { worktree_id } = event.payload;
-    const targetWt = worktrees.value.find((w) => w.id === worktree_id);
-    if (!targetWt) {
-      logDebug(`[Terminal] mcp-show-worktree: worktree ${worktree_id} not found, skipping`);
-      return;
-    }
-    // サブウィンドウへ分離済みならそのウィンドウを前面に出す（メイン側のタブは動かさない）
-    if (isDetached(worktree_id)) {
-      try {
-        await focusSubWindow(worktree_id);
-      } catch (e) {
-        logDebug(`[Terminal] mcp-show-worktree: focusSubWindow failed: ${e}`);
-      }
-      return;
-    }
-    // ホームへ戻ったときにカードが見えるよう、所属グループが非アクティブなら併せて切り替える。
-    // ホーム/リポジトリ擬似ワークツリーは専用パネル側の表示なのでグループ切替の対象外。
-    if (!isPseudoWorktree(targetWt)) {
-      const groupId = resolvedGroupId(targetWt.workgroupId);
-      if (groupId && groupId !== activeWorkgroupId.value) {
-        activeWorkgroupId.value = groupId;
-      }
-      // グループを選んだらリポジトリ一覧ではなくワークツリー一覧を出す
-      // （WorkgroupBar / cycleWorkgroup のグループ切替と同じ扱い）
-      listMode.value = "worktree";
-    }
-    try {
-      await switchToWorktree(worktree_id);
-    } catch (e) {
-      logDebug(`[Terminal] mcp-show-worktree: switchToWorktree failed: ${e}`);
-      return;
-    }
-    // トレイ常駐のためメインウィンドウは hide / minimize されているのが常態。
-    // setFocus だけでは画面に出てこないので show → unminimize から行う。
-    const win = getCurrentWindow();
-    await win.show();
-    await win.unminimize();
-    await win.setFocus();
+    await showWorktreeInWindows(event.payload.worktree_id, "mcp-show-worktree");
   });
 
   // MCP: git 上に存在するが oretachi 未登録のワークツリーを settings へ取り込む。
@@ -1864,6 +1874,41 @@ onMounted(async () => {
   // トレイポップアップからの通知クリア
   await listen<{ worktreeId: string }>("tray-clear-notification", (event) => {
     clearNotification(event.payload.worktreeId);
+  });
+
+  // トレイポップアップの「ウィンドウで開く」
+  await listen<{ worktreeId: string }>("tray-show-worktree", async (event) => {
+    await showWorktreeInWindows(event.payload.worktreeId, "tray-show-worktree");
+  });
+
+  // トレイポップアップからのアーカイブ要求（「アーカイブ化して次へ / 完了」）。
+  // トレイは完了を待たずに次へ進む契約。clearNotification / ローディング表示 /
+  // カードのフェードアウト / MCP 通知 / 二重実行防止 は archiveWorktree 側が面倒を見る。
+  await listen<{ worktreeId: string; deleteBranch: boolean }>("tray-archive-worktree", async (event) => {
+    const { worktreeId, deleteBranch } = event.payload;
+    const targetWt = worktrees.value.find((w) => w.id === worktreeId);
+    // ホーム/リポジトリ擬似ワークツリーは git 操作対象外。
+    // トレイ側も canArchive でメニューを出さないが、ここでも弾いておく。
+    if (!targetWt || isPseudoWorktree(targetWt)) {
+      logDebug(`[Tray] tray-archive-worktree: skip ${worktreeId}`);
+      return;
+    }
+    await archiveWorktree(
+      worktreeId,
+      // マージ先を持たない導線なので forceBranch = deleteBranch && !mergeTo === deleteBranch
+      // （RemoveWorktreeDialog の forceBranch と同じ導出）
+      { mergeTo: "", deleteBranch, forceBranch: deleteBranch },
+      async (result) => {
+        // 失敗時のエラーダイアログはメインが hide / minimize されていると気付けない。
+        // onSettled は message() 表示より前に呼ばれるので、ここでウィンドウを出しておく。
+        if (!result.ok && !result.cancelled && !result.busy) {
+          const win = getCurrentWindow();
+          await win.show().catch(() => {});
+          await win.unminimize().catch(() => {});
+          await win.setFocus().catch(() => {});
+        }
+      },
+    );
   });
 
   // トレイポップアップ閉鎖通知（tray popup自身がdestroyするのでskip）

--- a/src/App.vue
+++ b/src/App.vue
@@ -1876,9 +1876,16 @@ onMounted(async () => {
     clearNotification(event.payload.worktreeId);
   });
 
-  // トレイポップアップの「ウィンドウで開く」
+  // トレイポップアップの「ウィンドウで開く」。
+  // トレイの destroy はここで行う契約になっている（トレイ側は deferDestroy で待っている）。
+  // フォアグラウンドだったトレイが先に消えるとプロセスがフォアグラウンド権を失い、
+  // showWorktreeInWindows の setFocus が OS に拒否されてメインが前面に出ない。
   await listen<{ worktreeId: string }>("tray-show-worktree", async (event) => {
-    await showWorktreeInWindows(event.payload.worktreeId, "tray-show-worktree");
+    try {
+      await showWorktreeInWindows(event.payload.worktreeId, "tray-show-worktree");
+    } finally {
+      await closeTrayPopup();
+    }
   });
 
   // トレイポップアップからのアーカイブ要求（「アーカイブ化して次へ / 完了」）。

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -6,6 +6,7 @@ import TerminalView from "./components/TerminalView.vue";
 import FrameContainer from "./components/FrameContainer.vue";
 import IdeSelectDialog from "./components/IdeSelectDialog.vue";
 import AutoApprovalPromptDialog from "./components/AutoApprovalPromptDialog.vue";
+import TrayArchiveConfirmDialog from "./components/TrayArchiveConfirmDialog.vue";
 import { useWorktreeFrame } from "./composables/useWorktreeFrame";
 import { useSettings } from "./composables/useSettings";
 import { useHotkeyListener } from "./composables/useHotkeys";
@@ -57,8 +58,19 @@ const terminalUnreadByTab = computed(() =>
   collectUnreadByTab(terminalUnread.value, terminalEntries),
 );
 
-// 閉鎖処理の再入防止フラグ
-let closing = false;
+// 閉鎖処理の再入防止フラグ（フッターボタンの disabled にも使うため ref）
+const closing = ref(false);
+// 遷移中フラグ（連打・ホットキー二重発火の抑止 + ボタンの disabled 用）
+const navigating = ref(false);
+// 遷移の世代。await の後で自分が最新でなければ以降の副作用を捨てる
+// （destroy 済みウィンドウへの setSize や、打ち切った遷移の描画を防ぐ）
+let navToken = 0;
+
+// 「次へ ▾」ドロップダウンの開閉
+const menuOpen = ref(false);
+// アーカイブ確認ダイアログ
+const showArchiveConfirm = ref(false);
+const archiveDirtyCount = ref(0);
 
 // フレームレイアウト（useWorktreeFrameで共通化）
 const {
@@ -206,6 +218,9 @@ async function showWorktree(data: TrayWorktreeData) {
 
 const currentWorktree = computed(() => allWorktrees.value[currentIndex.value] ?? null);
 const isLast = computed(() => currentIndex.value >= allWorktrees.value.length - 1);
+const isFirst = computed(() => currentIndex.value <= 0);
+/** ナビゲーション系ボタンを止めるべき状態 */
+const navBusy = computed(() => navigating.value || closing.value);
 
 // IDE で開く
 const { showIdeDialog, detectedIdes, openInIde, onIdeSelected } = useIdeSelect();
@@ -239,8 +254,20 @@ async function onOpenInIde() {
   await openInIde(wt.worktreePath, { worktreeId: wt.worktreeId, worktreeName: wt.worktreeName, origin: "tray" });
 }
 
-/** 現在のターミナルを detach してから次に進む */
+/** 現在のターミナルを detach する（遷移・閉鎖の共通前処理） */
 async function detachCurrentTerminals() {
+  // 「前へ」で戻ったときに tray-init 時点の古いスナップショットで再アタッチされないよう、
+  // 離脱直前の画面内容を allWorktrees 側へ書き戻しておく。TerminalView の initialSnapshot は
+  // onMounted 時のみ参照されるため、次回マウント時にこの値が使われる。
+  // 制約: 離脱中に pty が exit しても再アタッチでは exit を受け取れない（既存挙動と同じ）。
+  const wt = currentWorktree.value;
+  if (wt) {
+    for (const term of wt.terminals) {
+      // serializeBuffer は内部で batcher.flush() してから serialize するので取りこぼさない
+      const snapshot = terminalRefs.get(term.id)?.serializeBuffer(300);
+      if (snapshot) term.snapshot = snapshot;
+    }
+  }
   returnAllToOffscreen();
   for (const [, ref] of terminalRefs) {
     ref.detach();
@@ -248,55 +275,152 @@ async function detachCurrentTerminals() {
   await nextTick();
 }
 
+type GoToOptions = {
+  /**
+   * 離れる側の通知を既読にする（既定 true）。アーカイブ導線では main 側の
+   * archiveWorktree が内部で clearNotification するため false にする。
+   */
+  clearLeaving?: boolean;
+  /** 呼び出し側で detachCurrentTerminals() を済ませている場合 true */
+  alreadyDetached?: boolean;
+};
+
+/**
+ * index のワークツリーを表示する。前へ / 次へ / アーカイブ後の再表示で共有する。
+ * - 離れる側の副作用: detach（+ 任意で通知クリア）
+ * - 入る側の副作用: tray-current-worktree-changed → showWorktree
+ * アーカイブ後は splice 済みで index が据え置きになるため、同一 index への goTo も
+ * 再表示として成立させる（同一 index を弾かない）。
+ */
+async function goTo(index: number, options: GoToOptions = {}): Promise<void> {
+  const { clearLeaving = true, alreadyDetached = false } = options;
+  if (closing.value || navigating.value) return;
+  if (index < 0 || index >= allWorktrees.value.length) return;
+
+  const token = ++navToken;
+  navigating.value = true;
+  try {
+    const leaving = currentWorktree.value;
+    if (!alreadyDetached) await detachCurrentTerminals();
+    if (clearLeaving && leaving) {
+      await emitTo("main", "tray-clear-notification", { worktreeId: leaving.worktreeId });
+    }
+    // await 中に閉鎖 / 別遷移が始まっていたら以降は行わない
+    if (token !== navToken || closing.value) return;
+
+    currentIndex.value = index;
+    const entering = allWorktrees.value[index];
+    await emitTo("main", "tray-current-worktree-changed", { worktreeId: entering.worktreeId });
+    if (token !== navToken || closing.value) return;
+    await showWorktree(entering);
+  } finally {
+    if (token === navToken) navigating.value = false;
+  }
+}
+
 async function onNext() {
-  const wt = currentWorktree.value;
-  if (!wt) return;
+  if (!isLast.value) await goTo(currentIndex.value + 1);
+}
 
-  await detachCurrentTerminals();
+async function onPrev() {
+  // 「見終わった」の意味づけは方向に依らないので、前へでも離脱側は既読にする（冪等）
+  if (!isFirst.value) await goTo(currentIndex.value - 1);
+}
 
-  // 通知クリアをメインに通知
-  await emitTo("main", "tray-clear-notification", { worktreeId: wt.worktreeId });
-
-  currentIndex.value += 1;
-  if (currentIndex.value < allWorktrees.value.length) {
-    const next = allWorktrees.value[currentIndex.value];
-    await emitTo("main", "tray-current-worktree-changed", { worktreeId: next.worktreeId });
-    await showWorktree(next);
+/**
+ * ポップアップを閉じる共通処理。
+ * 順序: detach → (通知クリア) → extraEmit → tray-closing → destroy
+ * destroy() は close() ではないので onUnmounted が走らない。emit はすべて destroy より
+ * 前に await して、IPC が落ちる前に届かせる。
+ */
+async function closePopup(options: {
+  clearCurrentNotification?: boolean;
+  /** tray-closing の直前に流す追加イベント */
+  extraEmit?: (worktree: TrayWorktreeData) => Promise<void>;
+} = {}): Promise<void> {
+  if (closing.value) return;
+  closing.value = true;
+  navToken++; // 進行中の goTo の続きを打ち切る
+  try {
+    const wt = currentWorktree.value;
+    await detachCurrentTerminals();
+    if (wt && (options.clearCurrentNotification ?? true)) {
+      await emitTo("main", "tray-clear-notification", { worktreeId: wt.worktreeId });
+    }
+    if (wt && options.extraEmit) await options.extraEmit(wt);
+    await emitTo("main", "tray-closing", {});
+    await getCurrentWindow().destroy();
+  } catch (e) {
+    // emit 失敗でボタンが永久に死ぬのを避ける（既存挙動を維持）
+    closing.value = false;
+    throw e;
   }
 }
 
 async function onDone() {
-  if (closing) return;
-  closing = true;
-  try {
-    const wt = currentWorktree.value;
-    if (wt) {
-      await detachCurrentTerminals();
-      await emitTo("main", "tray-clear-notification", { worktreeId: wt.worktreeId });
-    }
-    await emitTo("main", "tray-closing", {});
-    await getCurrentWindow().destroy();
-  } catch (e) {
-    closing = false;
-    throw e;
-  }
+  await closePopup();
 }
 
 async function onClose() {
-  if (closing) return;
-  closing = true;
-  try {
-    const wt = currentWorktree.value;
-    if (wt) {
-      await emitTo("main", "tray-clear-notification", { worktreeId: wt.worktreeId });
-    }
-    await detachCurrentTerminals();
-    await emitTo("main", "tray-closing", {});
-    await getCurrentWindow().destroy();
-  } catch (e) {
-    closing = false;
-    throw e;
+  await closePopup();
+}
+
+/**
+ * 表示中ワークツリーをメイン / サブウィンドウで開いてトレイを閉じる。
+ * トレイはターミナルを offscreen にマウントして掴んでいるため、detach で手放さないと
+ * メイン / サブ側で表示できない。かつメインが前面に出るのにトレイが残っても邪魔なだけ。
+ */
+async function onShowInWindow() {
+  await closePopup({
+    extraEmit: (wt) => emitTo("main", "tray-show-worktree", { worktreeId: wt.worktreeId }),
+  });
+}
+
+/** ▾ メニューの「アーカイブ化して…」→ 確認ダイアログを開く */
+async function onClickArchive() {
+  menuOpen.value = false;
+  const wt = currentWorktree.value;
+  if (!wt || !wt.canArchive || navBusy.value) return;
+  // 未コミット件数は警告表示用。取得に失敗しても確認自体は出す（0 件扱い）
+  archiveDirtyCount.value = await invoke<{ path: string }[]>("git_get_status", { repoPath: wt.worktreePath })
+    .then((files) => files.length)
+    .catch(() => 0);
+  // 取得中に別ワークツリーへ切り替わっていたら開かない
+  if (currentWorktree.value?.worktreeId !== wt.worktreeId) return;
+  showArchiveConfirm.value = true;
+}
+
+/** 確認ダイアログ確定 → main へアーカイブを依頼し、トレイ側は先に進む */
+async function onArchiveConfirmed(options: { deleteBranch: boolean }) {
+  showArchiveConfirm.value = false;
+  const wt = currentWorktree.value;
+  if (!wt || closing.value) return;
+
+  const index = currentIndex.value;
+  const wasLast = isLast.value;
+
+  // main 側のターミナル kill / git worktree remove とトレイの attach が競合しないよう、
+  // アーカイブ依頼より前にトレイ側のターミナルを必ず切り離す
+  await detachCurrentTerminals();
+
+  // アーカイブは数秒〜数十秒かかり、失敗時のエラーダイアログは main 側に出る。
+  // トレイは完了を待たずに次へ進む。通知クリアも archiveWorktree 内の clearNotification
+  // が行うので tray-clear-notification は出さない。
+  await emitTo("main", "tray-archive-worktree", {
+    worktreeId: wt.worktreeId,
+    deleteBranch: options.deleteBranch,
+  });
+
+  if (wasLast) {
+    // 「アーカイブ化して完了」: 表示中が最後の1件 → ポップアップを閉じる
+    await closePopup({ clearCurrentNotification: false });
+    return;
   }
+
+  // 「アーカイブ化して次へ」: 一覧から取り除くと後続が詰まるので、同じ index を再表示する。
+  // wasLast === false なので splice 後も index <= length - 1 が保証される。
+  allWorktrees.value.splice(index, 1);
+  await goTo(index, { clearLeaving: false, alreadyDetached: true });
 }
 
 function onHeaderDrag(e: MouseEvent) {
@@ -331,10 +455,15 @@ const { appliedZoom } = useUiZoom();
 useHotkeyListener(() => {
   const hk = settings.value.hotkeys;
   if (!hk || !initialized.value) return [];
+  // ダイアログ表示中はナビゲーション系を止める。useHotkeyListener は window capture で
+  // 登録されるため、ダイアログ側の stopPropagation より先に発火してしまう。
+  if (showArchiveConfirm.value || showIdeDialog.value || showAutoApprovalPromptDialog.value) return [];
   return [
     {
       binding: hk.trayNext,
       handler: () => {
+        menuOpen.value = false;
+        if (navBusy.value) return;
         if (isLast.value) {
           onDone();
         } else {
@@ -353,7 +482,16 @@ let unlistenSettings: UnlistenFn | null = null;
 let unlistenArtifact: UnlistenFn | null = null;
 let unlistenUnread: UnlistenFn | null = null;
 
+/** ▾ メニューを Escape で閉じる。ダイアログ側は各コンポーネントが自前で処理する */
+function onWindowKeydown(e: KeyboardEvent) {
+  if (e.key !== "Escape" || !menuOpen.value) return;
+  e.preventDefault();
+  e.stopPropagation();
+  menuOpen.value = false;
+}
+
 onMounted(async () => {
+  window.addEventListener("keydown", onWindowKeydown, true);
   await loadSettings();
 
   // タブ未読バッジの同期（#130）。event-inbox-changed は全 webview に届くので中継は不要。
@@ -398,6 +536,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  window.removeEventListener("keydown", onWindowKeydown, true);
   unlistenInit?.();
   unlistenSettings?.();
   unlistenArtifact?.();
@@ -534,19 +673,77 @@ onUnmounted(() => {
 
     <!-- フッター -->
     <div ref="footerRef" class="flex items-center justify-end gap-2 border-t border-[#313244] shrink-0 px-4 py-2" style="background-color: var(--bg-mantle-translucent)">
+      <!-- ウィンドウで開く: 押したらトレイは閉じる（= このワークツリーを開いて確認を終える） -->
       <button
-        v-if="!isLast"
-        class="px-4 py-1.5 text-sm rounded bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors"
-        @click="onNext"
+        class="shrink-0 px-3 py-1.5 text-sm rounded bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[#313244]"
+        :disabled="!currentWorktree || closing"
+        @click="onShowInWindow"
       >
-        {{ t('next') }}
+        {{ t('openInWindow') }}
       </button>
+
+      <!-- 前へ -->
       <button
-        class="px-4 py-1.5 text-sm rounded bg-[#a6e3a1] hover:bg-[#89c98a] text-[#1e1e2e] font-semibold transition-colors"
-        @click="onDone"
+        class="shrink-0 px-3 py-1.5 text-sm rounded bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[#313244]"
+        :disabled="isFirst || navBusy"
+        @click="onPrev"
       >
-        {{ t('done') }}
+        {{ t('prev') }}
       </button>
+
+      <!-- 次へ / 完了 + ▾ (split button)。isLast では primary が「完了」に変わるので
+           「次へ」と「完了」が同時に並ぶことはなく、フッターの要素数は常に一定 -->
+      <div class="relative flex shrink-0">
+        <button
+          v-if="isLast"
+          class="px-4 py-1.5 text-sm rounded-l bg-[#a6e3a1] hover:bg-[#89c98a] text-[#1e1e2e] font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          :disabled="closing"
+          @click="onDone"
+        >
+          {{ t('done') }}
+        </button>
+        <button
+          v-else
+          class="px-4 py-1.5 text-sm rounded-l bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          :disabled="navBusy"
+          @click="onNext"
+        >
+          {{ t('next') }}
+        </button>
+        <!-- ▾ は isLast でも有効（「アーカイブ化して完了」に到達させるため） -->
+        <button
+          class="px-2 py-1.5 text-sm rounded-r hover:bg-[#45475a] text-[#cdd6f4] border-l border-[#1e1e2e] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          :class="menuOpen ? 'bg-[#45475a]' : 'bg-[#313244]'"
+          :disabled="closing"
+          :title="t('moreActions')"
+          :aria-expanded="menuOpen"
+          @click="menuOpen = !menuOpen"
+        >
+          <span class="pi pi-chevron-up" style="font-size: 10px" />
+        </button>
+
+        <!-- クリックアウト用の透明バックドロップ（メニューより下、他要素より上） -->
+        <div v-if="menuOpen" class="fixed inset-0 z-[190]" @click="menuOpen = false" />
+
+        <!-- トレイウィンドウは高さ固定なのでメニューは上向きに開く -->
+        <div
+          v-if="menuOpen"
+          class="absolute bottom-full left-0 mb-1 z-[191] min-w-max rounded border border-[#45475a] py-1 shadow-lg"
+          style="background-color: #1e1e2e"
+        >
+          <button
+            v-if="currentWorktree?.canArchive"
+            class="flex w-full items-center gap-2 whitespace-nowrap px-3 py-1.5 text-left text-xs text-[#f38ba8] hover:bg-[#313244]"
+            @click="onClickArchive"
+          >
+            <span class="pi pi-inbox" style="font-size: 11px" />
+            {{ isLast ? t('archiveAndDone') : t('archiveAndNext') }}
+          </button>
+          <span v-else class="block whitespace-nowrap px-3 py-1.5 text-xs text-[#6c7086]">
+            {{ t('noMenuActions') }}
+          </span>
+        </div>
+      </div>
     </div>
 
     <!-- IDE 選択ダイアログ -->
@@ -566,6 +763,17 @@ onUnmounted(() => {
       :last-command="currentWorktree?.lastJudgedCommand ?? ''"
       @save="onSaveAutoApprovalPrompt"
       @cancel="showAutoApprovalPromptDialog = false"
+    />
+
+    <!-- アーカイブ簡易確認ダイアログ -->
+    <TrayArchiveConfirmDialog
+      v-if="showArchiveConfirm && currentWorktree"
+      :worktree-name="currentWorktree.worktreeName"
+      :branch-name="currentWorktree.branchName"
+      :dirty-count="archiveDirtyCount"
+      :is-last="isLast"
+      @confirm="onArchiveConfirmed"
+      @cancel="showArchiveConfirm = false"
     />
 
     <!-- TerminalView のマウント先 -->
@@ -599,8 +807,14 @@ onUnmounted(() => {
     "openArtifacts": "Artifacts",
     "loading": "Loading...",
     "noTerminals": "No terminals",
+    "prev": "← Prev",
     "next": "Next →",
     "done": "Done ✓",
+    "openInWindow": "Open in window",
+    "moreActions": "More actions",
+    "archiveAndNext": "Archive & next",
+    "archiveAndDone": "Archive & done",
+    "noMenuActions": "No actions available",
     "autoApprovalBadge": "Auto approval",
     "aiJudgingBadge": "AI judging",
     "editAutoApprovalPrompt": "Edit additional prompt"
@@ -612,8 +826,14 @@ onUnmounted(() => {
     "openArtifacts": "アーティファクト",
     "loading": "読み込み中...",
     "noTerminals": "ターミナルがありません",
+    "prev": "← 前へ",
     "next": "次へ →",
     "done": "完了 ✓",
+    "openInWindow": "ウィンドウで開く",
+    "moreActions": "その他の操作",
+    "archiveAndNext": "アーカイブ化して次へ",
+    "archiveAndDone": "アーカイブ化して完了",
+    "noMenuActions": "利用できる操作はありません",
     "autoApprovalBadge": "自動承認",
     "aiJudgingBadge": "AI判定中",
     "editAutoApprovalPrompt": "追加プロンプトを編集"

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -66,6 +66,11 @@ const navigating = ref(false);
 // （destroy 済みウィンドウへの setSize や、打ち切った遷移の描画を防ぐ）
 let navToken = 0;
 
+// destroy の二重実行防止（メイン経由と保険タイマーの両方から呼ばれる）
+let destroyed = false;
+// destroy をメインに委ねたのに閉じてもらえなかった場合の保険（メインが落ちている等）
+const DEFERRED_DESTROY_FALLBACK_MS = 3000;
+
 // 「次へ ▾」ドロップダウンの開閉
 const menuOpen = ref(false);
 // アーカイブ確認ダイアログ
@@ -327,6 +332,14 @@ async function onPrev() {
   if (!isFirst.value) await goTo(currentIndex.value - 1);
 }
 
+/** tray-closing を出してこのウィンドウを破棄する。保険タイマーからも呼ぶので冪等にする */
+async function destroySelf(): Promise<void> {
+  if (destroyed) return;
+  destroyed = true;
+  await emitTo("main", "tray-closing", {});
+  await getCurrentWindow().destroy();
+}
+
 /**
  * ポップアップを閉じる共通処理。
  * 順序: detach → (通知クリア) → extraEmit → tray-closing → destroy
@@ -337,6 +350,13 @@ async function closePopup(options: {
   clearCurrentNotification?: boolean;
   /** tray-closing の直前に流す追加イベント */
   extraEmit?: (worktree: TrayWorktreeData) => Promise<void>;
+  /**
+   * destroy をメイン側に任せる。「ウィンドウで開く」で必要。
+   * フォアグラウンドだったトレイが自分で先に消えるとプロセスがフォアグラウンド権を
+   * 失い、後から走るメイン側の setFocus が OS に拒否される（メインが前面に出ず、
+   * Z オーダー次第で別アプリがアクティブになる）。
+   */
+  deferDestroy?: boolean;
 } = {}): Promise<void> {
   if (closing.value) return;
   closing.value = true;
@@ -348,8 +368,12 @@ async function closePopup(options: {
       await emitTo("main", "tray-clear-notification", { worktreeId: wt.worktreeId });
     }
     if (wt && options.extraEmit) await options.extraEmit(wt);
-    await emitTo("main", "tray-closing", {});
-    await getCurrentWindow().destroy();
+    if (options.deferDestroy) {
+      // メインが閉じてくれなかったときだけ自分で閉じる
+      setTimeout(() => { void destroySelf(); }, DEFERRED_DESTROY_FALLBACK_MS);
+      return;
+    }
+    await destroySelf();
   } catch (e) {
     // emit 失敗でボタンが永久に死ぬのを避ける（既存挙動を維持）
     closing.value = false;
@@ -373,6 +397,8 @@ async function onClose() {
 async function onShowInWindow() {
   await closePopup({
     extraEmit: (wt) => emitTo("main", "tray-show-worktree", { worktreeId: wt.worktreeId }),
+    // メインが前面化を終えてから main 側にこのウィンドウを destroy させる
+    deferDestroy: true,
   });
 }
 
@@ -725,10 +751,12 @@ onUnmounted(() => {
         <!-- クリックアウト用の透明バックドロップ（メニューより下、他要素より上） -->
         <div v-if="menuOpen" class="fixed inset-0 z-[190]" @click="menuOpen = false" />
 
-        <!-- トレイウィンドウは高さ固定なのでメニューは上向きに開く -->
+        <!-- トレイウィンドウは高さ固定なのでメニューは上向きに開く。
+             split button はフッター右端にあるので right-0 で右揃えにする
+             （left-0 だと min-w-max がウィンドウ右外へはみ出して項目が切れる） -->
         <div
           v-if="menuOpen"
-          class="absolute bottom-full left-0 mb-1 z-[191] min-w-max rounded border border-[#45475a] py-1 shadow-lg"
+          class="absolute bottom-full right-0 mb-1 z-[191] min-w-max rounded border border-[#45475a] py-1 shadow-lg"
           style="background-color: #1e1e2e"
         >
           <button

--- a/src/TrayPopupApp.vue
+++ b/src/TrayPopupApp.vue
@@ -718,23 +718,16 @@ onUnmounted(() => {
       </button>
 
       <!-- 次へ / 完了 + ▾ (split button)。isLast では primary が「完了」に変わるので
-           「次へ」と「完了」が同時に並ぶことはなく、フッターの要素数は常に一定 -->
+           「次へ」と「完了」が同時に並ぶことはなく、フッターの要素数は常に一定。
+           状態でラベルと動作だけが変わり、色は他のフッターボタンと同じまま固定する
+           （押す位置の色が状態で入れ替わると誤操作を誘うため） -->
       <div class="relative flex shrink-0">
         <button
-          v-if="isLast"
-          class="px-4 py-1.5 text-sm rounded-l bg-[#a6e3a1] hover:bg-[#89c98a] text-[#1e1e2e] font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-          :disabled="closing"
-          @click="onDone"
-        >
-          {{ t('done') }}
-        </button>
-        <button
-          v-else
           class="px-4 py-1.5 text-sm rounded-l bg-[#313244] hover:bg-[#45475a] text-[#cdd6f4] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-          :disabled="navBusy"
-          @click="onNext"
+          :disabled="isLast ? closing : navBusy"
+          @click="isLast ? onDone() : onNext()"
         >
-          {{ t('next') }}
+          {{ isLast ? t('done') : t('next') }}
         </button>
         <!-- ▾ は isLast でも有効（「アーカイブ化して完了」に到達させるため） -->
         <button

--- a/src/components/TrayArchiveConfirmDialog.vue
+++ b/src/components/TrayArchiveConfirmDialog.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  worktreeName: string;
+  branchName: string;
+  /** 未コミットファイル件数（0 なら警告非表示） */
+  dirtyCount: number;
+  /** 表示中が最後の1件か。確定ボタンのラベル切替に使う */
+  isLast: boolean;
+}>();
+
+const emit = defineEmits<{
+  confirm: [options: { deleteBranch: boolean }];
+  cancel: [];
+}>();
+
+// マージ先の指定は持たない（トレイは高速レビュー動線。マージ先を選びたいときは
+// メインの削除ダイアログでやる）。ブランチ削除は常に OFF から始める。
+const deleteBranch = ref(false);
+
+// トレイは狭くオーバーレイの余白が小さいため、クリック以外の離脱手段を用意する。
+// TrayPopupApp の useHotkeyListener が window capture で先に発火するため、
+// こちらも capture フェーズで受けて stopPropagation する。
+function onKeydown(event: KeyboardEvent) {
+  if (event.key !== "Escape") return;
+  event.preventDefault();
+  event.stopPropagation();
+  emit("cancel");
+}
+
+onMounted(() => window.addEventListener("keydown", onKeydown, true));
+onUnmounted(() => window.removeEventListener("keydown", onKeydown, true));
+</script>
+
+<template>
+  <div class="dialog-overlay" @click.self="emit('cancel')">
+    <div class="dialog">
+      <h3 class="dialog-title">{{ t('title', { name: props.worktreeName }) }}</h3>
+
+      <div class="branch-info">
+        <span class="pi pi-code-branch" style="font-size: 10px" />
+        <span class="branch-name">{{ props.branchName }}</span>
+      </div>
+
+      <label class="checkbox-label">
+        <input v-model="deleteBranch" type="checkbox" />
+        {{ t('deleteBranch') }}
+      </label>
+
+      <p v-if="props.dirtyCount > 0" class="warn warn-dirty">
+        {{ t('dirtyFilesWarning', { count: props.dirtyCount }) }}
+      </p>
+      <p class="warn">{{ t('removeWarning') }}</p>
+      <p v-if="deleteBranch" class="warn warn-force">{{ t('forceDeleteWarning') }}</p>
+
+      <div class="dialog-actions">
+        <button class="btn-cancel" @click="emit('cancel')">{{ t('common.cancel') }}</button>
+        <button class="btn-danger" @click="emit('confirm', { deleteBranch })">
+          {{ props.isLast ? t('confirmDone') : t('confirmNext') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* スタイルは RemoveWorktreeDialog.vue に準拠。ただしトレイは高さが小さいことがあるため
+   全体をコンパクトにし、ダイアログ自体をスクロール可能にしている */
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.dialog {
+  background: #1e1e2e;
+  border: 1px solid #313244;
+  border-radius: 8px;
+  padding: 16px;
+  width: 340px;
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - 24px);
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.dialog-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #f38ba8;
+  margin: 0 0 10px;
+  overflow-wrap: anywhere;
+}
+
+.branch-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+  font-size: 12px;
+  color: #9399b2;
+}
+
+.branch-name {
+  font-family: monospace;
+  color: #cdd6f4;
+  background: #313244;
+  padding: 1px 6px;
+  border-radius: 4px;
+  overflow-wrap: anywhere;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #cdd6f4;
+  cursor: pointer;
+  user-select: none;
+  margin-bottom: 12px;
+}
+
+.checkbox-label input[type="checkbox"] {
+  cursor: pointer;
+  accent-color: #f38ba8;
+}
+
+/* .warn を先に定義してから警告の種類ごとに色を上書きする（同詳細度のため後勝ち） */
+.warn {
+  font-size: 11px;
+  color: #f9e2af;
+  margin: 0 0 6px;
+  line-height: 1.5;
+}
+
+.warn-dirty {
+  color: #fab387;
+}
+
+.warn-force {
+  color: #f38ba8;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.btn-cancel {
+  background: #313244;
+  color: #cdd6f4;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.btn-cancel:hover {
+  background: #45475a;
+}
+
+.btn-danger {
+  background: #f38ba8;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-danger:hover {
+  background: #eb6f8e;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Archive \"{name}\"",
+    "deleteBranch": "Delete branch",
+    "removeWarning": "⚠ The worktree will be saved to the archive and removed (git worktree remove)",
+    "forceDeleteWarning": "⚠ No merge target: git branch -D will force-delete",
+    "dirtyFilesWarning": "⚠ {count} uncommitted file(s) will be lost",
+    "confirmNext": "Archive & next",
+    "confirmDone": "Archive & done"
+  },
+  "ja": {
+    "title": "「{name}」をアーカイブ",
+    "deleteBranch": "ブランチを削除する",
+    "removeWarning": "⚠ アーカイブに保存して git worktree remove が実行されます",
+    "forceDeleteWarning": "⚠ マージ先未指定のため git branch -D で強制削除されます",
+    "dirtyFilesWarning": "⚠ {count} 件の未コミットファイルが失われます",
+    "confirmNext": "アーカイブ化して次へ",
+    "confirmDone": "アーカイブ化して完了"
+  }
+}
+</i18n>

--- a/src/composables/useTrayPopup.ts
+++ b/src/composables/useTrayPopup.ts
@@ -26,6 +26,9 @@ export interface TrayWorktreeData {
   autoApprovalPrompt?: string;
   lastJudgedCommand?: string;
   description?: string; // ホーム画面と同じ AI 生成説明。トレイの情報バーに表示
+  // アーカイブ操作を許可するか。ホーム/リポジトリ擬似ワークツリーもターミナルを持つため
+  // 通知対象になりトレイに載るが、git worktree ではないのでアーカイブしてはいけない
+  canArchive: boolean;
 }
 
 let trayWindow: WebviewWindow | null = null;


### PR DESCRIPTION
Closes #129

## やったこと

トレイポップアップのフッターは `[次へ →][完了 ✓]` の2つだけで前進しかできず、見落として先に進むと戻れない・その場でクローズできない・ウィンドウで開く導線がない、という片道切符になっていた。通知を順に確認していく動線を閉じる。

```
┌─────────────────────────────────────────────────────────────┐
│              [ウィンドウで開く]  [← 前へ]  [次へ → │▾]      │
└─────────────────────────────────────────────────────────────┘
                                            └─ ▾ で上向きメニュー
                                               ├ アーカイブ化して次へ
```

### 1. 前へボタン

`goTo(index, opts)` に切り出し、前へ / 次へ / アーカイブ後の再表示で共有する。`navToken` の世代チェックで、遷移中に閉鎖や別遷移が入ったら destroy 後の `setSize` などの副作用を捨てる。

`trayPrev` ホットキーの追加はスコープ外（`HotkeySettings` + 設定UI + ウィザードまで波及するため）。

### 2. ウィンドウで開く

`mcp-show-worktree` ハンドラを `showWorktreeInWindows` に切り出し、新設の `tray-show-worktree` と共有する。押すとトレイは閉じる（トレイはターミナルを offscreen で掴んでいるため手放さないとメイン/サブ側で表示できない）。

### 3. 次へのドロップダウン化 + アーカイブ

`archiveWorktree` はメインのコンテキストに依存するためトレイからは実行できない。`tray-archive-worktree` を新設してメイン側で実行する。トレイは完了を待たず次へ進み、失敗時は `onSettled` でメインを前面に出してエラーダイアログに気付かせる。

破壊的操作なので `TrayArchiveConfirmDialog` で簡易確認する（マージ先指定なし、ブランチ削除は初期 OFF、dirty 件数と force 削除の警告つき）。

**「次へ」と「完了」は同時に表示しない** — 同じ位置の primary がラベルと動作だけを切り替える。これでボタン数が状態で変わらず `applyWindowSize` のフッター高さ計測が安定し、`isLast` でも ▾ が生きたまま「アーカイブ化して完了」に到達できる。色は誤操作を誘わないようフッター他ボタンと同じグレーで固定。

### そのほか

- `detachCurrentTerminals` で離脱直前に `serializeBuffer` を `allWorktrees` へ書き戻す。`TerminalView` の `initialSnapshot` は `onMounted` 時のみ読まれるため、これがないと「前へ」で `tray-init` 時点の古い画面が復元され離脱中の出力が欠落する
- `onDone` / `onClose` / `onShowInWindow` を `closePopup()` に統合
- `TrayWorktreeData.canArchive` を追加。ホーム/リポジトリ擬似ワークツリーは git worktree ではないのでアーカイブ導線を出さない（App.vue 側にも二重ガード）

## 実機確認

`pnpm run tauri dev` を app_data 分離（identifier / MCP ポートを退避）で立て、使い捨てワークツリー2本を使って全経路をスクリーンショットで確認した。

- ナビゲーション（`1/3 → 2/3 → 3/3`、前への disabled 制御、往復でレイアウト崩れなし）
- `isLast` でのラベル切替と ▾ の生存、メニューが xterm より前面に上向きで開く、Escape で閉じる
- スナップショット書き戻し（マーカーが往復後も残存）
- 確認ダイアログの dirty 件数、force 警告が赤で表示
- ブランチ削除 ON → ブランチ削除 / OFF → ブランチ残存（どちらも意図どおり）
- 「アーカイブ化して次へ」で一覧が詰まる / 「完了」でポップアップが閉じ、破棄後もメイン側でアーカイブ完走（archives へ INSERT、`worktree.closed` 発火）
- 「ウィンドウで開く」でワークツリー切替 + トレイ破棄
- uiScale `xlarge` でフッターとメニューが切れない

### 実機で見つけて直した2件（2コミット目）

1. **▾ メニューが右端で切れる** — split button がフッター右端にあるのに `left-0` で左揃えにしていたため `min-w-max` がウィンドウ外へはみ出していた。`right-0` に変更
2. **「ウィンドウで開く」でメインが前面に出ない**（3/3 で再現） — トレイの `destroy()` がメインの `setFocus()` を追い越し、フォアグラウンドだったトレイが先に消えることでプロセスがフォアグラウンド権を失い `setFocus()` が OS に拒否されていた。ワークツリー切替自体は成功するためログには何も出ない。トレイは `deferDestroy` で自分では壊さず、メインが `showWorktreeInWindows` を完走してから `closeTrayPopup()` で壊す形にした（メイン無応答時の保険に3秒後の自己 destroy）

### 別 issue に切り出した

**#135** minimize されたメインウィンドウが `unminimize()` で復元されない。既存の `mcp-show-worktree` でも同一に再現する既存バグ。

### 未確認

- アーカイブ失敗時のエラーダイアログ表示 — #135 と経路が重なるため、そちらの修正後にまとめて確認するのが妥当
- detached ワークツリーでの「ウィンドウで開く」
- 3コミット目の色変更は type-check のみ（dev インスタンスを片付けた後の変更のため）

## テスト

`pnpm type-check` / `pnpm test`（94 件）ともグリーン。Rust の変更はなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
